### PR TITLE
[WIP] Collect Cinder AZs separately from Nova AZs

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -407,6 +407,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     ManageIQ::Providers::Openstack::CloudManager::EventCatcher
   end
 
+  def volume_availability_zones
+    cinder_manager.availability_zones
+  end
+
   #
   # Statistics
   #

--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -1,17 +1,9 @@
 class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < ManageIQ::Providers::Openstack::Inventory::Collector
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
 
-  def availability_zones_compute
-    @availability_zones_compute ||= safe_list { compute_service.availability_zones.summary }
-  end
-
-  def availability_zones_volume
-    return [] unless volume_service
-    @availability_zones_volume ||= safe_list { volume_service.availability_zones.summary }
-  end
-
   def availability_zones
-    (availability_zones_compute + availability_zones_volume).uniq(&:zoneName)
+    return @availability_zones if @availability_zones.any?
+    @availability_zones = safe_list { compute_service.availability_zones.summary }
   end
 
   def cloud_services

--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/cinder_manager.rb
@@ -1,6 +1,12 @@
 class ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Collector
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
 
+  def availability_zones
+    return [] unless volume_service
+    return @availability_zones if @availability_zones.any?
+    @availability_zones = safe_list { volume_service.availability_zones.summary }
+  end
+
   def cloud_volumes
     return [] unless volume_service
     return @cloud_volumes if @cloud_volumes.any?

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
@@ -1,9 +1,18 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Parser
   def parse
+    availability_zones
     cloud_volumes
     cloud_volume_snapshots
     cloud_volume_backups
     cloud_volume_types
+  end
+
+  def availability_zones
+    collector.availability_zones.each do |az|
+      availability_zone = persister.availability_zones.find_or_build(az.zoneName)
+      availability_zone.ems_ref = az.zoneName
+      availability_zone.name = az.zoneName
+    end
   end
 
   def cloud_volumes
@@ -19,7 +28,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
       volume.size = v.size.to_i.gigabytes
       volume.base_snapshot = persister.cloud_volume_snapshots.lazy_find(v.snapshot_id)
       volume.cloud_tenant = persister.cloud_tenants.lazy_find(v.tenant_id)
-      volume.availability_zone = persister.availability_zones.lazy_find(v.availability_zone || "null_az")
+      volume.availability_zone = persister.availability_zones.lazy_find(v.availability_zone)
 
       volume_attachments(volume, v.attachments)
     end
@@ -54,7 +63,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
       backup.name = b['display_name'] || b['name']
       backup.description = b['display_description'] || b['description']
       backup.cloud_volume = persister.cloud_volumes.lazy_find(b['volume_id'])
-      backup.availability_zone = persister.availability_zones.lazy_find(b['availability_zone'] || "null_az")
+      backup.availability_zone = persister.availability_zones.lazy_find(b['availability_zone'])
     end
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/storage_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/storage_collections.rb
@@ -2,7 +2,8 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Storag
   extend ActiveSupport::Concern
 
   def initialize_storage_inventory_collections
-    %i(cloud_volumes
+    %i(availability_zones
+       cloud_volumes
        cloud_volume_snapshots
        cloud_volume_types
        ).each do |name|

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
@@ -11,7 +11,6 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::Cind
 
   def initialize_cloud_inventory_collections
     %i(vms
-       availability_zones
        hardwares
        cloud_tenants
        disks).each do |name|

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -7,6 +7,9 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
   include ManageIQ::Providers::Openstack::ManagerMixin
 
   supports :cinder_volume_types
+  supports :volume_availability_zones
+
+  has_many :availability_zones, :foreign_key => :ems_id, :dependent => :destroy
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -243,7 +243,7 @@ module Openstack
     def assert_table_counts
       expect(ExtManagementSystem.count).to               eq 4 # Can this be not hardcoded? self/network/cinder/swift
       expect(Flavor.count).to                            eq compute_data.flavors.count
-      expect(AvailabilityZone.count).to                  eq availability_zones_count
+      expect(@ems.availability_zones.count).to           eq availability_zones_count
       expect(FloatingIp.count).to                        eq network_data.floating_ips.sum
       expect(AuthPrivateKey.count).to                    eq compute_data.key_pairs.count
       expect(security_groups_without_defaults.count).to  eq security_groups_count

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:47 GMT
+      - Mon, 04 Mar 2019 20:02:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8655b982-7c88-4757-8a86-42dbd36b62ee
+      - req-03d1b309-e991-44d2-896f-1c38b3f06339
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:47.258753", "expires":
-        "2019-01-08T20:15:47Z", "id": "84dbefd51e6c4a75b4619afd19631213", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:16.595421", "expires":
+        "2019-03-04T21:02:16Z", "id": "bcae1c85bef14db39a068d107c44ac52", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["AALeaXItSpmxZcnEgY5XIw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["RJ-auWwARLSNgYahDjtJ0w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:47 GMT
+      - Mon, 04 Mar 2019 20:02:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,132 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-08ff78c0-649c-4ccf-826b-ab532531526d
+      - req-dd96a381-60e1-4191-a5c2-be98757e8b0d
       Date:
-      - Tue, 08 Jan 2019 19:15:47 GMT
+      - Mon, 04 Mar 2019 20:02:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:47 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 08 Jan 2019 19:15:47 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-a0abd4c4-0306-4178-9370-43e39af463f9
-      Content-Length:
-      - '4170'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:47.717850", "expires":
-        "2019-01-08T20:15:47Z", "id": "82315594503a4b348d6cf83627f77c25", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["HqK-TpxPTu6aOXzYuEGTbQ"]}, "serviceCatalog":
-        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:47 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-8d1cfb4e-857e-4307-8cda-a949bfdc8e75
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '82'
-      X-Openstack-Request-Id:
-      - req-8d1cfb4e-857e-4307-8cda-a949bfdc8e75
-      Date:
-      - Tue, 08 Jan 2019 19:15:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
-        "nova"}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3d10e431-cbb8-4b7a-b871-ede94e92376a
+      - req-82bf04b0-074d-4a14-8745-a510f8ef806a
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +184,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:48.039067", "expires":
-        "2019-01-08T20:15:48Z", "id": "563327ebf9cd44d798f85d7f679651ec", "audit_ids":
-        ["UoQMhhPnRpikxb2dDmZ4Qw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:17.099825", "expires":
+        "2019-03-04T21:02:17Z", "id": "a9f8a82c031c47b4ad785c3541c52277", "audit_ids":
+        ["MIJTmlKJQ9agIAxMK2JpFg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +205,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 563327ebf9cd44d798f85d7f679651ec
+      - a9f8a82c031c47b4ad785c3541c52277
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-588c1458-ab90-449f-bf50-83bc58b6d969
+      - req-c99394a2-064d-47e1-af3e-a56540fed8e2
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +235,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +253,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8c851d03-05a4-49d7-ab1e-1c9eb8dae658
+      - req-6b319747-a341-4a85-b7ae-5aba74ba2866
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +268,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:48.360944", "expires":
-        "2019-01-08T20:15:48Z", "id": "cf17fb2ca67643559e913d2b199d12d7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:17.438829", "expires":
+        "2019-03-04T21:02:17Z", "id": "74e35980f50f4025ac7c158374664d42", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A9VzCpmvSN-QIUz0lreUbA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["FBpFApHGSZeigyZPcgUnLg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +315,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
   response:
     status:
       code: 200
@@ -458,7 +341,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +350,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +368,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ea8a937-8bdc-457e-bebc-db8c82f669ba
+      - req-1d326b2c-d3ab-4013-aa9a-421bbcd4549c
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +383,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:48.652742", "expires":
-        "2019-01-08T20:15:48Z", "id": "0c486c211c194328a48299af43beb901", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:17.710388", "expires":
+        "2019-03-04T21:02:17Z", "id": "61a938faf1d74c9a948fa1484fbae959", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hshOl0RcSAiDlOfTA20znw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ABf6dtcbR-yx0jXKxLnAwQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +430,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +445,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
   response:
     status:
       code: 200
@@ -573,7 +456,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +465,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +483,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:48 GMT
+      - Mon, 04 Mar 2019 20:02:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-380a783d-3656-4569-997e-0a525f820f18
+      - req-3b0fd342-40e3-441c-a366-21ef61a1955e
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +498,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:48.929821", "expires":
-        "2019-01-08T20:15:48Z", "id": "0120679043b642ce882792212bca72ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:18.006348", "expires":
+        "2019-03-04T21:02:17Z", "id": "74a221edd6414034bbf02157c4451daf", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["eXtuw4raTsyFywZwhJmZiw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_zpAt2ZOQieKbfh9T0lPfQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +545,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
   response:
     status:
       code: 200
@@ -688,7 +571,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +580,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +595,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +608,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-def849dc-07ff-4cc3-ad04-6655aa3ae29f
+      - req-2594fa85-c306-4867-8121-435ed3ddb414
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +655,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-63576af3-3124-4c58-bd95-1f5592235823
+      - req-65865d4b-57cf-42b8-a180-78aeaa500555
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +702,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1d514099-005f-42e8-8cdf-b7d2ccae1468
+      - req-15ac9075-ce73-4220-91c5-a1ed04346942
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +736,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +749,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-d042efdb-6cfc-4e89-a35b-b5cbbaa21a97
+      - req-5875979f-8b08-468e-bf4c-f3b9f3380b2f
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +796,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-f8a92510-3771-4f2e-8a9c-cdd9698ecec8
+      - req-9c582660-edfd-467b-a2ec-a81b5a571200
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +830,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +843,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-81731cc7-b587-44f9-873d-ce580246937b
+      - req-803af6ef-8ce4-4867-bc46-a57556bbc9c1
       Date:
-      - Tue, 08 Jan 2019 19:15:49 GMT
+      - Mon, 04 Mar 2019 20:02:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +877,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +890,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-18594c1f-aae7-471f-84b1-9416463d2a41
+      - req-81373cb7-1ae3-4f0e-b17d-0581c7d11f14
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:19 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +924,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +937,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-961fb6d1-ea87-442c-808a-20103df9cfea
+      - req-9c7ef24e-92a0-44c0-a437-ea73b1781b3a
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:44.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:02:13.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:43.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:43.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:02:12.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:46.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:02:11.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:46.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:02:13.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +971,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +984,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-5fb84db3-0c63-42bf-ae11-6d60030bb593
+      - req-10b1ebe4-6a21-4e87-85d7-4b2a8f9639bf
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1000,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1028,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-cea06fc6-d058-4839-9484-da5090da155d
+      - req-68ff71c0-f9c8-44a5-b398-aa98a190a1bf
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1044,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1072,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-f4087b1a-5947-47fd-8384-63469680af4f
+      - req-bb1d02d4-9ef9-46ce-ba64-52914eff76cf
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1089,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1117,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-9433564f-4142-4812-9cc4-d11f88fed6f9
+      - req-9631d4d9-b7da-4c8c-b1b7-823756acdca9
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1129,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1157,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-4c0cfa1a-174a-4d35-bcc2-1e6c3f3445c6
+      - req-7337ad7b-a951-4514-883e-a9ba40f1ace1
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1183,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:50 GMT
+      - Mon, 04 Mar 2019 20:02:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5613c717-0130-45b2-81c0-91b4c1067f06
+      - req-91f5a97c-9ae3-4ae9-8f9e-d4775e56beda
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1198,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:51.051725", "expires":
-        "2019-01-08T20:15:51Z", "id": "29a90f71332442d5b2e23bbe7337c939", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:21.162630", "expires":
+        "2019-03-04T21:02:21Z", "id": "506cdbf5868c4a759421af482a7bfae2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["wpsQJlKPROOuSzXbRGthGA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wOvswxMZTBaFMZb1svUrGg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1246,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:51 GMT
+      - Mon, 04 Mar 2019 20:02:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76f65517-fd43-48de-a817-460111e689e4
+      - req-d63f8975-7de9-4fea-a12b-bb8579dc83df
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:51.238177", "expires":
-        "2019-01-08T20:15:51Z", "id": "3b08cba538774a5f961e2f4accd93125", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:21.421488", "expires":
+        "2019-03-04T21:02:21Z", "id": "4605fe1eb1a74d06b882834ade7005af", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dXNMQEIGT2eLkLnxEm1OVQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["Q8S3X6GNS12MP0npSmu-9Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1326,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1461,13 +1344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:51 GMT
+      - Mon, 04 Mar 2019 20:02:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-feb61ff1-e757-4d9d-9ab6-125fd651de2b
+      - req-13a1a6a9-d59f-4dd0-8a5d-3eed8e03e025
       Content-Length:
       - '4131'
       Connection:
@@ -1476,10 +1359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:51.475867", "expires":
-        "2019-01-08T20:15:51Z", "id": "576ea277b03849ebae6842f65e996c62", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:21.703967", "expires":
+        "2019-03-04T21:02:21Z", "id": "eef67000a2924ef8a95afa4748baed07", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["094vcVFHStOvOzcglxm_CQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Jb6skFLPRCq2G8CVDiF6LQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1523,7 +1406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1541,13 +1424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:51 GMT
+      - Mon, 04 Mar 2019 20:02:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ecf1c145-61a7-4df7-b47b-58de0dafc293
+      - req-cc5e67ff-9efc-47db-817b-fb318a1c1c21
       Content-Length:
       - '4118'
       Connection:
@@ -1556,10 +1439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:51.662188", "expires":
-        "2019-01-08T20:15:51Z", "id": "fe4c8de852f04df3929477eb566d015a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:21.889181", "expires":
+        "2019-03-04T21:02:21Z", "id": "0525343391644838a36af912f81e97be", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9VdLNIvpQuKXIm63-Jeqfw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["AF8WX95rRBibejYTuN7Kjw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1603,7 +1486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1618,7 +1501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b08cba538774a5f961e2f4accd93125
+      - 4605fe1eb1a74d06b882834ade7005af
   response:
     status:
       code: 200
@@ -1629,9 +1512,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0d2ccf50-3da8-4d19-9b04-12ef5bd30b9b
+      - req-14e24a94-ba99-4ac6-912f-6a14285c5141
       Date:
-      - Tue, 08 Jan 2019 19:15:51 GMT
+      - Mon, 04 Mar 2019 20:02:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1673,7 +1556,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1688,7 +1571,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3b08cba538774a5f961e2f4accd93125
+      - 4605fe1eb1a74d06b882834ade7005af
   response:
     status:
       code: 200
@@ -1699,14 +1582,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f7792e82-5c5b-457b-a090-fc97229d2352
+      - req-a25f77a9-858a-4aa5-8c72-aa1c8bf6478d
       Date:
-      - Tue, 08 Jan 2019 19:15:51 GMT
+      - Mon, 04 Mar 2019 20:02:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1721,7 +1604,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 576ea277b03849ebae6842f65e996c62
+      - eef67000a2924ef8a95afa4748baed07
   response:
     status:
       code: 200
@@ -1732,9 +1615,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-ddf4a7b6-60e5-4812-8dac-f30f02737040
+      - req-e01eaf49-679c-4f0f-a340-5c33586c56cd
       Date:
-      - Tue, 08 Jan 2019 19:15:52 GMT
+      - Mon, 04 Mar 2019 20:02:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1776,7 +1659,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1791,7 +1674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 576ea277b03849ebae6842f65e996c62
+      - eef67000a2924ef8a95afa4748baed07
   response:
     status:
       code: 200
@@ -1802,14 +1685,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-6f15ffe6-fe72-4cb3-b34a-1c0a18ebe088
+      - req-f315be38-6860-4bf4-a4bc-096674d08654
       Date:
-      - Tue, 08 Jan 2019 19:15:52 GMT
+      - Mon, 04 Mar 2019 20:02:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1824,7 +1707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 29a90f71332442d5b2e23bbe7337c939
+      - 506cdbf5868c4a759421af482a7bfae2
   response:
     status:
       code: 200
@@ -1835,9 +1718,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-911df9f8-5d10-46ad-9e41-2abb15a0f254
+      - req-767ef218-d46a-4889-b97f-488c1de6cc68
       Date:
-      - Tue, 08 Jan 2019 19:15:52 GMT
+      - Mon, 04 Mar 2019 20:02:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1879,7 +1762,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1894,7 +1777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 29a90f71332442d5b2e23bbe7337c939
+      - 506cdbf5868c4a759421af482a7bfae2
   response:
     status:
       code: 200
@@ -1905,14 +1788,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-0f56ef42-227f-4723-86f0-a487b7aa14f6
+      - req-dbc12e66-ba20-410b-b1c2-47c52d52eff0
       Date:
-      - Tue, 08 Jan 2019 19:15:52 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4c8de852f04df3929477eb566d015a
+      - '0525343391644838a36af912f81e97be'
   response:
     status:
       code: 200
@@ -1938,9 +1821,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-51a82462-286b-4864-9690-287ee4e6319b
+      - req-7fe50d5b-e0d3-40c5-a176-f70d2ba16804
       Date:
-      - Tue, 08 Jan 2019 19:15:52 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1865,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe4c8de852f04df3929477eb566d015a
+      - '0525343391644838a36af912f81e97be'
   response:
     status:
       code: 200
@@ -2008,14 +1891,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-46b03881-d5d9-4b7e-acd3-70fce44f2d25
+      - req-71ba544d-a2ab-4987-b74c-0181c6bb0736
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +1926,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-88817d19-49fd-4152-bef8-3c655d563113
+      - req-fbaf2882-df1d-437d-8e9d-68e73b2d47c0
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +1938,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +1953,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +1966,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-98d7bc8b-fd99-454c-8bad-d284e632957b
+      - req-2d1d4542-538c-4b21-8986-92261a87133e
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +1978,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +1993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2006,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d7b9f492-94e9-4af8-aecb-f06d123ae8aa
+      - req-94f18eff-70bd-4387-9767-9d4776bad915
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2018,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2033,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2046,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d9898b2a-f2db-4905-aff0-e0023aa0fd90
+      - req-4467223a-8604-40f9-bce4-c7fd8a28781d
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2058,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2086,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-43231a2e-7ad6-4566-9dc5-0435b8b4eb47
+      - req-54d7e566-d63f-495c-9983-a340ed7bed5a
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2098,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2126,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e04dfa38-e78e-4f87-a128-d1f169965042
+      - req-74aa55f5-d88a-4bdc-b274-23f7ccb98168
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2138,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2153,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2166,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-b09f672b-d9fe-4cef-a108-e668fe537c71
+      - req-31efc4fd-9059-49b8-a2ec-41f7599ae798
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2178,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2206,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8be70beb-0887-4492-8a8c-63959a091a6b
+      - req-8977d57d-9d42-4fd9-a407-5a3bc9ce567c
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2218,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2236,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:53 GMT
+      - Mon, 04 Mar 2019 20:02:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52b48459-2c54-41a6-9823-010538295bbb
+      - req-35fcea98-ff87-4d2a-bea5-c863f73b9077
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2251,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:54.027744", "expires":
-        "2019-01-08T20:15:54Z", "id": "ddfef00b21f64446aea32a7e45fadf30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:25.173158", "expires":
+        "2019-03-04T21:02:25Z", "id": "288bc7a15be0460390e961120e01e044", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vn0OfSg1Tmys44AMYcPR2g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["anTZq8A1Rh6fLDUM5uZb-A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2299,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2317,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:54 GMT
+      - Mon, 04 Mar 2019 20:02:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68648052-01f7-434e-abf5-9eaf661952bc
+      - req-882b5c59-c733-482f-811e-ff2b4aa8e275
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2332,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:54.214875", "expires":
-        "2019-01-08T20:15:54Z", "id": "036cdb06527a4568b400af245d3a89ef", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:25.577718", "expires":
+        "2019-03-04T21:02:25Z", "id": "2a72b93b472c40fcbad8dffb7be2ed90", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["V4OxyqKLSei7WVyKK6cdtQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["t-iMjq2SQdGIOoBewFXDxQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2379,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2514,13 +2397,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:54 GMT
+      - Mon, 04 Mar 2019 20:02:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ace440c9-8411-4b40-8a88-94e0c5183bc0
+      - req-73114d97-0da0-4203-b2a7-f41dfdf76348
       Content-Length:
       - '4131'
       Connection:
@@ -2529,10 +2412,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:54.754425", "expires":
-        "2019-01-08T20:15:54Z", "id": "7258380500bd4355996661ba5568ef91", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:25.787419", "expires":
+        "2019-03-04T21:02:25Z", "id": "f68c504cca64431b83a35c07b21aec7d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["59jST8BwT6e4L4QzThAMHA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["wV8wZwPsS7uMSwW-V4ENsQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2576,7 +2459,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2594,13 +2477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:54 GMT
+      - Mon, 04 Mar 2019 20:02:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c10a233-5bcf-427a-a987-d3497cc445f7
+      - req-7a074052-a2ec-4343-9d47-b7adefbd9c49
       Content-Length:
       - '4118'
       Connection:
@@ -2609,10 +2492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:54.941969", "expires":
-        "2019-01-08T20:15:54Z", "id": "9172ea26499c4d879058e60ced0e9fa8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:25.984886", "expires":
+        "2019-03-04T21:02:25Z", "id": "a7cc2d37bf4a45688d35ddf712a7ee05", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["u7tjeqX6SSCn1uyhujeX5A"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["PzsnmfIAR4KXO3293AuP8Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2656,7 +2539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2671,7 +2554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -2682,9 +2565,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-68a36d2a-4813-4183-96aa-8ee0ca3abcb3
+      - req-fc30d32e-e175-434a-9fd0-6250bbce300d
       Date:
-      - Tue, 08 Jan 2019 19:15:55 GMT
+      - Mon, 04 Mar 2019 20:02:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2718,7 +2601,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2733,7 +2616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -2744,14 +2627,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a3a2c2ee-bc06-445c-8323-5d2a6fa6b5d7
+      - req-1e4f9bd8-c802-4a8c-aa34-35b15ecbff0e
       Date:
-      - Tue, 08 Jan 2019 19:15:55 GMT
+      - Mon, 04 Mar 2019 20:02:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2766,7 +2649,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7258380500bd4355996661ba5568ef91
+      - f68c504cca64431b83a35c07b21aec7d
   response:
     status:
       code: 200
@@ -2777,14 +2660,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2db2fc10-6d0a-4167-882b-9823e7568785
+      - req-886160f9-975a-4de4-9f3d-331e6b6d5004
       Date:
-      - Tue, 08 Jan 2019 19:15:55 GMT
+      - Mon, 04 Mar 2019 20:02:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2799,7 +2682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ddfef00b21f64446aea32a7e45fadf30
+      - 288bc7a15be0460390e961120e01e044
   response:
     status:
       code: 200
@@ -2810,14 +2693,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a665bc1c-2979-4a9c-81b2-ec8e56a7646e
+      - req-c3788c45-881f-40e4-8532-59291c01553b
       Date:
-      - Tue, 08 Jan 2019 19:15:55 GMT
+      - Mon, 04 Mar 2019 20:02:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2715,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9172ea26499c4d879058e60ced0e9fa8
+      - a7cc2d37bf4a45688d35ddf712a7ee05
   response:
     status:
       code: 200
@@ -2843,14 +2726,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-2f14451e-0916-4588-a0f5-2fa106d86c92
+      - req-53c31971-3252-40ab-b555-1de70ca0d092
       Date:
-      - Tue, 08 Jan 2019 19:15:55 GMT
+      - Mon, 04 Mar 2019 20:02:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2748,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -2876,9 +2759,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-df6b9b6c-4a87-4e9e-993c-ada2c301c81e
+      - req-c30ae5c0-a399-4996-af4e-294c5f3f1202
       Date:
-      - Tue, 08 Jan 2019 19:15:56 GMT
+      - Mon, 04 Mar 2019 20:02:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2788,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -2931,9 +2814,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f38e22c5-2e82-41b1-9d91-62c3ac5367f2
+      - req-a55a7fa4-30e4-4ea6-b7d8-8fe64e192a88
       Date:
-      - Tue, 08 Jan 2019 19:15:56 GMT
+      - Mon, 04 Mar 2019 20:02:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2843,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2858,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -2986,9 +2869,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-92970672-6216-4728-a0f5-3b1efc72cecb
+      - req-ee3c212f-cd80-4fd5-b9a5-920fe18e564a
       Date:
-      - Tue, 08 Jan 2019 19:15:56 GMT
+      - Mon, 04 Mar 2019 20:02:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +2898,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +2913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3041,9 +2924,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fb3ea992-65f6-4bd7-bd9e-55d6be6c4951
+      - req-73dfb54a-8864-47ca-b693-06790648ce83
       Date:
-      - Tue, 08 Jan 2019 19:15:56 GMT
+      - Mon, 04 Mar 2019 20:02:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +2982,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3125,9 +3008,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b3d22f14-11b7-48d9-b89d-fa8b8a0bec3e
+      - req-2a10989d-13b6-49b4-a4aa-40a680f95b01
       Date:
-      - Tue, 08 Jan 2019 19:15:57 GMT
+      - Mon, 04 Mar 2019 20:02:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3022,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3050,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-758f74a7-96ea-4fd4-9eda-6bd46501695c
+      - req-94940d5f-8af0-42fc-a161-6b9e23f277bf
       Date:
-      - Tue, 08 Jan 2019 19:15:57 GMT
+      - Mon, 04 Mar 2019 20:02:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3098,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3126,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-445a2098-e006-4c13-a646-7e174baee584
+      - req-f4aeca37-d7a8-4a34-b52e-63c71d4de84a
       Date:
-      - Tue, 08 Jan 2019 19:15:57 GMT
+      - Mon, 04 Mar 2019 20:02:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3174,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3202,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-fbd072dd-be7e-4f8a-aca1-9ebdf40b208e
+      - req-6f9b2383-6b9b-49e5-81c9-4186c0fc3afd
       Date:
-      - Tue, 08 Jan 2019 19:15:57 GMT
+      - Mon, 04 Mar 2019 20:02:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3252,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3280,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-1d3b0d3e-f3a3-47dc-ad4f-d7f0282f03aa
+      - req-87305d66-b66f-4bb3-b28f-80188711916f
       Date:
-      - Tue, 08 Jan 2019 19:15:58 GMT
+      - Mon, 04 Mar 2019 20:02:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3324,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3339,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3352,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-ee4d1f33-4d3a-44cc-8f12-917102e67eba
+      - req-1a5d1132-8544-430a-ac64-d42207ee73f2
       Date:
-      - Tue, 08 Jan 2019 19:15:58 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3377,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3405,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-c357cdd5-c85a-42ea-b315-4cf25ceb63a0
+      - req-a8123012-3dfa-45c1-a772-892c3975c50f
       Date:
-      - Tue, 08 Jan 2019 19:15:58 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3440,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-cccbfd0c-f290-43d9-a02b-5fc06069274c
+      - req-ebb52d25-0337-4cb9-90e0-10a03b88e117
       Date:
-      - Tue, 08 Jan 2019 19:15:58 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3475,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-e9995532-127b-4f6a-850d-7c41d658245f
+      - req-3a5002a6-854f-44bd-b284-b0f31637f015
       Date:
-      - Tue, 08 Jan 2019 19:15:58 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3497,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3625,9 +3508,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f3eab7bb-9dc8-4e75-9ecf-6c7d7f088a00
+      - req-1ef43cce-b7f9-4192-a1b1-fb008592ee60
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3566,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3709,9 +3592,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f7cfa5a9-305f-44a8-8919-97ce3f02fd79
+      - req-3bad44ab-7e3e-48ca-8d3c-b4af353c277d
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3606,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3749,9 +3632,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-cd8e90a7-fda0-434a-8139-2fa6abd5d68f
+      - req-ee140cf0-ced2-4725-8019-08dc12f9e20e
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3690,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3705,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 036cdb06527a4568b400af245d3a89ef
+      - 2a72b93b472c40fcbad8dffb7be2ed90
   response:
     status:
       code: 200
@@ -3833,9 +3716,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f6346809-5591-47bd-99e5-711c22b45a42
+      - req-c5716753-f3cc-4d7f-961b-dd777f17673c
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3730,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3745,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3758,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-15de8099-f411-4aa5-a81e-c17f87ad1f5a
+      - req-85b77186-2504-4c12-9706-d6b02326bad3
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3769,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c486c211c194328a48299af43beb901
+      - 61a938faf1d74c9a948fa1484fbae959
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3797,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-d152502d-960d-46de-b502-4c341a7ad8f0
+      - req-93144ef9-874e-47a9-add8-43df8c0a29d5
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3808,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3836,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b5503a98-75a0-4006-8774-f2994c6fd0a8
+      - req-6666d86d-8700-4df1-a646-ab949ee412ef
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3847,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '0120679043b642ce882792212bca72ef'
+      - 74a221edd6414034bbf02157c4451daf
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-623b273f-f8ac-40e8-9d30-f8eb716d994f
+      - req-543fa213-81b2-41fd-aa2f-a18f983836c7
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +3886,88 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:31 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Mar 2019 20:02:31 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-9d1c91b1-395a-4f09-8fa2-94c6f7bffb75
+      Content-Length:
+      - '4170'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:31.996338", "expires":
+        "2019-03-04T21:02:31Z", "id": "18185cf2e1024940ba490167a1914295", "tenant":
+        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
+        "name": "admin"}, "audit_ids": ["88p_7QUXROG8UWtdoybMZg"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
+        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
+        "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:02:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +3985,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:59 GMT
+      - Mon, 04 Mar 2019 20:02:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d6ed000-c2f7-4e40-87e8-fef474302ec6
+      - req-352eb496-39bc-4d14-adb5-dfcebb8911e8
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4000,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:00.032575", "expires":
-        "2019-01-08T20:16:00Z", "id": "4c86192bc37b4576b93acac20a26e433", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:32.192077", "expires":
+        "2019-03-04T21:02:32Z", "id": "0781aaead45542a389a5aa20a100979d", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A2VnPHPXTaOJVoxyShLwJg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RIBMprDWRkSlxjdq36QC3g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4047,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4101,13 +4065,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:00 GMT
+      - Mon, 04 Mar 2019 20:02:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6553a0db-07ce-48c2-847f-c0a3703a899d
+      - req-047b60ce-2f33-4590-94ca-eb87d50d1e4c
       Content-Length:
       - '4131'
       Connection:
@@ -4116,10 +4080,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:00.220813", "expires":
-        "2019-01-08T20:16:00Z", "id": "f5ef2deddb7a40f39d2c349215801b63", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:32.396933", "expires":
+        "2019-03-04T21:02:32Z", "id": "8b26910d88b146db90bc53aeadfec61b", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gtcNByLQRaulFVNX9rj_Jg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["lyGFcXLUTPCIHPHOROZc4Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4163,7 +4127,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4181,13 +4145,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:00 GMT
+      - Mon, 04 Mar 2019 20:02:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d445858a-24e9-4865-b99f-f05f6e9025e2
+      - req-eee3eea7-997b-4c61-99e5-5ffa1a615786
       Content-Length:
       - '4118'
       Connection:
@@ -4196,10 +4160,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:00.417865", "expires":
-        "2019-01-08T20:16:00Z", "id": "bb903f0a04d44639b9be7ca9313b0e30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:32.585053", "expires":
+        "2019-03-04T21:02:32Z", "id": "c1b89358e8ef409bb7b86f5196a0ea46", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9Ztp81ZwSCGjpfFNZgxEFQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DGgy4XuPSwq_RzUX7VqdWg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4243,7 +4207,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4258,22 +4222,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-538d27da-4f46-482c-a4f7-526385fd424d
+      - req-8070fd56-22d1-46f6-bcbb-ca92ec81cc6b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-538d27da-4f46-482c-a4f7-526385fd424d
+      - req-8070fd56-22d1-46f6-bcbb-ca92ec81cc6b
       Date:
-      - Tue, 08 Jan 2019 19:16:00 GMT
+      - Mon, 04 Mar 2019 20:02:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4247,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4298,22 +4262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5ef2deddb7a40f39d2c349215801b63
+      - 8b26910d88b146db90bc53aeadfec61b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b99b18f-1864-4e52-a1cf-f73c4283fcfa
+      - req-124fa29e-c466-44db-ae96-9b5c881885f4
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1b99b18f-1864-4e52-a1cf-f73c4283fcfa
+      - req-124fa29e-c466-44db-ae96-9b5c881885f4
       Date:
-      - Tue, 08 Jan 2019 19:16:01 GMT
+      - Mon, 04 Mar 2019 20:02:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4323,7 +4287,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4338,22 +4302,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
+      - 18185cf2e1024940ba490167a1914295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-23024f91-bc6a-422e-aba8-a4683db18af5
+      - req-8c00d45c-5afc-4495-ad87-6ce891f70d01
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-23024f91-bc6a-422e-aba8-a4683db18af5
+      - req-8c00d45c-5afc-4495-ad87-6ce891f70d01
       Date:
-      - Tue, 08 Jan 2019 19:16:01 GMT
+      - Mon, 04 Mar 2019 20:02:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4363,7 +4327,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4342,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb903f0a04d44639b9be7ca9313b0e30
+      - c1b89358e8ef409bb7b86f5196a0ea46
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b0f08d4-3b9e-4356-a5ab-c5097bca5571
+      - req-6d6af04d-2540-4b06-bbc2-f80585df8e54
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-0b0f08d4-3b9e-4356-a5ab-c5097bca5571
+      - req-6d6af04d-2540-4b06-bbc2-f80585df8e54
       Date:
-      - Tue, 08 Jan 2019 19:16:01 GMT
+      - Mon, 04 Mar 2019 20:02:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4367,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4385,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:01 GMT
+      - Mon, 04 Mar 2019 20:02:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-baea9728-bfc8-420c-9276-c3e76f4f24e4
+      - req-e28c36d8-35f0-4720-b9d4-57ed4060189d
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4400,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:01.780544", "expires":
-        "2019-01-08T20:16:01Z", "id": "9e252ef086a24fa8b71deff3b2d50327", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:34.260743", "expires":
+        "2019-03-04T21:02:34Z", "id": "59a05193a0a6412f93e9ab5f363bbed2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["VzWmSNzET0qlAmvEB5l67A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["GybDu92cTlim_CT8bAZSmg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4448,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:01 GMT
+      - Mon, 04 Mar 2019 20:02:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f8dcc820-09c6-4629-b1d2-242af6cf62dd
+      - req-05bdbf71-7321-431d-9538-8f73b229bd03
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:01.966165", "expires":
-        "2019-01-08T20:16:01Z", "id": "dca8b1b8b6934f61afdb56de8d65b619", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:34.482242", "expires":
+        "2019-03-04T21:02:34Z", "id": "bb4fc98e313a4c75b9b443242e2f1610", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RUO5oSWDQN6gdTVc-PFyvw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["mJ4Jle95QcC-4CbTk97MZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4582,13 +4546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-443a7c84-55b0-473e-8522-1d450cbe3de4
+      - req-60d01b01-9d69-4402-9caf-0f7ffdc319bb
       Content-Length:
       - '4131'
       Connection:
@@ -4597,10 +4561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:02.158470", "expires":
-        "2019-01-08T20:16:02Z", "id": "ad22f37d5a7c43708a251afd2ce12816", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:34.828699", "expires":
+        "2019-03-04T21:02:34Z", "id": "e785a06f7e914033acbd91c15a997c20", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CdtlNOq4TvWLPlGUPVkmNw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_XWDBr2MRKC7pyc9qk7Gew"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4644,7 +4608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4662,13 +4626,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-73ab5e2d-df75-40a6-a0cb-161bc4b721f3
+      - req-602cbc4e-fe26-46d2-a739-a9e6f14667fb
       Content-Length:
       - '4118'
       Connection:
@@ -4677,10 +4641,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:02.350385", "expires":
-        "2019-01-08T20:16:02Z", "id": "0cc1318b7eba4aa1bfb92c8877f86040", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:35.229325", "expires":
+        "2019-03-04T21:02:35Z", "id": "3c64cc0dc40c49659c475945d912dbb8", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["b_Z_CFBjQLun84sOmB0AVw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["gbh-rbEdQCeMFesGfd7kCA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4724,7 +4688,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4739,7 +4703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dca8b1b8b6934f61afdb56de8d65b619
+      - bb4fc98e313a4c75b9b443242e2f1610
   response:
     status:
       code: 200
@@ -4750,16 +4714,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-5e7b82f7-58b8-4c47-9f10-1c1c1f8430b7
+      - req-8134fff6-6a99-404f-87de-4e752caf3f86
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4774,7 +4738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad22f37d5a7c43708a251afd2ce12816
+      - e785a06f7e914033acbd91c15a997c20
   response:
     status:
       code: 200
@@ -4785,16 +4749,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4e16276f-bf44-45c4-825d-24160cf9bdd5
+      - req-8786f9b7-486c-432f-9d3c-d954dccbd411
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4809,7 +4773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e252ef086a24fa8b71deff3b2d50327
+      - 59a05193a0a6412f93e9ab5f363bbed2
   response:
     status:
       code: 200
@@ -4820,16 +4784,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-833a4439-2cf6-4413-b336-b8cabb9a4a4b
+      - req-19fbea44-55c0-41d7-bfbc-cf643f37e400
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0cc1318b7eba4aa1bfb92c8877f86040
+      - 3c64cc0dc40c49659c475945d912dbb8
   response:
     status:
       code: 200
@@ -4855,16 +4819,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e4f436f8-2dfe-4231-8e22-143665e54ad3
+      - req-bda1f38e-ca82-4187-a6cf-e2ed0b6001b0
       Date:
-      - Tue, 08 Jan 2019 19:16:02 GMT
+      - Mon, 04 Mar 2019 20:02:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4879,7 +4843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,15 +4856,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-5ec95b99-87c6-4d4c-b104-34bb8fbd3062
+      - req-9565aada-a4d8-4b28-8f29-f893a46e0c29
       Date:
-      - Tue, 08 Jan 2019 19:16:03 GMT
+      - Mon, 04 Mar 2019 20:02:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4915,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf17fb2ca67643559e913d2b199d12d7
+      - 74e35980f50f4025ac7c158374664d42
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4928,15 +4892,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-f0afb23f-f7f1-459b-bdb8-ed5dc5aa1926
+      - req-f0d22d19-be6f-48be-82d7-3a1c8d4ded9b
       Date:
-      - Tue, 08 Jan 2019 19:16:03 GMT
+      - Mon, 04 Mar 2019 20:02:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4954,13 +4918,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:03 GMT
+      - Mon, 04 Mar 2019 20:02:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1cc80527-45ae-40ab-b2be-a27d6a5a1d2c
+      - req-3db8c4ec-c3bc-4a7f-ace9-0f19336f87ce
       Content-Length:
       - '4170'
       Connection:
@@ -4969,10 +4933,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:03.708762", "expires":
-        "2019-01-08T20:16:03Z", "id": "59d3e26dd8fc4fd5834a41c8690aef73", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:36.544469", "expires":
+        "2019-03-04T21:02:36Z", "id": "ba8b529e05ae4a9cbcf28c9fca688322", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["n9RRzXSPRluIFGz9s-dTDw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["U10v99PNSm24XORekD76Hg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5017,7 +4981,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5035,13 +4999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:03 GMT
+      - Mon, 04 Mar 2019 20:02:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6dc28119-05b5-4a42-9568-a54ac1c3fb56
+      - req-5bef7579-b77d-4d22-b0ed-0f949354fd36
       Content-Length:
       - '4170'
       Connection:
@@ -5050,10 +5014,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:03.897958", "expires":
-        "2019-01-08T20:16:03Z", "id": "808ca85fb89544f0acb11d772c8c212a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:36.746374", "expires":
+        "2019-03-04T21:02:36Z", "id": "c4bbe860494b47a49c54b864f37945a1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["a0QfUVpfRkGe9OBkyfpYKQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FLkLCS3gRASod07RUkncJw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5098,7 +5062,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5113,7 +5077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 84dbefd51e6c4a75b4619afd19631213
+      - bcae1c85bef14db39a068d107c44ac52
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5126,14 +5090,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-d8075465-f6a7-46ef-8377-89cda8640ab2
+      - req-38c4eacf-3f17-4d06-b007-49bcf2f632c6
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5148,22 +5112,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7e23079-0a9a-46fc-b625-fa000a1d4409
+      - req-06876d1e-8826-445a-a003-352a072da862
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-e7e23079-0a9a-46fc-b625-fa000a1d4409
+      - req-06876d1e-8826-445a-a003-352a072da862
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5196,7 +5160,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5211,22 +5175,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-09f90e9d-b1c8-45a9-9781-72047cfad8a6
+      - req-e1d01a69-402a-4806-9741-2ea7c6c2f015
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-09f90e9d-b1c8-45a9-9781-72047cfad8a6
+      - req-e1d01a69-402a-4806-9741-2ea7c6c2f015
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5243,7 +5207,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5258,27 +5222,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5ef2deddb7a40f39d2c349215801b63
+      - 8b26910d88b146db90bc53aeadfec61b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-daf76d54-6270-481e-8963-0716a17b8cc2
+      - req-44487daa-a1b6-46d8-b851-42c4aa2adf18
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-daf76d54-6270-481e-8963-0716a17b8cc2
+      - req-44487daa-a1b6-46d8-b851-42c4aa2adf18
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5293,27 +5257,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
+      - 18185cf2e1024940ba490167a1914295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-61fccb40-7940-441a-969c-7f8fb329fbbd
+      - req-143a2a3f-2a04-47ac-91df-515f424bbf77
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-61fccb40-7940-441a-969c-7f8fb329fbbd
+      - req-143a2a3f-2a04-47ac-91df-515f424bbf77
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5328,27 +5292,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb903f0a04d44639b9be7ca9313b0e30
+      - c1b89358e8ef409bb7b86f5196a0ea46
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-11428d6c-3318-45a6-850f-7175c4af23e6
+      - req-c6725eee-2056-43c7-9d0b-81631186360f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-11428d6c-3318-45a6-850f-7175c4af23e6
+      - req-c6725eee-2056-43c7-9d0b-81631186360f
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5363,22 +5327,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b30d2369-0eaa-456d-8aa7-6e624060c1ef
+      - req-b0ae2c38-aec0-4d48-be0a-5ad4a6b7336b
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-b30d2369-0eaa-456d-8aa7-6e624060c1ef
+      - req-b0ae2c38-aec0-4d48-be0a-5ad4a6b7336b
       Date:
-      - Tue, 08 Jan 2019 19:16:04 GMT
+      - Mon, 04 Mar 2019 20:02:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5393,7 +5357,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5408,22 +5372,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3c27be94-a607-41eb-9df4-cabc7affacd4
+      - req-802af50b-0fa9-4d30-9818-5cc919dd1dbc
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-3c27be94-a607-41eb-9df4-cabc7affacd4
+      - req-802af50b-0fa9-4d30-9818-5cc919dd1dbc
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5438,7 +5402,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5453,27 +5417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5ef2deddb7a40f39d2c349215801b63
+      - 8b26910d88b146db90bc53aeadfec61b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f50452f8-fda6-41de-a248-68d88588ab9d
+      - req-c254f58c-4630-4681-be86-aa5fb5449898
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f50452f8-fda6-41de-a248-68d88588ab9d
+      - req-c254f58c-4630-4681-be86-aa5fb5449898
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5488,27 +5452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5ef2deddb7a40f39d2c349215801b63
+      - 8b26910d88b146db90bc53aeadfec61b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-692ed84c-2b23-46fe-bbdd-9ac65b222eaf
+      - req-184a6382-7dff-4a7b-a419-e70df45f0b2b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-692ed84c-2b23-46fe-bbdd-9ac65b222eaf
+      - req-184a6382-7dff-4a7b-a419-e70df45f0b2b
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5523,27 +5487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
+      - 18185cf2e1024940ba490167a1914295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd55d8f7-8804-4bb9-ad35-c4e48517eeab
+      - req-262cf5b1-9a0f-4d7d-98c9-8fc86e81bb39
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dd55d8f7-8804-4bb9-ad35-c4e48517eeab
+      - req-262cf5b1-9a0f-4d7d-98c9-8fc86e81bb39
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5558,27 +5522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
+      - 18185cf2e1024940ba490167a1914295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ec56e88e-8db9-4e58-9b35-4778c7e594ad
+      - req-cdec501c-9425-4ce0-b769-a8d37fe45f75
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ec56e88e-8db9-4e58-9b35-4778c7e594ad
+      - req-cdec501c-9425-4ce0-b769-a8d37fe45f75
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5593,27 +5557,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb903f0a04d44639b9be7ca9313b0e30
+      - c1b89358e8ef409bb7b86f5196a0ea46
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2e51e6e9-8abf-4aae-92f2-56176812d824
+      - req-0a34aa9a-5d7a-4984-b63e-525df78d12e6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2e51e6e9-8abf-4aae-92f2-56176812d824
+      - req-0a34aa9a-5d7a-4984-b63e-525df78d12e6
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5628,27 +5592,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb903f0a04d44639b9be7ca9313b0e30
+      - c1b89358e8ef409bb7b86f5196a0ea46
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0f141f5e-b4b1-4171-845d-8ebcfa2407af
+      - req-5d07b926-299f-49e1-a5ea-c5f7c348281f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0f141f5e-b4b1-4171-845d-8ebcfa2407af
+      - req-5d07b926-299f-49e1-a5ea-c5f7c348281f
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -5663,22 +5627,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b1cffca-d8af-4d92-b22c-6b10ff538727
+      - req-81293b2a-a774-47f2-bf36-3067a0867212
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-0b1cffca-d8af-4d92-b22c-6b10ff538727
+      - req-81293b2a-a774-47f2-bf36-3067a0867212
       Date:
-      - Tue, 08 Jan 2019 19:16:05 GMT
+      - Mon, 04 Mar 2019 20:02:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5711,7 +5675,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5726,22 +5690,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aab68afc-9024-4019-9bcc-6d5744a4f082
+      - req-4df6312c-7328-40f6-858f-c52c6fbf31a6
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-aab68afc-9024-4019-9bcc-6d5744a4f082
+      - req-4df6312c-7328-40f6-858f-c52c6fbf31a6
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5782,7 +5746,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5797,22 +5761,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a509dbb0-1999-44a1-9262-5b59e9302f04
+      - req-c44811b4-4bc3-4a35-96f2-bd119b044aa2
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-a509dbb0-1999-44a1-9262-5b59e9302f04
+      - req-c44811b4-4bc3-4a35-96f2-bd119b044aa2
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5846,7 +5810,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5861,27 +5825,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c86192bc37b4576b93acac20a26e433
+      - '0781aaead45542a389a5aa20a100979d'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60b186c3-4998-40a4-b24f-7196cbdc2811
+      - req-71fafe83-73a4-4231-abfb-6be146bbccf5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-60b186c3-4998-40a4-b24f-7196cbdc2811
+      - req-71fafe83-73a4-4231-abfb-6be146bbccf5
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -5896,27 +5860,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f5ef2deddb7a40f39d2c349215801b63
+      - 8b26910d88b146db90bc53aeadfec61b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b4341f3-8b9d-40f3-92d9-e2b7b7030ca9
+      - req-3b6f1f23-c975-4321-8dd5-3daab3e6dcc9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6b4341f3-8b9d-40f3-92d9-e2b7b7030ca9
+      - req-3b6f1f23-c975-4321-8dd5-3daab3e6dcc9
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -5931,27 +5895,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 82315594503a4b348d6cf83627f77c25
+      - 18185cf2e1024940ba490167a1914295
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b55124c-4a7b-4a88-9850-71df17b07aa7
+      - req-cf1d1664-8016-4768-8fb3-87fd4a755b4d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4b55124c-4a7b-4a88-9850-71df17b07aa7
+      - req-cf1d1664-8016-4768-8fb3-87fd4a755b4d
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -5966,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb903f0a04d44639b9be7ca9313b0e30
+      - c1b89358e8ef409bb7b86f5196a0ea46
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ac301b7-9290-476c-8491-6bd104d13d57
+      - req-8cad82e5-ea5e-48c6-8b05-824bcda14f2d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0ac301b7-9290-476c-8491-6bd104d13d57
+      - req-8cad82e5-ea5e-48c6-8b05-824bcda14f2d
       Date:
-      - Tue, 08 Jan 2019 19:16:06 GMT
+      - Mon, 04 Mar 2019 20:02:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6004,13 +5968,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:08 GMT
+      - Mon, 04 Mar 2019 20:02:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a44ac971-a968-4ab0-b075-2dc8277b01e9
+      - req-ce6ffe2c-be7e-4299-9414-4dde14938320
       Content-Length:
       - '4170'
       Connection:
@@ -6019,10 +5983,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:08.498690", "expires":
-        "2019-01-08T20:16:08Z", "id": "ab9cbedc2149485da1b286490c83e0da", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:43.080506", "expires":
+        "2019-03-04T21:02:43Z", "id": "f0551cb6270240bca44cbe26dcac5c4c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["diHlIHKSSruBMdjg0bGeHg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["pvpd1BsiQx-8QyBPPR6Ibg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6067,7 +6031,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6085,13 +6049,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:08 GMT
+      - Mon, 04 Mar 2019 20:02:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-49b65616-acb1-4915-8216-af3c57ee193f
+      - req-c64e169a-aae8-4e7e-af2c-d376927fe2ba
       Content-Length:
       - '4170'
       Connection:
@@ -6100,10 +6064,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:08.698398", "expires":
-        "2019-01-08T20:16:08Z", "id": "4e1add7c24234eefb24f60ec04e695b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:43.306606", "expires":
+        "2019-03-04T21:02:43Z", "id": "f206f4863f4c40019714bad37a642ea9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["oO4O2m35TxSkmwipSbBOkQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["7AF_xNBdTU2MWPoLU_oBxw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6148,7 +6112,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6163,7 +6127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -6174,22 +6138,32 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-00c644b8-91b9-4fcf-9673-e96337924c04
+      - req-f6e9953d-ca90-48da-8f67-e19d00b00233
       Date:
-      - Tue, 08 Jan 2019 19:16:08 GMT
+      - Mon, 04 Mar 2019 20:02:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6229,24 +6203,14 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6264,13 +6228,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:09 GMT
+      - Mon, 04 Mar 2019 20:02:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-94142e56-efd3-4c70-8319-ab193df92640
+      - req-ccea317d-223b-4135-bd57-341093b0bdc9
       Content-Length:
       - '4170'
       Connection:
@@ -6279,10 +6243,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:09.110869", "expires":
-        "2019-01-08T20:16:09Z", "id": "62303cb5fe9d47de9750ddbb8f545a88", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:43.731259", "expires":
+        "2019-03-04T21:02:43Z", "id": "9df1db811e6d4b10904f26becf38991e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["cP8YrWxUROu0zp-tJQi35w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["0mmRSMiOTG-XsnuM2O_Fqw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6327,7 +6291,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6345,13 +6309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:09 GMT
+      - Mon, 04 Mar 2019 20:02:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4717103c-2ce1-4d1d-9c67-d7d63e58f4b5
+      - req-ea0333a7-01ee-443d-954d-916ba9ae24bb
       Content-Length:
       - '370'
       Connection:
@@ -6360,13 +6324,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:09.275383", "expires":
-        "2019-01-08T20:16:09Z", "id": "c5dc7e26396547798ea7703b071fd67e", "audit_ids":
-        ["-bHVpT0CRF-4qRacf1LVFA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:44.029237", "expires":
+        "2019-03-04T21:02:44Z", "id": "7e849af71d3a42f7b46f06c48fed84ef", "audit_ids":
+        ["jUfmyf_6T9CHCRFMHlNTWg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:44 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6381,20 +6345,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c5dc7e26396547798ea7703b071fd67e
+      - 7e849af71d3a42f7b46f06c48fed84ef
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:09 GMT
+      - Mon, 04 Mar 2019 20:02:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-df94e9a7-82ca-416d-b677-39de727e99c5
+      - req-f5046aba-35f5-44bf-9f75-1a3183bbac57
       Content-Length:
       - '500'
       Connection:
@@ -6411,7 +6375,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6429,13 +6393,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:09 GMT
+      - Mon, 04 Mar 2019 20:02:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-19efd43f-7839-4b76-958f-0f6e65934bfa
+      - req-e0ae56dd-a76d-431d-ad94-71e9539174d8
       Content-Length:
       - '4117'
       Connection:
@@ -6444,10 +6408,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:09.725689", "expires":
-        "2019-01-08T20:16:09Z", "id": "b65e1ad49e0a41629ab40008a86f77b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:44.596870", "expires":
+        "2019-03-04T21:02:44Z", "id": "f05ad4f8924d43448ab0d2d1baa49182", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OUdXDvZhS_e41J1zbO2C1g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["T2ceoJ0MQt2JycuVvMf7HQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6491,7 +6455,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6509,13 +6473,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:09 GMT
+      - Mon, 04 Mar 2019 20:02:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-1738fcdf-9eda-404b-adab-1f247df91454
+      - req-44bd1d65-1638-4197-8c3b-65c0551b5259
       Content-Length:
       - '4131'
       Connection:
@@ -6524,10 +6488,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:09.921048", "expires":
-        "2019-01-08T20:16:09Z", "id": "1aee2ba839324fa4b9987482a5893251", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:44.884218", "expires":
+        "2019-03-04T21:02:44Z", "id": "cee2cef382fa4f38ab6184cad4a39441", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_qO4_bijS8OJWb8MouL6TA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SvpjDAGTQDWB-8td-YjqDg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6571,7 +6535,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6589,13 +6553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ae1f5001-fdc4-4cbe-bac0-861667d7177f
+      - req-9b4cefe8-4c69-4fb8-8e46-d8a61f65529c
       Content-Length:
       - '4118'
       Connection:
@@ -6604,10 +6568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:10.151303", "expires":
-        "2019-01-08T20:16:10Z", "id": "2c1c9237c36b4d7682f6945211483007", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:45.087178", "expires":
+        "2019-03-04T21:02:45Z", "id": "9ee668ad460c48bca7643d178f620b69", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["sMMVPnMhSIyh2kieL_oc4g"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vl4IkDwBQAGw0WuJH7uW8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6651,7 +6615,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6666,7 +6630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -6677,9 +6641,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-670ea580-df8b-4031-af61-5c416426f96e
+      - req-dfa883f3-27da-4639-a946-775cf012dc4b
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6713,7 +6677,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6728,7 +6692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -6739,14 +6703,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b93695d6-96ea-4efc-ab07-91939a0d1a81
+      - req-f5f925db-7f90-4fe9-9f7a-5250b3b13c85
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6761,7 +6725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1aee2ba839324fa4b9987482a5893251
+      - cee2cef382fa4f38ab6184cad4a39441
   response:
     status:
       code: 200
@@ -6772,14 +6736,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c581c1b1-fd89-4113-88cc-e5d343c82ab8
+      - req-870ec830-1a22-47a2-9755-a20868a11085
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6794,7 +6758,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62303cb5fe9d47de9750ddbb8f545a88
+      - 9df1db811e6d4b10904f26becf38991e
   response:
     status:
       code: 200
@@ -6805,14 +6769,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4884e78b-7dd9-4209-991b-5abde8a56307
+      - req-8ef68a86-0ea7-44b3-93a2-35553084ffd9
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6827,7 +6791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2c1c9237c36b4d7682f6945211483007
+      - 9ee668ad460c48bca7643d178f620b69
   response:
     status:
       code: 200
@@ -6838,14 +6802,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-32cfe5ba-fe95-4f1d-b180-ee0e871d8e1f
+      - req-62375157-4b7c-4aa5-b451-41388516d5de
       Date:
-      - Tue, 08 Jan 2019 19:16:10 GMT
+      - Mon, 04 Mar 2019 20:02:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6860,7 +6824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -6871,9 +6835,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-dffa7e73-d7bd-435c-b1d5-f3c279717ac1
+      - req-dd22d543-f2f5-4ea5-bd44-4c063204a876
       Date:
-      - Tue, 08 Jan 2019 19:16:11 GMT
+      - Mon, 04 Mar 2019 20:02:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6900,7 +6864,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6915,7 +6879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -6926,9 +6890,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a7c61248-0e72-4ef8-a08e-ae20b0bca800
+      - req-7e8210b2-006d-4ddb-93b7-0901904622d3
       Date:
-      - Tue, 08 Jan 2019 19:16:11 GMT
+      - Mon, 04 Mar 2019 20:02:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6955,7 +6919,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6970,7 +6934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -6981,9 +6945,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-a311f313-94cd-4cc7-b13a-498cce778697
+      - req-ec95164e-b1c0-495b-b4ce-6b7ee8b86552
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7010,7 +6974,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7025,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -7036,9 +7000,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7651dcae-1c0c-43b2-aa12-f3a8f2ecef9a
+      - req-517ab6d3-b827-441b-a421-1c6a9c8317d4
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7050,7 +7014,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7065,7 +7029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -7076,9 +7040,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-30897886-38f4-4521-98ed-0445a0abf529
+      - req-f6eef785-f829-436d-a45c-6c8f70c5282e
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7090,7 +7054,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7105,7 +7069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b65e1ad49e0a41629ab40008a86f77b6
+      - f05ad4f8924d43448ab0d2d1baa49182
   response:
     status:
       code: 200
@@ -7116,9 +7080,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-540a4eae-6890-44a7-be87-8640c9336bc5
+      - req-1749ed10-6270-4221-9f4e-49c4927e5faa
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7130,7 +7094,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7148,13 +7112,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fbd8a929-42f6-49b7-abdd-9d303474fcac
+      - req-bed72d40-06b1-4c0a-9b52-b1dc3c7069dc
       Content-Length:
       - '4117'
       Connection:
@@ -7163,10 +7127,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:12.604894", "expires":
-        "2019-01-08T20:16:12Z", "id": "42e56036deb7458eb8e95b2f1d90e337", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:47.703226", "expires":
+        "2019-03-04T21:02:47Z", "id": "824670d64e3f4d34b0ffaca3abdffc47", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["xiQmE2fzSA2RfmUOKaqZ5w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HokZwiO_SMqvZGPEV61HiA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7210,7 +7174,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7228,13 +7192,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:47 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5dd452b7-77b2-42b2-b018-03e4febb870e
+      - req-2925f0b9-410c-4748-b864-5defc27fe71e
       Content-Length:
       - '4131'
       Connection:
@@ -7243,10 +7207,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:12.810795", "expires":
-        "2019-01-08T20:16:12Z", "id": "f4c884fa014b427990e7a6431069eb13", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:47.947881", "expires":
+        "2019-03-04T21:02:47Z", "id": "2735afa260dc424eb450a8ae0f7bbd78", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FDVTt_ozQ6uXYzcUz7aGPA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["sDukiQFjSnG2CctziAaunA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7290,7 +7254,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:47 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7308,13 +7272,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:12 GMT
+      - Mon, 04 Mar 2019 20:02:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a567c015-052b-40b1-bfc7-d31cbaa137f9
+      - req-8b0db57c-ce52-4306-814d-44b6d613064f
       Content-Length:
       - '4118'
       Connection:
@@ -7323,10 +7287,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:13.047883", "expires":
-        "2019-01-08T20:16:13Z", "id": "f515307b938d4e59a3376364928e593b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:48.177976", "expires":
+        "2019-03-04T21:02:48Z", "id": "1ca2eca6bfde43d79689c32900102b09", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["OfiP0dyES3yu-KAv7iEQmQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yMbVyKtCRQyaLOBO6fvMdg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7370,7 +7334,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7385,7 +7349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -7396,13 +7360,72 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-039a4bdd-7c68-4534-b632-398b2e88ca9c
+      - req-56d3a6ab-e157-470f-b52c-5f12d480d21f
       Date:
-      - Tue, 08 Jan 2019 19:16:13 GMT
+      - Mon, 04 Mar 2019 20:02:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -7424,6 +7447,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:02:48 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 824670d64e3f4d34b0ffaca3abdffc47
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-19ad3516-b118-434f-ac62-eef086357658
+      Date:
+      - Mon, 04 Mar 2019 20:02:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7489,6 +7579,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -7502,7 +7598,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7517,7 +7613,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -7528,46 +7624,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8b2dbcc-97af-4471-ae2f-25498f328795
+      - req-794aef8c-a1d5-4c7d-beea-713aa45b0d2e
       Date:
-      - Tue, 08 Jan 2019 19:16:13 GMT
+      - Mon, 04 Mar 2019 20:02:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7621,20 +7699,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7649,7 +7745,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -7660,430 +7756,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a972d439-e678-4891-a6cb-0b8b096533b7
+      - req-4527fb5d-e7d6-4d92-a1d9-22d5edf9d25e
       Date:
-      - Tue, 08 Jan 2019 19:16:13 GMT
+      - Mon, 04 Mar 2019 20:02:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-95213231-7a70-4094-accc-9a955e0c0d49
-      Date:
-      - Tue, 08 Jan 2019 19:16:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4fa46cac-1aa5-4124-b57a-da1737f041a9
-      Date:
-      - Tue, 08 Jan 2019 19:16:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a2f43e76-faf0-444e-a766-acfc49d12d22
-      Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8149,6 +7843,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8162,7 +7862,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -8177,7 +7877,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -8188,46 +7888,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-46433cee-3435-42f8-a38f-c4cea77c0aef
+      - req-bb76e137-02ec-4db4-a845-e485ab6ddae7
       Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
+      - Mon, 04 Mar 2019 20:02:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8281,20 +7963,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8309,7 +8009,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -8320,430 +8020,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f82090de-9178-43ca-b2a7-879c753fcb5a
+      - req-53be02b9-2f8f-4376-bc75-9862ca0d2f1a
       Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
+      - Mon, 04 Mar 2019 20:02:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-9cf720c5-5a6f-45e0-aeef-5024fdeb9257
-      Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b4d77327-e9d2-4286-99ff-21bfbdac3663
-      Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4e5ac994-ba0a-42b6-bb34-761436048e16
-      Date:
-      - Tue, 08 Jan 2019 19:16:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8809,6 +8107,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -8822,7 +8126,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:49 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f206f4863f4c40019714bad37a642ea9
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-05ab1bd1-213b-4bb4-88bf-e64d52206da7
+      Date:
+      - Mon, 04 Mar 2019 20:02:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:02:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -8837,7 +8273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -8848,298 +8284,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7306043d-207e-42d6-9daa-ce1c7c677098
+      - req-15f0d242-e36a-45c9-b6e2-f33a8141f51a
       Date:
-      - Tue, 08 Jan 2019 19:16:15 GMT
+      - Mon, 04 Mar 2019 20:02:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a7e84b19-3d70-4ba8-a6e6-fcd88075a84a
-      Date:
-      - Tue, 08 Jan 2019 19:16:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:15 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-21065b8e-2d91-4af6-9a69-fe4847e339f9
-      Date:
-      - Tue, 08 Jan 2019 19:16:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9205,6 +8371,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -9218,7 +8390,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -9233,7 +8405,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -9244,46 +8416,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-2bbf9727-98c9-422f-95ed-392df3620b11
+      - req-386ec8c6-6793-4a29-a4ae-ab93b24e299b
       Date:
-      - Tue, 08 Jan 2019 19:16:15 GMT
+      - Mon, 04 Mar 2019 20:02:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9337,20 +8491,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9365,7 +8537,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -9376,9 +8548,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-da6a6f64-dfd3-4a20-91a9-48dec4c0485c
+      - req-f83de640-46e3-4ac4-9e23-d9fc46b4da5f
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9420,7 +8592,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9435,7 +8607,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -9446,9 +8618,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e5258f78-680c-4c40-ab7a-4d85661f655f
+      - req-173e13a5-7f5d-435f-8792-d29c6d273e8a
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9490,7 +8662,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9505,7 +8677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -9516,9 +8688,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3aaf06e1-b532-408f-9ce2-1741c0283fc5
+      - req-7649a031-a39f-42d0-96ce-ac7d2766b9e6
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9560,7 +8732,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9575,7 +8747,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -9586,9 +8758,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-fd727101-175e-445f-8bc9-defeeff6486a
+      - req-452d3930-8367-4869-81ac-a08e1ed9133b
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9630,7 +8802,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9645,7 +8817,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -9656,9 +8828,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0f5b8919-725c-4bed-b1c2-5ad56b22ecfd
+      - req-a3a1ad84-1929-4b10-97db-ef6d1459df6e
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9700,7 +8872,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9715,7 +8887,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -9726,9 +8898,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-4795819f-ec21-4509-a11f-39f70be6bdc6
+      - req-c4fc7f6a-0fd2-4b00-9690-923015fff297
       Date:
-      - Tue, 08 Jan 2019 19:16:16 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9770,7 +8942,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9785,7 +8957,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -9796,9 +8968,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5d914681-c4c7-4c53-bb19-908f6ef07c88
+      - req-78ce061e-9682-4960-947b-8bc3fc60dced
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9840,7 +9012,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9855,7 +9027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -9866,9 +9038,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6dfac3d3-584c-40d3-9771-a5e3dd2c44e9
+      - req-a390d3f3-b3be-459d-9aeb-739a677c5b3a
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9910,7 +9082,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -9925,7 +9097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -9936,9 +9108,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-f94e862f-84b8-44f6-a2c1-2d4d02ef219b
+      - req-eb85ac8b-aeff-4816-9447-11188dada26f
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10341,7 +9513,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10356,7 +9528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -10367,9 +9539,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bb364340-044c-41df-9093-b0103c9688cb
+      - req-48065db9-8cd7-410e-95f2-49af9eeb23d2
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10772,7 +9944,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10787,7 +9959,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -10798,9 +9970,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-3c4b6232-bfbd-413e-b6f7-8290ecabbb8b
+      - req-af2cdd1d-6345-4cae-b2b5-367d5f4b78cf
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11203,7 +10375,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11218,7 +10390,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -11229,9 +10401,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4563b5a0-a128-41e4-a032-5d66f8256aab
+      - req-6893a29c-495a-45aa-9395-f4d1addfbe50
       Date:
-      - Tue, 08 Jan 2019 19:16:17 GMT
+      - Mon, 04 Mar 2019 20:02:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11634,7 +10806,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11649,7 +10821,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -11660,9 +10832,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-0f183324-e17f-4b05-a78c-66f075b12068
+      - req-7b0b917f-12d3-46f7-9f35-375d40d55ed8
       Date:
-      - Tue, 08 Jan 2019 19:16:18 GMT
+      - Mon, 04 Mar 2019 20:02:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12065,7 +11237,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12080,7 +11252,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -12091,9 +11263,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-cb562faa-a0d8-4b6a-a7bc-1e1c740bffa3
+      - req-4fcbf805-bba8-4277-8ffd-d46bfc5260c5
       Date:
-      - Tue, 08 Jan 2019 19:16:18 GMT
+      - Mon, 04 Mar 2019 20:02:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12496,7 +11668,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12511,7 +11683,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -12522,9 +11694,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b446b8b2-8e9d-48fd-8888-4e21ffa9f04d
+      - req-601db3e5-256f-42b4-8c58-2fb054d229cd
       Date:
-      - Tue, 08 Jan 2019 19:16:18 GMT
+      - Mon, 04 Mar 2019 20:02:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12927,7 +12099,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12942,7 +12114,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -12953,9 +12125,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-1b579acf-de7c-4aad-b652-1682bbeb4a34
+      - req-68a1d4d6-81e2-4b9e-bb99-8d1eff1346e3
       Date:
-      - Tue, 08 Jan 2019 19:16:18 GMT
+      - Mon, 04 Mar 2019 20:02:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13358,7 +12530,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13373,7 +12545,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -13384,9 +12556,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fca1b7e7-cbcb-43d8-b604-7ac73a9ea666
+      - req-6c91c13e-71c4-448e-8f3c-8dd1ba85609c
       Date:
-      - Tue, 08 Jan 2019 19:16:19 GMT
+      - Mon, 04 Mar 2019 20:02:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13418,7 +12590,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13433,7 +12605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -13444,9 +12616,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-afb93bb4-6c8c-40ed-8859-c51995fe6a39
+      - req-4cb645f8-8926-46f0-9172-a7fb8d4a9f30
       Date:
-      - Tue, 08 Jan 2019 19:16:19 GMT
+      - Mon, 04 Mar 2019 20:02:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13478,7 +12650,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13493,7 +12665,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -13504,9 +12676,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-12f760a3-3624-4771-b8cf-eb4abd273807
+      - req-cff4be47-3f59-46a4-acc9-20a1c423dffe
       Date:
-      - Tue, 08 Jan 2019 19:16:19 GMT
+      - Mon, 04 Mar 2019 20:02:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13538,7 +12710,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13553,7 +12725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -13564,9 +12736,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-702560d5-72c7-4718-9b7c-94f9caa92428
+      - req-8ce30fd7-a4ce-4bff-b631-4d2c8e9c8bb9
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:02:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13598,7 +12770,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13613,7 +12785,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -13624,9 +12796,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2ead684e-790b-41db-8c85-8c17873c53fd
+      - req-de19878d-1d02-4cc7-916f-9f9f29c9e14c
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:03:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13658,7 +12830,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13673,7 +12845,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -13684,9 +12856,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-34f25167-005b-46ab-b22d-99201ed5b7c2
+      - req-b98fe304-57c3-456b-b231-1c621ec687ce
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:03:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13718,7 +12890,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13733,7 +12905,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -13744,9 +12916,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-41a3e8e9-b9bc-4083-bc77-e7953fb5ff28
+      - req-de3b040d-b413-4399-a198-61b9f7863e1c
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13778,7 +12950,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13793,7 +12965,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -13804,9 +12976,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-0dd90732-ec52-4b75-a768-16628045238d
+      - req-559b6d2e-e511-4db8-9697-c7f8a7d3e08f
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13838,7 +13010,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13853,7 +13025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -13864,9 +13036,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f024aacc-0cb4-41ae-a5a9-88b1556ce0e6
+      - req-aae5f76f-0ea5-4c3d-9c03-9ef62707e5af
       Date:
-      - Tue, 08 Jan 2019 19:16:20 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -13908,7 +13080,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -13923,7 +13095,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -13934,9 +13106,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d990e060-1ba9-468f-9f6a-c3d356438635
+      - req-395ada68-617a-4f5a-8b16-c7ecb4587054
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -13979,7 +13151,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -13994,7 +13166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -14005,9 +13177,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-897002aa-7a2c-423b-97a0-642000ca34d3
+      - req-79c8fe0e-b7e4-47b4-a6d0-65520ce5544c
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14042,7 +13214,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14057,7 +13229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 42e56036deb7458eb8e95b2f1d90e337
+      - 824670d64e3f4d34b0ffaca3abdffc47
   response:
     status:
       code: 200
@@ -14068,9 +13240,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-afdd5b2b-7810-4295-849b-7f3919c20d6c
+      - req-22c419b3-de6e-41a1-8d7d-1263965d1ca0
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14157,7 +13329,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14172,7 +13344,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -14183,9 +13355,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-94961e0b-cfd3-4b69-8d88-471cf0a9a9e2
+      - req-11f66a93-fbb6-4486-8575-f77c305e5414
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14227,7 +13399,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14242,7 +13414,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -14253,9 +13425,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cbac0200-4689-4b3a-9e7f-108201f463dd
+      - req-d0a253eb-accf-4936-949b-1014a3fe1d1b
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14298,7 +13470,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14313,7 +13485,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -14324,9 +13496,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-fee5a817-5f8e-4169-8879-5f2f26cb42fd
+      - req-070b4363-02fd-48f1-a00f-b717fcf1635c
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14361,7 +13533,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14376,7 +13548,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c884fa014b427990e7a6431069eb13
+      - 2735afa260dc424eb450a8ae0f7bbd78
   response:
     status:
       code: 200
@@ -14387,9 +13559,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-c399b507-d264-409d-9b3d-11912dac372e
+      - req-7a035ad8-c90d-4c51-9d86-57eb8fe2d62c
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14476,7 +13648,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14491,7 +13663,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -14502,9 +13674,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0f8fa4e4-79e5-41d6-af1c-e5704c38bcef
+      - req-5edae668-702c-4039-a571-de38c6fc0472
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14546,7 +13718,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14561,7 +13733,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -14572,9 +13744,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-5917ae15-bc8f-4088-b691-0a86de880b1b
+      - req-a986c466-897b-4536-8af8-480f16a5f1f2
       Date:
-      - Tue, 08 Jan 2019 19:16:21 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14617,7 +13789,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14632,7 +13804,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -14643,9 +13815,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-bfb95b35-7fba-4399-a60e-f911a2c1372b
+      - req-4511c95e-264a-40ee-9c8b-1a994887d16f
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14680,7 +13852,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14695,7 +13867,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4e1add7c24234eefb24f60ec04e695b6
+      - f206f4863f4c40019714bad37a642ea9
   response:
     status:
       code: 200
@@ -14706,9 +13878,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-b2d55360-bddc-4e5c-a294-904c5e239a4e
+      - req-ac147913-cd1a-41fc-88f6-339b91e7beaa
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14795,7 +13967,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14810,7 +13982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -14821,9 +13993,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-f99d2c7a-c4a4-4ec5-9d3d-1d81353c0178
+      - req-46f2eb5a-93dd-4d78-bdc3-1b67f256d344
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14865,7 +14037,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14880,7 +14052,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -14891,9 +14063,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a282447b-266f-4571-bc25-18b27b17f896
+      - req-66c68bbc-52d1-4cbe-8256-c35bc4b29e35
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14936,7 +14108,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14951,7 +14123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -14962,9 +14134,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2c2de438-8c86-4d85-b9a5-a289096564d6
+      - req-f905d9bc-4706-4298-aa52-27e3c4583fcb
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14999,7 +14171,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -15014,7 +14186,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f515307b938d4e59a3376364928e593b
+      - 1ca2eca6bfde43d79689c32900102b09
   response:
     status:
       code: 200
@@ -15025,9 +14197,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-e0cdf66f-8df7-436a-9212-ee0e545e05ae
+      - req-1a1e9537-d7f3-4e27-89d5-66f9c6fb9269
       Date:
-      - Tue, 08 Jan 2019 19:16:22 GMT
+      - Mon, 04 Mar 2019 20:03:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -15114,7 +14286,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15132,13 +14304,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:23 GMT
+      - Mon, 04 Mar 2019 20:03:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-836a1b2a-98e8-415c-aad2-045a0ace7b7c
+      - req-0a78f021-45cb-4997-a47e-439eb77c3272
       Content-Length:
       - '4170'
       Connection:
@@ -15147,10 +14319,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:23.395589", "expires":
-        "2019-01-08T20:16:23Z", "id": "2017b7b55f974366a56a6bfcf41bac19", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:06.220841", "expires":
+        "2019-03-04T21:03:06Z", "id": "06488c75093547af9e9e777ac85ab413", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["FsiWvp7vRYWSUBd1P5P3rw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["8Vckc95XSHKWwNLawz3vlg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15195,7 +14367,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15213,13 +14385,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:23 GMT
+      - Mon, 04 Mar 2019 20:03:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec01c416-b73c-448e-962c-d28c4c8d3e50
+      - req-d7be3039-6072-4350-bfc0-459f9b61b303
       Content-Length:
       - '4170'
       Connection:
@@ -15228,10 +14400,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:23.583221", "expires":
-        "2019-01-08T20:16:23Z", "id": "56da36ac09ed41dfac3ff54ca6ef2384", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:06.420446", "expires":
+        "2019-03-04T21:03:06Z", "id": "302f68a8bde14b98878d8cb9c8ae632b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7Ee4AsWVTnSK4uw5C8lljQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["j1OP6l0ORdWFqC2z9kCNGw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15276,7 +14448,43 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:06 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 302f68a8bde14b98878d8cb9c8ae632b
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-4f8d581d-45db-4415-aebf-4f5a40e9c201
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-4f8d581d-45db-4415-aebf-4f5a40e9c201
+      Date:
+      - Mon, 04 Mar 2019 20:03:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:03:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15294,13 +14502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:23 GMT
+      - Mon, 04 Mar 2019 20:03:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-22f86b35-5cd6-4573-b137-ce951317887e
+      - req-ebbc0eab-989a-4b7b-bec6-9b21ab856cd2
       Content-Length:
       - '370'
       Connection:
@@ -15309,13 +14517,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:23.748495", "expires":
-        "2019-01-08T20:16:23Z", "id": "d873f649fd0b44ba967ca46368dba45d", "audit_ids":
-        ["XY4xXyqBQ3eorqjUzQQLkw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:06.784361", "expires":
+        "2019-03-04T21:03:06Z", "id": "b4c81ab73bfa42849f911ef779faccb9", "audit_ids":
+        ["3HpnEEW4R426-yMgEHZdlw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:06 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15330,20 +14538,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d873f649fd0b44ba967ca46368dba45d
+      - b4c81ab73bfa42849f911ef779faccb9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:23 GMT
+      - Mon, 04 Mar 2019 20:03:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-580d03ef-3d0f-491b-97af-1d0225f7acbe
+      - req-d87d584b-cf5a-4403-8453-fec71bbf69b2
       Content-Length:
       - '500'
       Connection:
@@ -15360,7 +14568,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15378,13 +14586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:24 GMT
+      - Mon, 04 Mar 2019 20:03:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ecc66ca-dd02-4d03-8228-a106fb49ba42
+      - req-1cb74a38-0a6c-4581-9c8d-f4092ae9577c
       Content-Length:
       - '4117'
       Connection:
@@ -15393,10 +14601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:24.072016", "expires":
-        "2019-01-08T20:16:24Z", "id": "8ecdbef471af4fe9a4e617ec2cc3378e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:07.235051", "expires":
+        "2019-03-04T21:03:07Z", "id": "8f9e30f471ae41dfa3441c781a2d5c58", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IrijmLdcSFqhMWBu3BdaTg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["1SBIWbjBT4O6vkx241d9aw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15440,7 +14648,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15458,13 +14666,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:24 GMT
+      - Mon, 04 Mar 2019 20:03:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ed5357fb-e902-4087-b58a-269d55c9df99
+      - req-9fc7c979-d6e3-4e0e-a2a8-2749e2af1f3d
       Content-Length:
       - '4131'
       Connection:
@@ -15473,10 +14681,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:24.256280", "expires":
-        "2019-01-08T20:16:24Z", "id": "1ed5d3e7e11a4a5991efd7a37f9f6336", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:07.514952", "expires":
+        "2019-03-04T21:03:07Z", "id": "1108e12f91c54439bd904c860f02f428", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1oKTLXONQ2S8sFc1HEFNng"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yss2whtGR32xnFLDvGCFtQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15520,7 +14728,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15538,13 +14746,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:24 GMT
+      - Mon, 04 Mar 2019 20:03:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0a2bda8c-ad4e-455e-b3fa-112a39f1c86a
+      - req-aa15401a-2657-4557-9f07-bce6ac865b04
       Content-Length:
       - '4118'
       Connection:
@@ -15553,10 +14761,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:24.445678", "expires":
-        "2019-01-08T20:16:24Z", "id": "594c08ca20254fb5af4f86a294d0a084", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:07.859870", "expires":
+        "2019-03-04T21:03:07Z", "id": "73448ebec67346f2a760f41cde7fb418", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["MI2fOaoEReSgICzGaCJgrg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["py4XJo40Sfmn4W7yTehA4A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15600,7 +14808,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -15615,22 +14823,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a35ae499-3c09-4002-a786-d88991583269
+      - req-521b16e0-a852-4474-8692-94a6002b062e
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-a35ae499-3c09-4002-a786-d88991583269
+      - req-521b16e0-a852-4474-8692-94a6002b062e
       Date:
-      - Tue, 08 Jan 2019 19:16:24 GMT
+      - Mon, 04 Mar 2019 20:03:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -15663,7 +14871,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -15678,22 +14886,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-31d0b907-2f29-4f94-a6b4-6a267030d2d7
+      - req-880ed900-c239-4a42-abf1-8a53055086af
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-31d0b907-2f29-4f94-a6b4-6a267030d2d7
+      - req-880ed900-c239-4a42-abf1-8a53055086af
       Date:
-      - Tue, 08 Jan 2019 19:16:24 GMT
+      - Mon, 04 Mar 2019 20:03:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -15734,7 +14942,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -15749,22 +14957,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fa569402-1238-49d5-aa59-0255c9ed8cf8
+      - req-eca0ebbc-524d-4ecd-be96-bb37530d68e4
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-fa569402-1238-49d5-aa59-0255c9ed8cf8
+      - req-eca0ebbc-524d-4ecd-be96-bb37530d68e4
       Date:
-      - Tue, 08 Jan 2019 19:16:25 GMT
+      - Mon, 04 Mar 2019 20:03:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -15798,7 +15006,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -15813,27 +15021,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e366144f-2d8b-44da-9bf3-b578961867e3
+      - req-579cbfe8-6cc2-4edd-a9ce-2b80b10c7bf3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e366144f-2d8b-44da-9bf3-b578961867e3
+      - req-579cbfe8-6cc2-4edd-a9ce-2b80b10c7bf3
       Date:
-      - Tue, 08 Jan 2019 19:16:25 GMT
+      - Mon, 04 Mar 2019 20:03:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -15848,27 +15056,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-631faa77-bcef-4e65-9c48-e89cc58c5d1d
+      - req-7226a74f-f9bb-4576-bb69-4f18f5ba3163
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-631faa77-bcef-4e65-9c48-e89cc58c5d1d
+      - req-7226a74f-f9bb-4576-bb69-4f18f5ba3163
       Date:
-      - Tue, 08 Jan 2019 19:16:25 GMT
+      - Mon, 04 Mar 2019 20:03:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -15883,27 +15091,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0dcabd68-6014-4455-8abc-35f3dc0a61c6
+      - req-3e7f6870-63bc-4d5c-8d02-469b750b328d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0dcabd68-6014-4455-8abc-35f3dc0a61c6
+      - req-3e7f6870-63bc-4d5c-8d02-469b750b328d
       Date:
-      - Tue, 08 Jan 2019 19:16:25 GMT
+      - Mon, 04 Mar 2019 20:03:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -15918,27 +15126,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42b73416-89d0-4ff1-b063-e0a15a06c748
+      - req-194d42d0-bd7a-4a1d-8942-df6f1cdc6bcd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-42b73416-89d0-4ff1-b063-e0a15a06c748
+      - req-194d42d0-bd7a-4a1d-8942-df6f1cdc6bcd
       Date:
-      - Tue, 08 Jan 2019 19:16:25 GMT
+      - Mon, 04 Mar 2019 20:03:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -15953,22 +15161,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-365af281-86d5-4a55-b9da-4fd12b061c5d
+      - req-ad82095b-5e37-4fd7-ad30-9c397d79aeff
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-365af281-86d5-4a55-b9da-4fd12b061c5d
+      - req-ad82095b-5e37-4fd7-ad30-9c397d79aeff
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -15983,7 +15191,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -15998,22 +15206,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e2090ac4-4f1e-41cf-88bc-136315317ed0
+      - req-b22a6e1e-310a-43e8-8f46-c19d226332e7
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-e2090ac4-4f1e-41cf-88bc-136315317ed0
+      - req-b22a6e1e-310a-43e8-8f46-c19d226332e7
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -16028,7 +15236,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -16043,27 +15251,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffa22f39-9ab7-43b6-8575-b63c5b065b0a
+      - req-b4853f40-e57d-4108-aff9-1c9208770b4e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ffa22f39-9ab7-43b6-8575-b63c5b065b0a
+      - req-b4853f40-e57d-4108-aff9-1c9208770b4e
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -16078,27 +15286,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ea14368-4cfa-4dc8-a797-76a55415433e
+      - req-117bfd87-a936-430b-827f-0f41deac2fac
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3ea14368-4cfa-4dc8-a797-76a55415433e
+      - req-117bfd87-a936-430b-827f-0f41deac2fac
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -16113,27 +15321,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93071208-686e-431a-9dca-0a4c3bd477b4
+      - req-254975a1-a6a9-43a6-b6a3-8d0038700f63
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-93071208-686e-431a-9dca-0a4c3bd477b4
+      - req-254975a1-a6a9-43a6-b6a3-8d0038700f63
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16148,27 +15356,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf6b7d12-6ced-439a-aa42-4fff6e856de5
+      - req-9340af71-c731-440a-81c4-b668b6bc8ed6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bf6b7d12-6ced-439a-aa42-4fff6e856de5
+      - req-9340af71-c731-440a-81c4-b668b6bc8ed6
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16183,27 +15391,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-82fc4adb-ce26-48d4-a95f-b22981421484
+      - req-5c770361-fb7e-467e-85d3-182f5913760e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-82fc4adb-ce26-48d4-a95f-b22981421484
+      - req-5c770361-fb7e-467e-85d3-182f5913760e
       Date:
-      - Tue, 08 Jan 2019 19:16:26 GMT
+      - Mon, 04 Mar 2019 20:03:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16218,27 +15426,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-daf2450d-730d-4521-9eeb-ef5764a923a8
+      - req-f09698bd-9a10-43f8-bbb3-ffaaa1bcde68
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-daf2450d-730d-4521-9eeb-ef5764a923a8
+      - req-f09698bd-9a10-43f8-bbb3-ffaaa1bcde68
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16253,27 +15461,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aaec2ae8-f76f-4f29-b143-739f333c27c0
+      - req-4a325b9d-7b9c-482f-ae63-f32bcfeea660
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aaec2ae8-f76f-4f29-b143-739f333c27c0
+      - req-4a325b9d-7b9c-482f-ae63-f32bcfeea660
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16288,27 +15496,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-efd15db7-5281-4389-9c9f-abfee890a6c3
+      - req-21af1dd8-9dd7-4d5e-aa62-c9789e7ca73f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-efd15db7-5281-4389-9c9f-abfee890a6c3
+      - req-21af1dd8-9dd7-4d5e-aa62-c9789e7ca73f
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16323,27 +15531,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae9adcef-0463-4e9b-aa7b-c0565a034746
+      - req-b7a67105-6804-4288-9026-8ebe25dd6d67
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ae9adcef-0463-4e9b-aa7b-c0565a034746
+      - req-b7a67105-6804-4288-9026-8ebe25dd6d67
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16358,27 +15566,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc446216-6ff6-421d-8a72-710f86174adb
+      - req-4eed490a-d641-4fdd-9099-4a200d4864e9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fc446216-6ff6-421d-8a72-710f86174adb
+      - req-4eed490a-d641-4fdd-9099-4a200d4864e9
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16393,27 +15601,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-67898e12-c869-4cd7-9f1c-10b0ebcd1142
+      - req-674bb452-432c-4724-b5e2-57d1971b85d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-67898e12-c869-4cd7-9f1c-10b0ebcd1142
+      - req-674bb452-432c-4724-b5e2-57d1971b85d0
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16428,27 +15636,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a881d47-b058-4971-83a0-4c8d4f3b311c
+      - req-a105299a-37c8-453b-a1c0-43c2eacc03b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4a881d47-b058-4971-83a0-4c8d4f3b311c
+      - req-a105299a-37c8-453b-a1c0-43c2eacc03b5
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -16463,27 +15671,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8700ef7f-248e-4103-bf91-fec699b9f4bc
+      - req-dcd76a8a-d23a-4bb7-bb0a-faeca1451636
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8700ef7f-248e-4103-bf91-fec699b9f4bc
+      - req-dcd76a8a-d23a-4bb7-bb0a-faeca1451636
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -16498,27 +15706,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-18e456d0-1e0a-4410-bf74-a078440b3559
+      - req-740b5141-c8f7-48b9-903e-a1ba3b714ec0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-18e456d0-1e0a-4410-bf74-a078440b3559
+      - req-740b5141-c8f7-48b9-903e-a1ba3b714ec0
       Date:
-      - Tue, 08 Jan 2019 19:16:27 GMT
+      - Mon, 04 Mar 2019 20:03:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -16533,22 +15741,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28cec731-4357-4680-86bb-262c5c739354
+      - req-3850efac-22d1-4762-8c7e-068c058e0748
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-28cec731-4357-4680-86bb-262c5c739354
+      - req-3850efac-22d1-4762-8c7e-068c058e0748
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16560,7 +15768,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16575,22 +15783,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ecdbef471af4fe9a4e617ec2cc3378e
+      - 8f9e30f471ae41dfa3441c781a2d5c58
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42630830-bb8c-4222-ab71-e8ebc695fa9d
+      - req-0c4b4cfa-326c-484a-b747-3c8fba70286f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-42630830-bb8c-4222-ab71-e8ebc695fa9d
+      - req-0c4b4cfa-326c-484a-b747-3c8fba70286f
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16602,7 +15810,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -16617,22 +15825,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a79d991a-9ab8-4564-a510-1f3309a5d134
+      - req-df6d5e07-4c68-44bc-8461-707d5175ca22
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a79d991a-9ab8-4564-a510-1f3309a5d134
+      - req-df6d5e07-4c68-44bc-8461-707d5175ca22
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16644,7 +15852,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16659,22 +15867,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ed5d3e7e11a4a5991efd7a37f9f6336
+      - 1108e12f91c54439bd904c860f02f428
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99d6e125-ef3e-45fe-8cb6-915a039dcffa
+      - req-6e403984-7e4c-4edf-a479-eae73326dddc
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-99d6e125-ef3e-45fe-8cb6-915a039dcffa
+      - req-6e403984-7e4c-4edf-a479-eae73326dddc
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16686,7 +15894,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -16701,22 +15909,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4a974e8-6d21-48d3-bc7f-3557b007d6a8
+      - req-917baf8c-debc-422b-9ea4-2e7acd5d6c67
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a4a974e8-6d21-48d3-bc7f-3557b007d6a8
+      - req-917baf8c-debc-422b-9ea4-2e7acd5d6c67
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16728,7 +15936,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16743,22 +15951,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 56da36ac09ed41dfac3ff54ca6ef2384
+      - 302f68a8bde14b98878d8cb9c8ae632b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e9675763-3bf1-4d83-b73b-070aa92f7a80
+      - req-a66e24ae-09ce-4bc2-baec-b53d462bd36e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e9675763-3bf1-4d83-b73b-070aa92f7a80
+      - req-a66e24ae-09ce-4bc2-baec-b53d462bd36e
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16770,7 +15978,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -16785,22 +15993,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-52a31ad0-5b4e-492e-8236-627f41703aed
+      - req-a9b57689-0d34-4d10-88af-dbd7de4991b2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-52a31ad0-5b4e-492e-8236-627f41703aed
+      - req-a9b57689-0d34-4d10-88af-dbd7de4991b2
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16812,7 +16020,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16827,22 +16035,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 594c08ca20254fb5af4f86a294d0a084
+      - 73448ebec67346f2a760f41cde7fb418
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1c859f3b-f74f-4035-a5ee-5bed7c58eafa
+      - req-5f121340-0d00-49d1-8ace-18c78da2d6d2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1c859f3b-f74f-4035-a5ee-5bed7c58eafa
+      - req-5f121340-0d00-49d1-8ace-18c78da2d6d2
       Date:
-      - Tue, 08 Jan 2019 19:16:28 GMT
+      - Mon, 04 Mar 2019 20:03:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16854,7 +16062,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16872,13 +16080,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:29 GMT
+      - Mon, 04 Mar 2019 20:03:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bc2e6452-d127-4e28-b981-e6c9ee9e5568
+      - req-7d54ee10-a6d8-4965-8818-7434b17e67c8
       Content-Length:
       - '4170'
       Connection:
@@ -16887,10 +16095,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:29.083007", "expires":
-        "2019-01-08T20:16:29Z", "id": "097ed4bd451b4e84948d8b3d20a9362d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:15.265021", "expires":
+        "2019-03-04T21:03:15Z", "id": "607ccf29710b4b2d87b00deb61c2fb85", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["JQORQopBTMqaQbFrcCxY0w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vu5GEPOWR-eY9M69hZfzVg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16935,7 +16143,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16953,13 +16161,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:29 GMT
+      - Mon, 04 Mar 2019 20:03:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-753dc3f7-3669-4034-88f1-2c82e0a31cc4
+      - req-837242dc-c980-48cd-83da-8546d480bc8c
       Content-Length:
       - '4170'
       Connection:
@@ -16968,10 +16176,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:29.535435", "expires":
-        "2019-01-08T20:16:29Z", "id": "1b47f32130fc498e867453a7f685d623", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:15.683532", "expires":
+        "2019-03-04T21:03:15Z", "id": "d03684f838b248b59c94c444c35fc1b2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["zVXZJDzyQz6oEOeP9UE95g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["EJc-Jql9Q7ycW6crOu_DGw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -17016,7 +16224,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17034,13 +16242,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:29 GMT
+      - Mon, 04 Mar 2019 20:03:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-00191270-2f7c-4a35-b9dd-dc80082bff2e
+      - req-7a85ce20-3e10-41be-bfb9-edde1dfde867
       Content-Length:
       - '370'
       Connection:
@@ -17049,13 +16257,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:29.694244", "expires":
-        "2019-01-08T20:16:29Z", "id": "9491e3ef31ce4283956322d9502f707a", "audit_ids":
-        ["B2-u4STiTi2EbEa2jHqEdA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:16.748030", "expires":
+        "2019-03-04T21:03:16Z", "id": "38885207c77642b5b2ffd8f755450f88", "audit_ids":
+        ["YRm5p2JqTfyG-YhskGv3Dg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -17070,20 +16278,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9491e3ef31ce4283956322d9502f707a
+      - 38885207c77642b5b2ffd8f755450f88
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:29 GMT
+      - Mon, 04 Mar 2019 20:03:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c8929513-dddb-409d-bc3c-9de0963ba99f
+      - req-5d9ad779-299b-4eaa-85da-923767f448ab
       Content-Length:
       - '500'
       Connection:
@@ -17100,7 +16308,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17118,13 +16326,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:29 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-26e7501d-6d65-4d07-aec6-d7b7b10560ae
+      - req-fff64d90-51d5-407b-b0b0-69baea193308
       Content-Length:
       - '4117'
       Connection:
@@ -17133,10 +16341,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:30.026397", "expires":
-        "2019-01-08T20:16:30Z", "id": "f4848dd8f9c646aab404a458b6119cd3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:17.092702", "expires":
+        "2019-03-04T21:03:17Z", "id": "9e6045cf2988447086eeab4209aabdca", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ttpft-JNQ8S_ISOE1XLqfQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["yXN5DkaZQeOEyhKo_72odg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17180,7 +16388,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17198,13 +16406,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a7a3dee-9dc0-47b6-a1b8-b2e288cd53c4
+      - req-1a930161-55e3-4ad2-9576-eff63c097669
       Content-Length:
       - '4131'
       Connection:
@@ -17213,10 +16421,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:30.225879", "expires":
-        "2019-01-08T20:16:30Z", "id": "9cb0263fdd6048dea84a9b4835902952", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:17.292473", "expires":
+        "2019-03-04T21:03:17Z", "id": "2273dc96de494997bb0d6760a21b3c75", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4m8ov8S0TQ64d22Bs5WLHw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["TQr7SzZpQmOwSTeducvO3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17260,7 +16468,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17278,13 +16486,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3980a913-c7a3-4ca1-b365-cd92bbb495e7
+      - req-b71025ca-c0f4-4948-9032-51737bbfcfa1
       Content-Length:
       - '4118'
       Connection:
@@ -17293,10 +16501,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:30.437901", "expires":
-        "2019-01-08T20:16:30Z", "id": "bb85422aafe94267a17f3ffeaac6ab75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:17.499503", "expires":
+        "2019-03-04T21:03:17Z", "id": "9681d0f39b014c56ba9b3892762ec9bb", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["yuKBIR_BQFmJhnShYKsOSA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DB_UXuZPRu6ZyzUBFNza5A"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17340,7 +16548,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17355,7 +16563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4848dd8f9c646aab404a458b6119cd3
+      - 9e6045cf2988447086eeab4209aabdca
   response:
     status:
       code: 200
@@ -17384,15 +16592,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txbf58415b46d34f00844a5-005c34f70e
+      - txfd4982a9cd224914b455f-005c7d8485
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -17407,7 +16615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4848dd8f9c646aab404a458b6119cd3
+      - 9e6045cf2988447086eeab4209aabdca
   response:
     status:
       code: 200
@@ -17436,14 +16644,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx0efdd9dd71f84b2eb257f-005c34f70e
+      - txefc1a0873f494e79b125b-005c7d8485
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -17458,7 +16666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9cb0263fdd6048dea84a9b4835902952
+      - 2273dc96de494997bb0d6760a21b3c75
   response:
     status:
       code: 200
@@ -17471,22 +16679,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974990.84215'
+      - '1551729797.91683'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974990.84215'
+      - '1551729797.91683'
       X-Trans-Id:
-      - txc56f019672014d33ac73b-005c34f70e
+      - tx9f0bb74a71f745bdb4c9e-005c7d8485
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -17501,7 +16709,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b47f32130fc498e867453a7f685d623
+      - d03684f838b248b59c94c444c35fc1b2
   response:
     status:
       code: 200
@@ -17514,22 +16722,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974990.98523'
+      - '1551729798.07201'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974990.98523'
+      - '1551729798.07201'
       X-Trans-Id:
-      - txf2f4ca191df74613af7b8-005c34f70e
+      - txd4765446b2e643c988f83-005c7d8486
       Date:
-      - Tue, 08 Jan 2019 19:16:30 GMT
+      - Mon, 04 Mar 2019 20:03:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -17544,7 +16752,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb85422aafe94267a17f3ffeaac6ab75
+      - 9681d0f39b014c56ba9b3892762ec9bb
   response:
     status:
       code: 200
@@ -17557,22 +16765,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974991.13758'
+      - '1551729798.22434'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974991.13758'
+      - '1551729798.22434'
       X-Trans-Id:
-      - txe3686e0c19d646e88d543-005c34f70f
+      - tx08a016c1003c4fdb93a42-005c7d8486
       Date:
-      - Tue, 08 Jan 2019 19:16:31 GMT
+      - Mon, 04 Mar 2019 20:03:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -17587,7 +16795,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4848dd8f9c646aab404a458b6119cd3
+      - 9e6045cf2988447086eeab4209aabdca
   response:
     status:
       code: 200
@@ -17608,9 +16816,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2f943bd1c4554ea08214a-005c34f70f
+      - tx5ceac947ff504a6ab1168-005c7d8486
       Date:
-      - Tue, 08 Jan 2019 19:16:31 GMT
+      - Mon, 04 Mar 2019 20:03:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -17620,7 +16828,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -17635,7 +16843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4848dd8f9c646aab404a458b6119cd3
+      - 9e6045cf2988447086eeab4209aabdca
   response:
     status:
       code: 200
@@ -17656,14 +16864,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx1f554dde0cf24127825da-005c34f70f
+      - tx68bcbd3ad3384254a1c08-005c7d8486
       Date:
-      - Tue, 08 Jan 2019 19:16:31 GMT
+      - Mon, 04 Mar 2019 20:03:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -17678,7 +16886,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4848dd8f9c646aab404a458b6119cd3
+      - 9e6045cf2988447086eeab4209aabdca
   response:
     status:
       code: 200
@@ -17699,12 +16907,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txe59851b43b694d5488fd1-005c34f70f
+      - txd95b680a6e1647c3a367a-005c7d8486
       Date:
-      - Tue, 08 Jan 2019 19:16:31 GMT
+      - Mon, 04 Mar 2019 20:03:18 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:18 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:31 GMT
+      - Mon, 04 Mar 2019 20:03:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d1f82828-2ca2-4d3d-a20e-679c1bd47347
+      - req-460e513a-f399-443c-9a5b-68c89db2c936
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:31.407026", "expires":
-        "2019-01-08T20:18:31Z", "id": "5ee1cebbcc81488b9c68f736ac25e3d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:23.514654", "expires":
+        "2019-03-04T21:03:23Z", "id": "d210b99f393b4ffc94fa2a56790e4ced", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["iYPzZ0_cQJy99HlOsEv44Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["wRjwabCfR_uejVNREaWrvg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:31 GMT
+      - Mon, 04 Mar 2019 20:03:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,132 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-0b07b975-6649-4f4d-9fb9-b67c8aa9b1de
+      - req-3d5e81d4-3bda-45a6-9256-5bd99775d3b0
       Date:
-      - Tue, 08 Jan 2019 19:18:31 GMT
+      - Mon, 04 Mar 2019 20:03:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:31 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 08 Jan 2019 19:18:31 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-d3610aff-33f3-41f6-b19c-3eff9dfd5116
-      Content-Length:
-      - '4170'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:31.864482", "expires":
-        "2019-01-08T20:18:31Z", "id": "a7e2b8477af045c795863251e644c5c9", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["m58llzFsRVeAsgUrIRpFow"]}, "serviceCatalog":
-        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:31 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-e42aa2d0-6dd5-42c7-9485-4418ccf21e47
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '82'
-      X-Openstack-Request-Id:
-      - req-e42aa2d0-6dd5-42c7-9485-4418ccf21e47
-      Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
-        "nova"}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -283,7 +166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -296,26 +179,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-e95cda10-5cd9-4db8-b914-8097341e68bf
+      - req-9bb37f5d-0e06-401f-959d-e6dd7b7379b6
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:18:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:03:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:18:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:03:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:18:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:03:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:18:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:03:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:18:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:03:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -330,7 +213,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -343,26 +226,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-59d9a67d-662d-4af3-9053-c596d0e44b2f
+      - req-879c7afd-6486-47cb-95df-c428bd2a570b
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:18:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:03:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:18:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:03:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:18:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:03:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:18:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:03:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:18:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:03:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -377,7 +260,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -390,9 +273,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-7b7311b5-d07b-42b7-af43-16eb0a8f8525
+      - req-9d39ee31-a60a-4101-aad3-582e839e31b4
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -406,7 +289,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -421,7 +304,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -434,9 +317,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-a2d2f783-b2ac-47a7-9494-dab3fb244290
+      - req-4b6ea8e2-6c54-4406-8735-ba187a3cc856
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -450,7 +333,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -465,7 +348,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -478,9 +361,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-4cb16139-a217-447d-a881-86c461a54511
+      - req-decb18c7-4991-422a-ac27-d98690ba4342
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -495,7 +378,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -510,7 +393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -523,9 +406,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-7f110c18-b051-485e-a9df-80d8b83addda
+      - req-31f66ff5-1668-4284-b0db-9b18f5ab070f
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -535,7 +418,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -553,13 +436,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:32 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46bd761e-2e8f-414d-bab0-9e8a878ea4d6
+      - req-9165830f-94c5-4f98-8366-c44f1bfdc2be
       Content-Length:
       - '370'
       Connection:
@@ -568,13 +451,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:32.914568", "expires":
-        "2019-01-08T20:18:32Z", "id": "ba1820397d7545cd898a732bfad2ebe8", "audit_ids":
-        ["seygatM5R8qG5M3UqiXM8w"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:26.271618", "expires":
+        "2019-03-04T21:03:26Z", "id": "a4d18c62544a48c89188a3f754c5faf9", "audit_ids":
+        ["0Plx2NvFThW3ykr8xCwEZw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -589,20 +472,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ba1820397d7545cd898a732bfad2ebe8
+      - a4d18c62544a48c89188a3f754c5faf9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:33 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b558c415-241b-40f3-b105-8acf052e6192
+      - req-500d1fcd-295d-4bbf-a91c-066c5bc816f0
       Content-Length:
       - '500'
       Connection:
@@ -619,7 +502,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -634,7 +517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -647,15 +530,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-6d9af6f7-ccb9-4ae2-afc6-1b001a069bea
+      - req-91cdaea7-ce89-474d-bfd1-b19975338bfe
       Date:
-      - Tue, 08 Jan 2019 19:18:33 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -673,13 +556,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:33 GMT
+      - Mon, 04 Mar 2019 20:03:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c54784de-5a63-4209-9e60-ba60f84eacec
+      - req-24f8e56b-2c78-44da-8abb-c782038f60ae
       Content-Length:
       - '4170'
       Connection:
@@ -688,10 +571,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:33.349599", "expires":
-        "2019-01-08T20:18:33Z", "id": "96b428f0d10840af8e300b13bd637a75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:26.914533", "expires":
+        "2019-03-04T21:03:26Z", "id": "caa4af88a76a4c14b6c26ab37f37b9a2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["W5S81g8xRNm7TysqSmiu5g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bT1QKk6XR9qj_VJGfHiGVw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -736,7 +619,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -751,7 +634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96b428f0d10840af8e300b13bd637a75
+      - caa4af88a76a4c14b6c26ab37f37b9a2
   response:
     status:
       code: 200
@@ -762,9 +645,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-a85e0850-3c17-4725-b3c9-7ac4d560eea4
+      - req-b0a5e599-fd66-48cd-81e7-0c3bafb4c351
       Date:
-      - Tue, 08 Jan 2019 19:18:34 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -806,7 +689,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -821,7 +704,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96b428f0d10840af8e300b13bd637a75
+      - caa4af88a76a4c14b6c26ab37f37b9a2
   response:
     status:
       code: 200
@@ -832,14 +715,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2252ddd1-78d6-442c-bd04-b94abec28f96
+      - req-6de2be79-b546-4ebe-bf4e-56c930c8be73
       Date:
-      - Tue, 08 Jan 2019 19:18:34 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -854,7 +737,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -867,9 +750,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-bbaec2ec-b386-4dda-ae39-64bbf1af822b
+      - req-c1564e39-16d3-4050-b402-1b20a0317a2c
       Date:
-      - Tue, 08 Jan 2019 19:18:34 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -879,7 +762,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -894,7 +777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -907,9 +790,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-03e3e910-59d7-44ca-93d0-a7966ecac61c
+      - req-963e9c7b-ac92-42c1-8a8c-579856fd2ef7
       Date:
-      - Tue, 08 Jan 2019 19:18:34 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -919,7 +802,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -937,13 +820,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:35 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8ef1aeb0-2d59-4d44-b2b5-6f479ca62de8
+      - req-d6bc3365-1455-4ca4-89d3-ae6681901575
       Content-Length:
       - '4170'
       Connection:
@@ -952,10 +835,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:35.129546", "expires":
-        "2019-01-08T20:18:35Z", "id": "ef928670b31443b89e6f1d9f4e7c4ea6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:27.635166", "expires":
+        "2019-03-04T21:03:27Z", "id": "c38aacc35f504662befe344d329ca27b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["N132BxhWScaw5HFE3QwTAg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["adgDat2sQJmYjNGHO-Qazg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1000,7 +883,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1018,13 +901,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:35 GMT
+      - Mon, 04 Mar 2019 20:03:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5694b3bb-569b-4cdc-953a-4a5a1abf184a
+      - req-77576a3f-37ca-4e6a-8dbf-06b23180a8ca
       Content-Length:
       - '4117'
       Connection:
@@ -1033,10 +916,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:35.505088", "expires":
-        "2019-01-08T20:18:35Z", "id": "bd34ccaa7fc34f8d9f65387c646212e5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:27.924552", "expires":
+        "2019-03-04T21:03:27Z", "id": "47dceb235c384acba12da40b93ba723c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["OJGo_kJmTMGHKyXtg4WN3Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["wAANGeaHRKSvHxBtwSIeFA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1080,7 +963,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1098,13 +981,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:35 GMT
+      - Mon, 04 Mar 2019 20:03:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fc80dd1c-e862-4b7a-afc7-8985be431305
+      - req-a715c348-ca12-4c29-bd02-17466eb08296
       Content-Length:
       - '4131'
       Connection:
@@ -1113,10 +996,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:35.697778", "expires":
-        "2019-01-08T20:18:35Z", "id": "324b56897a8340cf99413f42d46c22b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:28.186051", "expires":
+        "2019-03-04T21:03:28Z", "id": "e3eb232ec04a457baaaaa748d33e9d05", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8K8aFYDkSS2T6kOuitVn9g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["jxY8qOpkRkWmdLt5h_ZiCA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1160,7 +1043,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1178,13 +1061,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:35 GMT
+      - Mon, 04 Mar 2019 20:03:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e721fd6c-73ee-4b3a-8aa6-ced7fb94322e
+      - req-6ac4529f-a5db-493f-835f-ed6b38e5ca66
       Content-Length:
       - '4118'
       Connection:
@@ -1193,10 +1076,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:35.885773", "expires":
-        "2019-01-08T20:18:35Z", "id": "acf8cc5a2bbb4e25becc4bc5167be5ae", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:28.406776", "expires":
+        "2019-03-04T21:03:28Z", "id": "55cd3e1615794cbba4a266077d89dd2c", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hcyOYxP6QD6-l2AiA8rnCQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["lT8cehRGQH6VHblHPH2f9Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1240,7 +1123,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -1255,7 +1138,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1266,9 +1149,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-b1a96264-1606-4ea0-b355-6e9181055838
+      - req-c8b382b3-6b88-451d-974f-7c9c2aed3a64
       Date:
-      - Tue, 08 Jan 2019 19:18:36 GMT
+      - Mon, 04 Mar 2019 20:03:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -1302,7 +1185,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -1317,7 +1200,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1328,14 +1211,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c685b646-7f17-4566-93e0-03f7e59d5a89
+      - req-8de3de6c-1c9b-4386-81c1-6a979b81e169
       Date:
-      - Tue, 08 Jan 2019 19:18:36 GMT
+      - Mon, 04 Mar 2019 20:03:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -1350,7 +1233,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 324b56897a8340cf99413f42d46c22b5
+      - e3eb232ec04a457baaaaa748d33e9d05
   response:
     status:
       code: 200
@@ -1361,14 +1244,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-148bd34b-c8c5-490a-a3d7-7dd48f767f4d
+      - req-08c31894-a592-4503-97c8-5d468c2aad96
       Date:
-      - Tue, 08 Jan 2019 19:18:36 GMT
+      - Mon, 04 Mar 2019 20:03:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -1383,7 +1266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ef928670b31443b89e6f1d9f4e7c4ea6
+      - c38aacc35f504662befe344d329ca27b
   response:
     status:
       code: 200
@@ -1394,14 +1277,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4267cab1-f71f-48f2-b140-8d42e15d6316
+      - req-712aa860-b7ea-4b3b-924d-63573a074aec
       Date:
-      - Tue, 08 Jan 2019 19:18:36 GMT
+      - Mon, 04 Mar 2019 20:03:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -1416,7 +1299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - acf8cc5a2bbb4e25becc4bc5167be5ae
+      - 55cd3e1615794cbba4a266077d89dd2c
   response:
     status:
       code: 200
@@ -1427,14 +1310,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9318ed2d-e7ea-47e4-82f9-46fb02ce26d7
+      - req-c2950709-ab45-4208-ba9e-d79904da9905
       Date:
-      - Tue, 08 Jan 2019 19:18:36 GMT
+      - Mon, 04 Mar 2019 20:03:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -1449,7 +1332,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1460,9 +1343,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b8111f50-c474-45db-8045-c886888f79fc
+      - req-d47314ff-c5cd-475d-acfc-d5be4d9fc9a3
       Date:
-      - Tue, 08 Jan 2019 19:18:37 GMT
+      - Mon, 04 Mar 2019 20:03:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1489,7 +1372,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -1504,7 +1387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1515,9 +1398,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-eb4e3c3c-ef6c-437c-8503-2e43a04f7e14
+      - req-c05b5348-44ee-4134-bf82-416af49cf1ab
       Date:
-      - Tue, 08 Jan 2019 19:18:37 GMT
+      - Mon, 04 Mar 2019 20:03:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1544,7 +1427,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -1559,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1570,9 +1453,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3f45e892-c59b-488e-be65-c1a9a2d23255
+      - req-3f995870-7e8e-4eca-a89d-62a79dd70d40
       Date:
-      - Tue, 08 Jan 2019 19:18:37 GMT
+      - Mon, 04 Mar 2019 20:03:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -1599,7 +1482,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -1614,7 +1497,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1625,9 +1508,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-c97f5bfc-488e-48c8-83a1-495df12490e3
+      - req-6ff50716-8999-428c-961f-5ca30f7f84a3
       Date:
-      - Tue, 08 Jan 2019 19:18:37 GMT
+      - Mon, 04 Mar 2019 20:03:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -1683,7 +1566,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -1698,7 +1581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -1709,9 +1592,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-04b38725-e76a-4b69-8c1c-57769ac56505
+      - req-afe9d09b-70e3-4e6d-825c-7a730f92ac04
       Date:
-      - Tue, 08 Jan 2019 19:18:38 GMT
+      - Mon, 04 Mar 2019 20:03:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -1723,7 +1606,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -1738,7 +1621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1751,9 +1634,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-6f0dfa2e-2fce-4cde-955b-d5f6601f71b1
+      - req-e137888c-09c6-4936-a88b-a7a3a3219784
       Date:
-      - Tue, 08 Jan 2019 19:18:41 GMT
+      - Mon, 04 Mar 2019 20:03:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -1799,7 +1682,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -1814,7 +1697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1827,9 +1710,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-3451a6bb-50da-45b3-a736-1d1cff6269ae
+      - req-75895618-7999-4cde-9bf7-2cd0cc64a617
       Date:
-      - Tue, 08 Jan 2019 19:18:41 GMT
+      - Mon, 04 Mar 2019 20:03:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -1875,7 +1758,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -1890,7 +1773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1903,9 +1786,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-1d8aef47-a722-4d08-9172-3d703ab755e1
+      - req-0aee6eb0-35bc-4690-a5b7-cb35bf18e5be
       Date:
-      - Tue, 08 Jan 2019 19:18:42 GMT
+      - Mon, 04 Mar 2019 20:03:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -1953,7 +1836,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -1968,7 +1851,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1981,9 +1864,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-754492fe-4495-4cdf-a6a7-2d5f70f17bdc
+      - req-d87e6969-8a9f-4f06-b3ed-bbf6e09eb5f6
       Date:
-      - Tue, 08 Jan 2019 19:18:42 GMT
+      - Mon, 04 Mar 2019 20:03:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -2025,7 +1908,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -2040,7 +1923,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2053,9 +1936,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-2cfac446-6d91-4d86-9821-cac566c798f1
+      - req-8b9bed36-2077-4096-b488-8dbbb75e8363
       Date:
-      - Tue, 08 Jan 2019 19:18:42 GMT
+      - Mon, 04 Mar 2019 20:03:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -2078,7 +1961,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -2093,7 +1976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -2104,9 +1987,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ec719af3-4124-4a05-9d6c-2274f6f127e0
+      - req-b29f267b-c268-4112-a9ec-8af1bfd50f93
       Date:
-      - Tue, 08 Jan 2019 19:18:42 GMT
+      - Mon, 04 Mar 2019 20:03:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2162,7 +2045,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -2177,7 +2060,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -2188,9 +2071,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-655bee0d-b7ff-4f96-b82c-3dc7297b8be8
+      - req-868b4125-cc70-4845-a573-c604f1030910
       Date:
-      - Tue, 08 Jan 2019 19:18:42 GMT
+      - Mon, 04 Mar 2019 20:03:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2202,7 +2085,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -2217,7 +2100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -2228,9 +2111,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4025ce6d-7a29-4a8e-86b4-1cadc111224c
+      - req-9fd7434b-258e-41b2-85eb-68a7baf5bbdb
       Date:
-      - Tue, 08 Jan 2019 19:18:43 GMT
+      - Mon, 04 Mar 2019 20:03:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2286,7 +2169,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -2301,7 +2184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd34ccaa7fc34f8d9f65387c646212e5
+      - 47dceb235c384acba12da40b93ba723c
   response:
     status:
       code: 200
@@ -2312,9 +2195,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b53173a2-dbe1-4e07-af7f-57a0321567e4
+      - req-a058f778-72f4-4c06-babc-ffeabf1824a4
       Date:
-      - Tue, 08 Jan 2019 19:18:46 GMT
+      - Mon, 04 Mar 2019 20:03:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2326,7 +2209,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2344,13 +2227,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:46 GMT
+      - Mon, 04 Mar 2019 20:03:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-812e5974-e437-40b1-99c5-9c142f1ea7dc
+      - req-391ad74b-0675-416d-8efa-e3b61fe8f567
       Content-Length:
       - '4117'
       Connection:
@@ -2359,10 +2242,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:46.414108", "expires":
-        "2019-01-08T20:18:46Z", "id": "6e9909a61e9d4f73ba525c4b6d28dfc5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:33.960244", "expires":
+        "2019-03-04T21:03:33Z", "id": "e71dba52bf8d48309a5a771c7c2d2698", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["RsVu1OBkRsG19Y-DyfX8wA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["93yoPyxsT9eLHq3II2CAFg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2406,7 +2289,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2421,7 +2304,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e9909a61e9d4f73ba525c4b6d28dfc5
+      - e71dba52bf8d48309a5a771c7c2d2698
   response:
     status:
       code: 200
@@ -2432,7 +2315,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:46 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2441,7 +2324,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2459,13 +2342,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:46 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4aaadf93-6a8e-4acc-a0e2-cbc3827ce9b7
+      - req-9e6811e6-3639-46d1-935c-c416fe6a0967
       Content-Length:
       - '4131'
       Connection:
@@ -2474,10 +2357,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:46.687603", "expires":
-        "2019-01-08T20:18:46Z", "id": "25b41a1bd60b4bc7a83515d0349a6886", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:34.310678", "expires":
+        "2019-03-04T21:03:34Z", "id": "c2945759f75c40bfaf950342067b8f6c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["LZAfUuk-TMeeZmMvXGmtCw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["qHKc7MZyQEuptYmf2Cw0HQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2521,7 +2404,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2536,7 +2419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25b41a1bd60b4bc7a83515d0349a6886
+      - c2945759f75c40bfaf950342067b8f6c
   response:
     status:
       code: 200
@@ -2547,7 +2430,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:47 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2556,7 +2439,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2574,13 +2457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:47 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b65bedfc-28fc-449a-a1fe-3b81ed704b18
+      - req-742d7b7c-544b-4090-b3f8-670a6e491d07
       Content-Length:
       - '4118'
       Connection:
@@ -2589,10 +2472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:47.974845", "expires":
-        "2019-01-08T20:18:47Z", "id": "b7d386d925dd467d94593d651928d8b6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:34.601590", "expires":
+        "2019-03-04T21:03:34Z", "id": "0151e0b9cd3d45908306a8ceeeaa94f6", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["VBHc76vYQD-I-gujxUR1Gw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["XkQ-GQ8ATrG_El3acbXbHA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2636,7 +2519,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -2651,7 +2534,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7d386d925dd467d94593d651928d8b6
+      - 0151e0b9cd3d45908306a8ceeeaa94f6
   response:
     status:
       code: 200
@@ -2662,7 +2545,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:48 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2671,7 +2554,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -2686,7 +2569,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e9909a61e9d4f73ba525c4b6d28dfc5
+      - e71dba52bf8d48309a5a771c7c2d2698
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2699,9 +2582,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7190b87c-19ca-4b3d-93e8-01d97d8d1682
+      - req-fc415b8b-45d6-4f15-9c31-71207288e5ff
       Date:
-      - Tue, 08 Jan 2019 19:18:48 GMT
+      - Mon, 04 Mar 2019 20:03:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2710,7 +2593,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -2725,7 +2608,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25b41a1bd60b4bc7a83515d0349a6886
+      - c2945759f75c40bfaf950342067b8f6c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2738,9 +2621,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8a151f66-cbb0-4a7e-90ca-aa46c33bd38f
+      - req-f05ab61d-a588-4ed1-ae4a-895b7a256019
       Date:
-      - Tue, 08 Jan 2019 19:18:48 GMT
+      - Mon, 04 Mar 2019 20:03:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2749,7 +2632,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2764,7 +2647,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2777,9 +2660,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-86171253-d6af-476a-bed5-6600cb5987ea
+      - req-4cc929b7-21e3-4a96-836c-92085adc4118
       Date:
-      - Tue, 08 Jan 2019 19:18:48 GMT
+      - Mon, 04 Mar 2019 20:03:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2788,7 +2671,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -2803,7 +2686,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b7d386d925dd467d94593d651928d8b6
+      - 0151e0b9cd3d45908306a8ceeeaa94f6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2816,9 +2699,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-4b538db0-ac00-47d2-88fa-f0722e6d9f33
+      - req-05397ec8-8f5b-4c31-97ce-a8f1141f3754
       Date:
-      - Tue, 08 Jan 2019 19:18:49 GMT
+      - Mon, 04 Mar 2019 20:03:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2827,7 +2710,88 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Mar 2019 20:03:35 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-24c22484-6213-40f0-94d2-30bcabc0604f
+      Content-Length:
+      - '4170'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:35.497877", "expires":
+        "2019-03-04T21:03:35Z", "id": "b52e7f4e8087497dbde40445645733e3", "tenant":
+        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
+        "name": "admin"}, "audit_ids": ["Wg_46Y4yThCBjQHx0vyIdw"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
+        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
+        "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2845,13 +2809,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:49 GMT
+      - Mon, 04 Mar 2019 20:03:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52687d01-0d71-4d55-b0d8-939123addecf
+      - req-a2e93816-0e11-4be4-bc43-5b2e8b80184f
       Content-Length:
       - '4117'
       Connection:
@@ -2860,10 +2824,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:49.216207", "expires":
-        "2019-01-08T20:18:49Z", "id": "5586db4a81454ab98b4a4fcf64a73053", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:35.699621", "expires":
+        "2019-03-04T21:03:35Z", "id": "da251d1e2b934e46b320f6093df1b7d4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tjzxoxkHSdmvjm6k43Y_CA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["rBrKE9e2QTOUuMBvxFSKaQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2907,7 +2871,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2925,13 +2889,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:49 GMT
+      - Mon, 04 Mar 2019 20:03:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-95270df1-d56d-4986-8bac-8afee93986e7
+      - req-be89a121-aa8e-4f4b-8c44-e42911574bab
       Content-Length:
       - '4131'
       Connection:
@@ -2940,10 +2904,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:49.405317", "expires":
-        "2019-01-08T20:18:49Z", "id": "cf36ffa72320409399ddb0ddc4f7c1ba", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:35.893329", "expires":
+        "2019-03-04T21:03:35Z", "id": "6990f2aa3367447ea73752ded86fff55", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["kOL0tg_-RrCmN0NlOlUo1g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-XBIWlCrRsGpzPAwP3qWqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2987,7 +2951,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3005,13 +2969,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:49 GMT
+      - Mon, 04 Mar 2019 20:03:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2fa6d224-15a7-4be1-8578-69386c8138ea
+      - req-9daa1b67-7871-44d9-8f52-763cd5d1182c
       Content-Length:
       - '4118'
       Connection:
@@ -3020,10 +2984,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:49.592654", "expires":
-        "2019-01-08T20:18:49Z", "id": "c26ab116af5943bd8077a2c2f18c6ed3", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:36.087070", "expires":
+        "2019-03-04T21:03:36Z", "id": "a8088239a88943b1a74beaa72a88feab", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FBAQplEnTEO2KnZT2dRxIA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_qyANZkxS-i1NTXzSN5c_Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3067,7 +3031,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3082,22 +3046,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5586db4a81454ab98b4a4fcf64a73053
+      - da251d1e2b934e46b320f6093df1b7d4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19918350-607c-4b9e-99fa-7f517c42bfe6
+      - req-d1ec3b05-fabd-41a8-b35c-ea4a3eca977a
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-19918350-607c-4b9e-99fa-7f517c42bfe6
+      - req-d1ec3b05-fabd-41a8-b35c-ea4a3eca977a
       Date:
-      - Tue, 08 Jan 2019 19:18:49 GMT
+      - Mon, 04 Mar 2019 20:03:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3107,7 +3071,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3122,22 +3086,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cf36ffa72320409399ddb0ddc4f7c1ba
+      - 6990f2aa3367447ea73752ded86fff55
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eff1d666-cc70-446d-b91c-b2b3b9ba4f80
+      - req-30df55a5-d79b-421f-8800-b951b4ab4ebf
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-eff1d666-cc70-446d-b91c-b2b3b9ba4f80
+      - req-30df55a5-d79b-421f-8800-b951b4ab4ebf
       Date:
-      - Tue, 08 Jan 2019 19:18:50 GMT
+      - Mon, 04 Mar 2019 20:03:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3147,7 +3111,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3162,22 +3126,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d28c8f27-4bff-4837-b244-a7e924668a8d
+      - req-42762a39-2970-4271-ab52-821a65283173
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d28c8f27-4bff-4837-b244-a7e924668a8d
+      - req-42762a39-2970-4271-ab52-821a65283173
       Date:
-      - Tue, 08 Jan 2019 19:18:50 GMT
+      - Mon, 04 Mar 2019 20:03:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3187,7 +3151,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3202,22 +3166,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c26ab116af5943bd8077a2c2f18c6ed3
+      - a8088239a88943b1a74beaa72a88feab
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21996659-d1db-4c81-a191-6bd70b48c1bb
+      - req-8bdd71b7-87e1-4dce-ae7b-0d2305d70489
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-21996659-d1db-4c81-a191-6bd70b48c1bb
+      - req-8bdd71b7-87e1-4dce-ae7b-0d2305d70489
       Date:
-      - Tue, 08 Jan 2019 19:18:50 GMT
+      - Mon, 04 Mar 2019 20:03:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3227,7 +3191,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3245,13 +3209,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:51 GMT
+      - Mon, 04 Mar 2019 20:03:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5fd1a686-8a37-4657-b47f-d0281bbb318a
+      - req-33bc25b0-9321-43b2-a502-75ceae3e39f6
       Content-Length:
       - '4170'
       Connection:
@@ -3260,10 +3224,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:51.097253", "expires":
-        "2019-01-08T20:18:51Z", "id": "3e4e3b35c6604343aa5503d57d0c1ec7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:37.594607", "expires":
+        "2019-03-04T21:03:37Z", "id": "ed710144aea5448bbb00dc06b7e56b7f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["8xB9ZK5bR0GAWsJxslWgRg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["9m3g1TEITPizpIjk7EZoMQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3308,7 +3272,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3326,13 +3290,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:51 GMT
+      - Mon, 04 Mar 2019 20:03:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c51eebe6-f713-463e-9247-9557d6d94795
+      - req-2b42d4a5-96e3-4b99-ab26-785ea29afdbd
       Content-Length:
       - '4117'
       Connection:
@@ -3341,10 +3305,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:51.297330", "expires":
-        "2019-01-08T20:18:51Z", "id": "8bf016c2d8ec4b1691ca2821b76088da", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:37.794204", "expires":
+        "2019-03-04T21:03:37Z", "id": "4031d68c4f10454d9e7b805692c8f3c0", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["x2B5dmfFQPKKf8-IYiXP5w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["p0FmRKPsSyGBovDK90_KvA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -3388,7 +3352,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3406,13 +3370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:51 GMT
+      - Mon, 04 Mar 2019 20:03:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a176a525-d226-4f45-b700-14df9b6a25d9
+      - req-bbb1a525-fb8c-4768-bfcf-9c6c346d0488
       Content-Length:
       - '4131'
       Connection:
@@ -3421,10 +3385,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:51.530440", "expires":
-        "2019-01-08T20:18:51Z", "id": "340f089a051e48c0bd80debb4f7c63be", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:37.995083", "expires":
+        "2019-03-04T21:03:37Z", "id": "16f2c5e9f8b2466dad3fdf345edc8817", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["gXsFOOdtT62kj3gIMxuwig"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["MHs6i9uwQceoy_a21b1Jlg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -3468,7 +3432,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3486,13 +3450,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:51 GMT
+      - Mon, 04 Mar 2019 20:03:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-973b1e09-2d82-417d-9d1a-c096e00e12f5
+      - req-3c6cea3e-e8dc-4774-9173-20cdbf73bc8b
       Content-Length:
       - '4118'
       Connection:
@@ -3501,10 +3465,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:51.720506", "expires":
-        "2019-01-08T20:18:51Z", "id": "477d6a6a03494bc09e17b028339307c1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:38.198398", "expires":
+        "2019-03-04T21:03:38Z", "id": "2a6fb3017a864ef9b0e29f7cc5c47799", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["myv10ks7Tjqz7Duu_-xQOA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["nylCjhvGR9u6yllHQUtK-w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -3548,7 +3512,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -3563,7 +3527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bf016c2d8ec4b1691ca2821b76088da
+      - 4031d68c4f10454d9e7b805692c8f3c0
   response:
     status:
       code: 200
@@ -3574,16 +3538,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-0f98a004-23d0-4dfa-bd0f-72e686b28ad9
+      - req-58984891-8231-4d59-97dd-302fded0d520
       Date:
-      - Tue, 08 Jan 2019 19:18:51 GMT
+      - Mon, 04 Mar 2019 20:03:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -3598,7 +3562,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 340f089a051e48c0bd80debb4f7c63be
+      - 16f2c5e9f8b2466dad3fdf345edc8817
   response:
     status:
       code: 200
@@ -3609,16 +3573,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a0817f31-9b0a-4e9a-a0c0-b4514a930479
+      - req-e874b551-c1dc-48cf-9f5c-6114d29829ce
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3633,7 +3597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e4e3b35c6604343aa5503d57d0c1ec7
+      - ed710144aea5448bbb00dc06b7e56b7f
   response:
     status:
       code: 200
@@ -3644,16 +3608,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4e326876-b272-47cc-9b1b-4b2d2407cd73
+      - req-2794ffa0-ace2-4249-8256-4fbb8eee4196
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -3668,7 +3632,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 477d6a6a03494bc09e17b028339307c1
+      - 2a6fb3017a864ef9b0e29f7cc5c47799
   response:
     status:
       code: 200
@@ -3679,16 +3643,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ff117afb-7d44-4cde-865a-eb18a6ac8d98
+      - req-58cc5d92-40b2-4fc5-9ae1-d88908aa3a98
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -3703,7 +3667,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3716,15 +3680,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-60168caf-a9e1-46ca-992a-15994ac58994
+      - req-9d006380-2686-4c2c-b1a2-69d69f84d27a
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -3739,7 +3703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3752,15 +3716,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-bd411a30-6fda-4953-9a0c-b6a244f13171
+      - req-6d240ef6-037b-4eaa-afe3-843b6abbf60e
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3778,13 +3742,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7a279898-afd7-46ff-8b78-e2d760f62847
+      - req-e1878420-87d1-48d9-937d-465d9aeecac4
       Content-Length:
       - '4170'
       Connection:
@@ -3793,10 +3757,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:52.779293", "expires":
-        "2019-01-08T20:18:52Z", "id": "1681a7c13c36438eb5374e0ed79cf7c0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:39.549771", "expires":
+        "2019-03-04T21:03:39Z", "id": "70ff4165230e4a6e89c1bee2b09fea67", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NuumKCVmR46fE1XI4vpWuA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MdTTQjWmRJeFNCLnt-BtfA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3841,7 +3805,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3859,13 +3823,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:52 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e545814f-5957-4ef0-a913-7c6d413bc5b6
+      - req-2f0c6489-8a79-41bb-bb3f-c416cefd65ea
       Content-Length:
       - '4170'
       Connection:
@@ -3874,10 +3838,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:52.972340", "expires":
-        "2019-01-08T20:18:52Z", "id": "5f8e9eae5e184159ba59ba8474404b51", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:39.756910", "expires":
+        "2019-03-04T21:03:39Z", "id": "f95aa68e89384fcdb0766a3b1d5ea294", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["6SRxcJrOTlC_kCakG4eZJQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["WzuKZqJpQS-GV7tC6gjCHQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3922,7 +3886,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -3937,7 +3901,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ee1cebbcc81488b9c68f736ac25e3d5
+      - d210b99f393b4ffc94fa2a56790e4ced
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3950,14 +3914,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-7830987d-1364-46ac-9ac0-acfffb0c1cf5
+      - req-4d40c79c-5bc4-4c1b-989a-e248e29bd89e
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -3972,22 +3936,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af062f41-7b9a-4b49-b43f-de68ba85213e
+      - req-c2cc6332-a861-4f4b-bad3-f35df3c1a274
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-af062f41-7b9a-4b49-b43f-de68ba85213e
+      - req-c2cc6332-a861-4f4b-bad3-f35df3c1a274
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4020,7 +3984,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -4035,22 +3999,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96652612-b83f-4b96-9751-12248dc1ceb1
+      - req-67503b06-e3c2-455c-bdbe-1e1188b9174c
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-96652612-b83f-4b96-9751-12248dc1ceb1
+      - req-67503b06-e3c2-455c-bdbe-1e1188b9174c
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -4067,7 +4031,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -4082,27 +4046,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-22a9dc1c-f098-4729-b3ca-16f76eee82b4
+      - req-37cf9210-65ca-4904-9ff0-91b7b3e9a8b3
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-22a9dc1c-f098-4729-b3ca-16f76eee82b4
+      - req-37cf9210-65ca-4904-9ff0-91b7b3e9a8b3
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -4117,22 +4081,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be146012-f363-4324-9eb8-9659d4b212d7
+      - req-808192d1-ce24-4d55-9102-dbe9b7f6889c
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-be146012-f363-4324-9eb8-9659d4b212d7
+      - req-808192d1-ce24-4d55-9102-dbe9b7f6889c
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -4147,7 +4111,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000
@@ -4162,22 +4126,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4162d5da-f1bf-4b5f-abf9-228b014b50dd
+      - req-2b2daedb-f134-470d-a352-f87a48bdd4bc
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-4162d5da-f1bf-4b5f-abf9-228b014b50dd
+      - req-2b2daedb-f134-470d-a352-f87a48bdd4bc
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -4210,7 +4174,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -4225,22 +4189,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7f981ca-f788-4f3d-b442-263236191338
+      - req-ba05a07f-3d80-4e20-988a-25f151df9c78
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-d7f981ca-f788-4f3d-b442-263236191338
+      - req-ba05a07f-3d80-4e20-988a-25f151df9c78
       Date:
-      - Tue, 08 Jan 2019 19:18:53 GMT
+      - Mon, 04 Mar 2019 20:03:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -4281,7 +4245,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -4296,22 +4260,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-77881acd-4c12-425e-92c5-340658578c97
+      - req-25b1ea3d-f921-45db-92b3-4b3463d65ea0
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-77881acd-4c12-425e-92c5-340658578c97
+      - req-25b1ea3d-f921-45db-92b3-4b3463d65ea0
       Date:
-      - Tue, 08 Jan 2019 19:18:54 GMT
+      - Mon, 04 Mar 2019 20:03:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -4345,7 +4309,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?all_tenants=True&limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -4360,27 +4324,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a7e2b8477af045c795863251e644c5c9
+      - b52e7f4e8087497dbde40445645733e3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0708d43-d5cf-4bb9-8891-23843a2d07d4
+      - req-3003bb30-64b9-44e2-90b5-4587641e2f85
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c0708d43-d5cf-4bb9-8891-23843a2d07d4
+      - req-3003bb30-64b9-44e2-90b5-4587641e2f85
       Date:
-      - Tue, 08 Jan 2019 19:18:54 GMT
+      - Mon, 04 Mar 2019 20:03:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4398,13 +4362,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:55 GMT
+      - Mon, 04 Mar 2019 20:03:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-57232fd5-eada-43f5-ba0f-1599dfa60129
+      - req-0c2bccf2-4d38-4d7b-88cf-96e573212f6d
       Content-Length:
       - '4170'
       Connection:
@@ -4413,10 +4377,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:55.400828", "expires":
-        "2019-01-08T20:18:55Z", "id": "a1504049a2bf412191ef766343b36a92", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:42.827544", "expires":
+        "2019-03-04T21:03:42Z", "id": "4a286fd0dcbd42d3913b6fa7c2a9a398", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9N_OsssHQYK-ldgdVPrdQA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["xb0CMZkwQua2IAMXKpRn3g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4461,7 +4425,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4479,13 +4443,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:55 GMT
+      - Mon, 04 Mar 2019 20:03:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-907a938b-8db6-4143-ba07-d2f0ba0192bf
+      - req-7a58378c-88b5-44a8-95b4-62d32b970254
       Content-Length:
       - '4170'
       Connection:
@@ -4494,10 +4458,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:55.588490", "expires":
-        "2019-01-08T20:18:55Z", "id": "964dcdc5fb6543699ec72acc8a183d30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:43.044516", "expires":
+        "2019-03-04T21:03:43Z", "id": "a087dad51a1d481bab48813c8f8a3a64", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["48_G5r-vQQi-8Jev7ly8_Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DsEMv3FJTvappvl_7DOC-Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4542,7 +4506,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4557,7 +4521,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -4568,27 +4532,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-4c8bbe77-773c-45c9-857c-603fc7ab874c
+      - req-ec8b237f-9c57-49de-b7ee-f41116b0f54b
       Date:
-      - Tue, 08 Jan 2019 19:18:55 GMT
+      - Mon, 04 Mar 2019 20:03:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -4640,7 +4604,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4658,13 +4622,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:55 GMT
+      - Mon, 04 Mar 2019 20:03:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c958ca51-6d93-40d4-a1e3-31e5845af8ec
+      - req-7058a451-0af6-4592-81e3-6f7effb07874
       Content-Length:
       - '4170'
       Connection:
@@ -4673,10 +4637,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:55.964382", "expires":
-        "2019-01-08T20:18:55Z", "id": "41d1492f2dd64ee7bbf124404842dbd9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:43.417301", "expires":
+        "2019-03-04T21:03:43Z", "id": "8eb82abd79b84a27b1ad3ca237b38ca2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Kv1ziNyOQvGgkeM_38oQmA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["HieFR2EpQleWqkJIYj65PA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4721,7 +4685,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4739,13 +4703,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:56 GMT
+      - Mon, 04 Mar 2019 20:03:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-92c26f26-98bb-4f24-916d-7d2cee00eeff
+      - req-ac6e9c2b-5771-4c67-a100-51e91d85163b
       Content-Length:
       - '370'
       Connection:
@@ -4754,13 +4718,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:56.122795", "expires":
-        "2019-01-08T20:18:56Z", "id": "3e1c5212e7ec4e2b9f90298bef90952b", "audit_ids":
-        ["DSpCbqykTKmkD-E6lu6VEA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:43.577799", "expires":
+        "2019-03-04T21:03:43Z", "id": "7539b4f572264cc68dd21a31e6cc9901", "audit_ids":
+        ["k8WNoGlmQS2MEDiDRUkNFA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -4775,20 +4739,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3e1c5212e7ec4e2b9f90298bef90952b
+      - 7539b4f572264cc68dd21a31e6cc9901
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:56 GMT
+      - Mon, 04 Mar 2019 20:03:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d85c6b1b-e420-4ea9-899d-be43d265b0f8
+      - req-5c595572-907d-4e02-b694-989331c51255
       Content-Length:
       - '500'
       Connection:
@@ -4805,7 +4769,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4823,13 +4787,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:56 GMT
+      - Mon, 04 Mar 2019 20:03:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-736524c7-d97c-4398-92e6-e9168fe006cd
+      - req-f968cac2-1e38-438c-8f39-a35bc9da25fe
       Content-Length:
       - '4117'
       Connection:
@@ -4838,10 +4802,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:56.453352", "expires":
-        "2019-01-08T20:18:56Z", "id": "8878239278a24907b769df8b5a86f77a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:43.907801", "expires":
+        "2019-03-04T21:03:43Z", "id": "1e6fcf8618ee4edfad50fa01cb78e3cb", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZYj-Wz21Q6qfUVfp_FEijA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["tlXlL8JWTrepei1VSFz5zA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4885,7 +4849,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4903,13 +4867,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:56 GMT
+      - Mon, 04 Mar 2019 20:03:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f38cbdef-01ff-4e2a-b171-fb581372be94
+      - req-81448c1c-7ded-4afe-9aef-73c8d671af4c
       Content-Length:
       - '4131'
       Connection:
@@ -4918,10 +4882,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:56.639286", "expires":
-        "2019-01-08T20:18:56Z", "id": "d4992c1fa73a4e54bf603e89b9875165", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:44.115084", "expires":
+        "2019-03-04T21:03:44Z", "id": "18daff123a7649ccbe17f595d758957d", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["XbtMiqMWRPKFynS-jUhKXA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["HvmGVDegQPi50NIovJ-xag"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4965,7 +4929,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4983,13 +4947,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:56 GMT
+      - Mon, 04 Mar 2019 20:03:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-26a60efc-cbc3-4d5c-bd22-e4e84e1a18e8
+      - req-d8ce200a-4a70-48f9-8949-d04a313190c0
       Content-Length:
       - '4118'
       Connection:
@@ -4998,10 +4962,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:56.838367", "expires":
-        "2019-01-08T20:18:56Z", "id": "4c52130ac3ca4b93a49017a176c687db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:44.305447", "expires":
+        "2019-03-04T21:03:44Z", "id": "0fbc046258ba468a9f9ee35dd7a01e0e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["LOrpP2puRK6OCWx1XdJFeA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ye_EQNH2QtSehvD-F4bdDg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -5045,7 +5009,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -5060,7 +5024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5071,9 +5035,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-534fd11e-c7c8-405d-b48a-80ba3181c903
+      - req-404c33a1-d443-4b89-912e-7977e08daef2
       Date:
-      - Tue, 08 Jan 2019 19:18:57 GMT
+      - Mon, 04 Mar 2019 20:03:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5107,7 +5071,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -5122,7 +5086,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5133,14 +5097,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ecdfd551-dbdb-45e0-8cb9-7ee5c9770fba
+      - req-06ac1d43-02c3-41d2-b67d-ce9cc96806eb
       Date:
-      - Tue, 08 Jan 2019 19:18:57 GMT
+      - Mon, 04 Mar 2019 20:03:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -5155,7 +5119,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4992c1fa73a4e54bf603e89b9875165
+      - 18daff123a7649ccbe17f595d758957d
   response:
     status:
       code: 200
@@ -5166,14 +5130,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1bae946b-9b37-4f9e-9dae-c2098aea2ba1
+      - req-573cebdc-cef2-4e1a-b198-2714e533427c
       Date:
-      - Tue, 08 Jan 2019 19:18:57 GMT
+      - Mon, 04 Mar 2019 20:03:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -5188,7 +5152,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 41d1492f2dd64ee7bbf124404842dbd9
+      - 8eb82abd79b84a27b1ad3ca237b38ca2
   response:
     status:
       code: 200
@@ -5199,14 +5163,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-21ef28e4-03be-42e9-a97b-dffa1f694398
+      - req-14965db2-4a8b-40ce-8d73-c815151fcb3a
       Date:
-      - Tue, 08 Jan 2019 19:18:57 GMT
+      - Mon, 04 Mar 2019 20:03:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -5221,7 +5185,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c52130ac3ca4b93a49017a176c687db
+      - 0fbc046258ba468a9f9ee35dd7a01e0e
   response:
     status:
       code: 200
@@ -5232,14 +5196,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-467c7064-9f08-4f5b-bf02-8ab709cebdbb
+      - req-893ba4ee-145c-4f48-88d7-e29953cbe7b2
       Date:
-      - Tue, 08 Jan 2019 19:18:57 GMT
+      - Mon, 04 Mar 2019 20:03:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -5254,7 +5218,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5265,9 +5229,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-991963b5-14d3-4464-a4ec-178954687543
+      - req-fbf6d3e3-8fa0-4d70-80b0-c53bbaff5005
       Date:
-      - Tue, 08 Jan 2019 19:18:58 GMT
+      - Mon, 04 Mar 2019 20:03:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5294,7 +5258,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -5309,7 +5273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5320,9 +5284,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f3c31005-072f-4820-a62a-12e99b8acf87
+      - req-bc318222-45e1-4963-84eb-ba7a485d4df9
       Date:
-      - Tue, 08 Jan 2019 19:18:58 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5349,7 +5313,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -5364,7 +5328,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5375,9 +5339,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-77420bac-2b5b-4b06-96ba-7aae8c168fad
+      - req-4b00c419-5969-4423-bb78-a95e201be788
       Date:
-      - Tue, 08 Jan 2019 19:18:58 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5404,7 +5368,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -5419,7 +5383,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5430,9 +5394,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e1a77afd-b9c3-445e-b1e0-62150806bd56
+      - req-ce369741-9be2-4dac-a432-2d83ffb52c17
       Date:
-      - Tue, 08 Jan 2019 19:18:58 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5444,7 +5408,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -5459,7 +5423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5470,9 +5434,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-3e571570-c8ba-46c8-803e-b98c3fd92a42
+      - req-a36ae233-830f-497a-bb7c-b09b98be77f9
       Date:
-      - Tue, 08 Jan 2019 19:18:58 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5484,7 +5448,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -5499,7 +5463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8878239278a24907b769df8b5a86f77a
+      - 1e6fcf8618ee4edfad50fa01cb78e3cb
   response:
     status:
       code: 200
@@ -5510,9 +5474,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-94878edb-37ba-425a-a2b9-172690f3e350
+      - req-744e3068-28fc-4c45-b257-0237bb231766
       Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5524,7 +5488,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5539,7 +5503,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -5550,16 +5514,39 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-06025835-ab76-40b3-a8d3-e4bcff7e87b2
+      - req-53ecca39-1796-4613-b714-6640045c55a3
       Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
+      - Mon, 04 Mar 2019 20:03:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -5568,12 +5555,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -5626,40 +5607,23 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:46 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -5671,7 +5635,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -5682,46 +5646,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-93b714ea-94bd-4e34-9f3b-c0c0d392c169
+      - req-6d307d75-03da-412f-978e-fa25e2a6c429
       Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5741,103 +5687,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-123c9488-d284-4a10-9d06-7e8a1ce917cc
-      Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -5890,301 +5739,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-931f5f26-d1ce-4127-99d8-9d8e0084212b
-      Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a2fc0418-e6e4-436d-b5af-3aecafe22370
-      Date:
-      - Tue, 08 Jan 2019 19:18:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6199,7 +5767,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -6210,9 +5778,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-158e05d3-2ef7-4562-aab7-1c327298153c
+      - req-5391895f-50f9-4611-86ce-c95e81f836a8
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6254,7 +5822,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6269,7 +5837,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -6280,9 +5848,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8f2b22d7-0511-4e00-b159-9d3076a8bbee
+      - req-9e727bda-48fd-4853-aed3-8672a6ea7eb0
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6324,7 +5892,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -6339,7 +5907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -6350,9 +5918,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-231232e2-dc85-4ec6-9cbc-4602760bf3c1
+      - req-fde1f2b6-6368-46a0-a1ad-242c5aa474d7
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6755,7 +6323,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -6770,7 +6338,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -6781,9 +6349,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ae6d23a4-61a0-4ecb-bc83-078b10c44e8a
+      - req-57b58c25-3537-49a8-9f6b-837d376259dd
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7186,7 +6754,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -7201,7 +6769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7212,9 +6780,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9db991aa-66dc-4150-8ef8-9d66064cac3f
+      - req-df961283-5e93-4702-984f-10e83824cd6c
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7246,7 +6814,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -7261,7 +6829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7272,9 +6840,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8351d727-3be0-4759-8f2a-aa2e915969b6
+      - req-ec0bac4f-a167-42c2-972a-58a02038129e
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7306,7 +6874,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7321,7 +6889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7332,9 +6900,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-4415dfc4-22ab-4715-a07d-50576ad27c11
+      - req-30892761-463c-4296-baa0-16d559cce74f
       Date:
-      - Tue, 08 Jan 2019 19:19:00 GMT
+      - Mon, 04 Mar 2019 20:03:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -7376,7 +6944,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -7391,7 +6959,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7402,9 +6970,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-eefe7404-6583-46a3-835d-ae8a8cfb8c8d
+      - req-ae896850-0295-4b11-87da-aa2fb3c0179c
       Date:
-      - Tue, 08 Jan 2019 19:19:01 GMT
+      - Mon, 04 Mar 2019 20:03:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -7447,7 +7015,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -7462,7 +7030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7473,9 +7041,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-61a29799-c074-4eb5-b0c0-d33a3fb91a71
+      - req-732f3d0e-3c2c-40fc-987d-6286771a6a7a
       Date:
-      - Tue, 08 Jan 2019 19:19:01 GMT
+      - Mon, 04 Mar 2019 20:03:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -7510,7 +7078,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -7525,7 +7093,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 964dcdc5fb6543699ec72acc8a183d30
+      - a087dad51a1d481bab48813c8f8a3a64
   response:
     status:
       code: 200
@@ -7536,9 +7104,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-4873c88b-321e-46dd-af8d-95907a213baa
+      - req-25ba2051-3877-4894-955a-dc3e3c10e180
       Date:
-      - Tue, 08 Jan 2019 19:19:01 GMT
+      - Mon, 04 Mar 2019 20:03:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -7625,7 +7193,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7643,13 +7211,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:01 GMT
+      - Mon, 04 Mar 2019 20:03:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9356dff9-a8f6-43af-a282-5dee629e9a46
+      - req-eb178345-5cd5-4e63-a2b7-1eb93d6cc344
       Content-Length:
       - '4170'
       Connection:
@@ -7658,10 +7226,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:02.009828", "expires":
-        "2019-01-08T20:19:01Z", "id": "3f547ada5a5545389a4ac92d80fb987e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:49.383033", "expires":
+        "2019-03-04T21:03:49Z", "id": "5a7cc34b9914472a861c3c40ba7bb07f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["XAbOxOMKQ4msPVmumf9DYg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ky-U_JRoSD2AFl6533QSGg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7706,7 +7274,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7724,13 +7292,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:02 GMT
+      - Mon, 04 Mar 2019 20:03:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-696fd5f1-04df-482a-8939-b6e897e17e57
+      - req-f43c321e-e2b6-40ea-b9bf-2011a0104146
       Content-Length:
       - '4170'
       Connection:
@@ -7739,10 +7307,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:02.205257", "expires":
-        "2019-01-08T20:19:02Z", "id": "737c6b3a6a8e4dfaa567d809aea35a20", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:49.589652", "expires":
+        "2019-03-04T21:03:49Z", "id": "a437bc46b519449aa4e3efcdd59c6d67", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3OWWKpvKR5aTi2UN3_UQ_g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FebLCfgnQsOTfSMpzIlGyQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7787,7 +7355,43 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:49 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a437bc46b519449aa4e3efcdd59c6d67
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-4bdf6bf9-3345-43f6-ab8d-4ce7ca433d41
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-4bdf6bf9-3345-43f6-ab8d-4ce7ca433d41
+      Date:
+      - Mon, 04 Mar 2019 20:03:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:03:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7805,13 +7409,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:02 GMT
+      - Mon, 04 Mar 2019 20:03:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc731e55-73c4-4b1f-8cd2-a6788c2f58ec
+      - req-b562cca9-a1e7-4ea9-9f71-cfd15ab5540e
       Content-Length:
       - '370'
       Connection:
@@ -7820,13 +7424,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:02.367006", "expires":
-        "2019-01-08T20:19:02Z", "id": "d49026bc9326440397c30d8ee198fdd4", "audit_ids":
-        ["NbKdOXe8RuOB5yb5jeP56g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:49.924933", "expires":
+        "2019-03-04T21:03:49Z", "id": "7deafc11c4e94b8c8529c3cff70b7170", "audit_ids":
+        ["Ut1iOqCYRayb_ysZ1rQfvA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:49 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7841,20 +7445,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d49026bc9326440397c30d8ee198fdd4
+      - 7deafc11c4e94b8c8529c3cff70b7170
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:02 GMT
+      - Mon, 04 Mar 2019 20:03:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-46769a3e-1840-4d9f-b02d-9bbfee6584ed
+      - req-e7a00431-4872-45a2-a14e-05a333d2b7f3
       Content-Length:
       - '500'
       Connection:
@@ -7871,7 +7475,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7889,13 +7493,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:02 GMT
+      - Mon, 04 Mar 2019 20:03:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a73fea47-2331-4542-990a-b215da43e3b8
+      - req-9f420e61-8058-4645-b14a-c8d1843c13db
       Content-Length:
       - '4117'
       Connection:
@@ -7904,10 +7508,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:02.693123", "expires":
-        "2019-01-08T20:19:02Z", "id": "aeed97d8fbd84ced922f2b3bdebd696d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:50.265804", "expires":
+        "2019-03-04T21:03:50Z", "id": "c5322d1571ab42a2a5232dfa4a006523", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["p3uEnTqoSQ2ZVzUVWy9XCA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["AQX68bSnQY2QteJ1bB63qQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7951,7 +7555,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7969,13 +7573,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:02 GMT
+      - Mon, 04 Mar 2019 20:03:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c19ed23-cab3-44b0-9a17-b8c48f5da8b9
+      - req-3a023f2e-d778-4508-8744-26835383bea2
       Content-Length:
       - '4131'
       Connection:
@@ -7984,10 +7588,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:02.882496", "expires":
-        "2019-01-08T20:19:02Z", "id": "baf26c5c5f754e72ab35e9f489c2a2b9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:50.468073", "expires":
+        "2019-03-04T21:03:50Z", "id": "0e82f0a75fc5492ab6eed06883eed1b9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9vt3I74vSXeH1FgX_DjJHw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["IjHTU-z5STGxzYUw4_U2BA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8031,7 +7635,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8049,13 +7653,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7efd99c8-415e-4ff7-ae72-c1eee3ff2e64
+      - req-2071b7d7-a82c-42d0-a769-3c5ec1744987
       Content-Length:
       - '4118'
       Connection:
@@ -8064,10 +7668,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:03.083856", "expires":
-        "2019-01-08T20:19:03Z", "id": "bb6e91ae1b5f43158367b683149e7245", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:50.661056", "expires":
+        "2019-03-04T21:03:50Z", "id": "647f434d43424ab3a59aa1b2184b9513", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Tb7SihUoR1eBmdREaWMaTQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Ft6ckC1CQOG5aWA4Ym3x9Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8111,7 +7715,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -8126,22 +7730,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-500ea451-6a42-4504-a40e-7c3fee2eba4c
+      - req-37801ebe-ead5-4147-8fd7-99ff7e1b87d1
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-500ea451-6a42-4504-a40e-7c3fee2eba4c
+      - req-37801ebe-ead5-4147-8fd7-99ff7e1b87d1
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -8174,7 +7778,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -8189,22 +7793,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6f0417c7-9236-407b-894b-0e7edec15c89
+      - req-97db5e20-20f6-4ec3-9739-0266a3f2978f
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-6f0417c7-9236-407b-894b-0e7edec15c89
+      - req-97db5e20-20f6-4ec3-9739-0266a3f2978f
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -8245,7 +7849,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -8260,22 +7864,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e9137eb-184a-4dfc-b728-c6233365b371
+      - req-48584b91-ac17-4d72-8b91-37b7d2847d45
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-6e9137eb-184a-4dfc-b728-c6233365b371
+      - req-48584b91-ac17-4d72-8b91-37b7d2847d45
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -8309,7 +7913,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -8324,27 +7928,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de9760c7-9131-4a7b-a4ab-6520d39d5007
+      - req-c3a169b2-4b72-4037-a51a-421a43ee2112
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-de9760c7-9131-4a7b-a4ab-6520d39d5007
+      - req-c3a169b2-4b72-4037-a51a-421a43ee2112
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -8359,27 +7963,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ae4c731-598f-4501-b1f2-37025aefca11
+      - req-4e4f8f5a-325c-473b-ae68-2aab8b714fe7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7ae4c731-598f-4501-b1f2-37025aefca11
+      - req-4e4f8f5a-325c-473b-ae68-2aab8b714fe7
       Date:
-      - Tue, 08 Jan 2019 19:19:03 GMT
+      - Mon, 04 Mar 2019 20:03:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -8394,27 +7998,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2742095-efb9-4d08-85bd-74283ca459ca
+      - req-8a867745-d739-493b-8801-3c3486334917
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a2742095-efb9-4d08-85bd-74283ca459ca
+      - req-8a867745-d739-493b-8801-3c3486334917
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -8429,27 +8033,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6845b9e9-5455-4a2a-8282-ffe342409745
+      - req-26a985f2-27a4-4d15-80c7-facc70067949
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6845b9e9-5455-4a2a-8282-ffe342409745
+      - req-26a985f2-27a4-4d15-80c7-facc70067949
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -8464,22 +8068,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fd6e13d-e921-440d-9d70-a20e676add70
+      - req-fa12d14a-effd-453b-ac53-8cb5e512c746
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-3fd6e13d-e921-440d-9d70-a20e676add70
+      - req-fa12d14a-effd-453b-ac53-8cb5e512c746
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8494,7 +8098,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -8509,22 +8113,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2f5510d0-bb6d-45bc-b853-63f89666eb33
+      - req-81e843e2-cb54-4e1d-94e4-40e8c3b5cb30
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-2f5510d0-bb6d-45bc-b853-63f89666eb33
+      - req-81e843e2-cb54-4e1d-94e4-40e8c3b5cb30
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -8539,7 +8143,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -8554,27 +8158,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a3a04c50-2ab3-4946-9694-8ea17f04654c
+      - req-a75dc7cb-17b8-400f-8d80-7aa2fe785a66
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a3a04c50-2ab3-4946-9694-8ea17f04654c
+      - req-a75dc7cb-17b8-400f-8d80-7aa2fe785a66
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -8589,27 +8193,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b2d79f6a-d434-40c6-85b6-79bbbe95768d
+      - req-2b1a1b63-9466-465d-9e11-23ada3a159f6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b2d79f6a-d434-40c6-85b6-79bbbe95768d
+      - req-2b1a1b63-9466-465d-9e11-23ada3a159f6
       Date:
-      - Tue, 08 Jan 2019 19:19:04 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -8624,27 +8228,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-93cd403e-2a64-4d4c-bcd3-da5da63487ba
+      - req-3bc9f65f-9ccc-4883-b8a5-27c95825e0d2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-93cd403e-2a64-4d4c-bcd3-da5da63487ba
+      - req-3bc9f65f-9ccc-4883-b8a5-27c95825e0d2
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -8659,27 +8263,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4184b16f-d79c-43b6-81c9-3d3379f1a823
+      - req-c26bad05-428c-4968-9010-75fc39938360
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-4184b16f-d79c-43b6-81c9-3d3379f1a823
+      - req-c26bad05-428c-4968-9010-75fc39938360
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -8694,27 +8298,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7ac7154d-9277-497b-b90e-1cba5eb22184
+      - req-1715c560-eb2e-4730-b2f7-5559d55089ab
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7ac7154d-9277-497b-b90e-1cba5eb22184
+      - req-1715c560-eb2e-4730-b2f7-5559d55089ab
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -8729,27 +8333,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb6f42ef-e342-438d-8f69-cc67c3353d8e
+      - req-c388bd6f-b2c5-469d-9294-0514556ae830
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-bb6f42ef-e342-438d-8f69-cc67c3353d8e
+      - req-c388bd6f-b2c5-469d-9294-0514556ae830
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -8764,27 +8368,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7575b30b-bfa9-412a-ab16-3a8020e4f97e
+      - req-11c85af9-92f7-4b7d-b8bd-a6a4d7ef8583
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7575b30b-bfa9-412a-ab16-3a8020e4f97e
+      - req-11c85af9-92f7-4b7d-b8bd-a6a4d7ef8583
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -8799,27 +8403,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63786008-7238-49c8-a4ec-ea12c6b86a26
+      - req-e3846307-bcec-40a0-ba61-1fe134c029ae
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-63786008-7238-49c8-a4ec-ea12c6b86a26
+      - req-e3846307-bcec-40a0-ba61-1fe134c029ae
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -8834,27 +8438,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d88dd334-cd15-47a3-81a9-ed6fae325322
+      - req-50dc0c1d-f462-4985-85ff-a17da6eb93f2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d88dd334-cd15-47a3-81a9-ed6fae325322
+      - req-50dc0c1d-f462-4985-85ff-a17da6eb93f2
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -8869,27 +8473,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d79c851a-fe2c-4878-be9d-76bcf8a9371e
+      - req-f4e603e2-1bf0-45a7-8c07-5b81db13de10
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d79c851a-fe2c-4878-be9d-76bcf8a9371e
+      - req-f4e603e2-1bf0-45a7-8c07-5b81db13de10
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -8904,27 +8508,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-838547de-20cf-4f9c-90c5-9796cbcc4b19
+      - req-41b273ff-a5d5-45a7-8f70-7216ecd658ca
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-838547de-20cf-4f9c-90c5-9796cbcc4b19
+      - req-41b273ff-a5d5-45a7-8f70-7216ecd658ca
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -8939,27 +8543,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0541402-fea3-4cc6-8c52-0a20fb764dd9
+      - req-096573a8-1ad4-4e20-876e-724a30cdccd9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c0541402-fea3-4cc6-8c52-0a20fb764dd9
+      - req-096573a8-1ad4-4e20-876e-724a30cdccd9
       Date:
-      - Tue, 08 Jan 2019 19:19:05 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -8974,27 +8578,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9b46699c-c882-4750-8f70-13be6ad578e4
+      - req-c5d6330d-ce6f-43e5-a2a8-a7964c3444fe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9b46699c-c882-4750-8f70-13be6ad578e4
+      - req-c5d6330d-ce6f-43e5-a2a8-a7964c3444fe
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -9009,27 +8613,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a8e7d3a7-e5af-44de-8e4f-fdb61747e474
+      - req-8deba32f-4728-4ae0-90d3-dc1d8f464273
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a8e7d3a7-e5af-44de-8e4f-fdb61747e474
+      - req-8deba32f-4728-4ae0-90d3-dc1d8f464273
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -9044,22 +8648,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c6fca618-3b50-4469-a8e9-289ca4d8e962
+      - req-5b5d2ee4-497a-42e2-96aa-d28b325f8dbb
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c6fca618-3b50-4469-a8e9-289ca4d8e962
+      - req-5b5d2ee4-497a-42e2-96aa-d28b325f8dbb
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9071,7 +8675,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9086,22 +8690,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aeed97d8fbd84ced922f2b3bdebd696d
+      - c5322d1571ab42a2a5232dfa4a006523
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3f2b98b2-9e62-485e-b93d-a255adc9b90c
+      - req-c3e9bd23-6f56-4837-aec1-2d43f45b66da
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3f2b98b2-9e62-485e-b93d-a255adc9b90c
+      - req-c3e9bd23-6f56-4837-aec1-2d43f45b66da
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9113,7 +8717,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -9128,22 +8732,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d411b32f-ecb3-40f5-bdcf-03629217dbf1
+      - req-3edf608a-1232-4cf0-8b2b-4aaea63d940d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d411b32f-ecb3-40f5-bdcf-03629217dbf1
+      - req-3edf608a-1232-4cf0-8b2b-4aaea63d940d
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9155,7 +8759,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9170,22 +8774,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - baf26c5c5f754e72ab35e9f489c2a2b9
+      - 0e82f0a75fc5492ab6eed06883eed1b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-94b95b9f-c322-4ac5-ad28-6c71ce9fd49c
+      - req-7953423b-660b-473b-9b12-e2e61060bdb9
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-94b95b9f-c322-4ac5-ad28-6c71ce9fd49c
+      - req-7953423b-660b-473b-9b12-e2e61060bdb9
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9197,7 +8801,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -9212,22 +8816,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d7ca6611-5307-49b7-9b67-d4943eab459c
+      - req-9e1ebf98-ce1f-450e-8122-316dd12a996e
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-d7ca6611-5307-49b7-9b67-d4943eab459c
+      - req-9e1ebf98-ce1f-450e-8122-316dd12a996e
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9239,7 +8843,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9254,22 +8858,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 737c6b3a6a8e4dfaa567d809aea35a20
+      - a437bc46b519449aa4e3efcdd59c6d67
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b273b0e7-e2e8-4796-8950-df8a42c9014f
+      - req-2d5582d7-b0ec-4411-a7c7-99a6a68ca676
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b273b0e7-e2e8-4796-8950-df8a42c9014f
+      - req-2d5582d7-b0ec-4411-a7c7-99a6a68ca676
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9281,7 +8885,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -9296,22 +8900,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-101889ba-fbd9-4080-a1d5-4e96a6926648
+      - req-804c013b-d2ff-4974-ae7b-b8e11e631f0c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-101889ba-fbd9-4080-a1d5-4e96a6926648
+      - req-804c013b-d2ff-4974-ae7b-b8e11e631f0c
       Date:
-      - Tue, 08 Jan 2019 19:19:06 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9323,7 +8927,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -9338,22 +8942,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb6e91ae1b5f43158367b683149e7245
+      - 647f434d43424ab3a59aa1b2184b9513
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-42431a9d-d7c4-488e-9301-826be013778e
+      - req-a0b549a8-6229-46d3-8f82-c63cbeacf0a6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-42431a9d-d7c4-488e-9301-826be013778e
+      - req-a0b549a8-6229-46d3-8f82-c63cbeacf0a6
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -9365,7 +8969,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9383,13 +8987,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6c729d3b-e907-491a-a9d0-d78fb04a4e27
+      - req-cf842b35-9760-4f78-bc35-d8cbd53971e8
       Content-Length:
       - '4170'
       Connection:
@@ -9398,10 +9002,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:07.326327", "expires":
-        "2019-01-08T20:19:07Z", "id": "cb1598f2386541c2bd360e517ef128a7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:56.912878", "expires":
+        "2019-03-04T21:03:56Z", "id": "2f0a94e51f3a4a2d922aa248d813f3ef", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["5hhrmFAIT4ucfpcBwremHw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AIUJSH-EQ5uGyWcYjuvSyw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -9446,7 +9050,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9464,13 +9068,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-edf1b30d-dd6a-4a2c-b404-f4a9de9260b4
+      - req-b43c90f8-2fa3-4408-8e40-d527d4f51464
       Content-Length:
       - '4170'
       Connection:
@@ -9479,10 +9083,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:07.535151", "expires":
-        "2019-01-08T20:19:07Z", "id": "52f57a9203094a2fbb3d5541ff24d96e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:57.171303", "expires":
+        "2019-03-04T21:03:57Z", "id": "8ae2ce5ab76d4877a96ab925eef49b08", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qXq7TjHNRcGJ5kaPNIRzRQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tyApJ69wTW6i9dv_oLt0ag"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -9527,7 +9131,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9545,13 +9149,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f575fbc6-3eb3-411d-835a-10ceb7ead9d7
+      - req-7ddfe8b8-b14e-4713-8d70-f27812d247c7
       Content-Length:
       - '370'
       Connection:
@@ -9560,13 +9164,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:07.704293", "expires":
-        "2019-01-08T20:19:07Z", "id": "c3d3ca9d731f491fbefe72ab5f12f3fe", "audit_ids":
-        ["3v2QiNgXSB-uOmwwYKZW_A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:57.336308", "expires":
+        "2019-03-04T21:03:57Z", "id": "3df82333482c4361aeb9ca558a4593cd", "audit_ids":
+        ["UwEpz8e1Sfisk0oYVZGvRw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -9581,20 +9185,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c3d3ca9d731f491fbefe72ab5f12f3fe
+      - 3df82333482c4361aeb9ca558a4593cd
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d41dc7bc-da60-435a-816c-d29a203ffb08
+      - req-36fd1d7c-85d4-430f-bcad-2dec588d0482
       Content-Length:
       - '500'
       Connection:
@@ -9611,7 +9215,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9629,13 +9233,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:07 GMT
+      - Mon, 04 Mar 2019 20:03:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a0fc156-9a6b-4924-8811-d418ea692114
+      - req-ebdd3a7c-4f97-46d2-884f-2115854ed2ba
       Content-Length:
       - '4117'
       Connection:
@@ -9644,10 +9248,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:08.036074", "expires":
-        "2019-01-08T20:19:08Z", "id": "046f94610210438ea3bd720b1c3cb84a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:57.707407", "expires":
+        "2019-03-04T21:03:57Z", "id": "a3d9a0c6cfb54d9c920107c3b0c0a078", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["XqWHcoSjRXyS879rhqVJAA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["UbulHmUtRAGLtDyMa7KbTQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -9691,7 +9295,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9709,13 +9313,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:08 GMT
+      - Mon, 04 Mar 2019 20:03:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d03a1e13-c7dc-4ef9-b3ed-20fbe0f636d3
+      - req-13ac792d-9efc-4f5d-a192-ed090c923732
       Content-Length:
       - '4131'
       Connection:
@@ -9724,10 +9328,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:08.231701", "expires":
-        "2019-01-08T20:19:08Z", "id": "5161c16e0178447da5b135a029755196", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:57.925021", "expires":
+        "2019-03-04T21:03:57Z", "id": "4a18f8c2066e43fb9fabb6e74a797b10", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["2O75wNrTRf25G2CdbC-V7g"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Qna6jWi1RX2eW37tI88sOw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -9771,7 +9375,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -9789,13 +9393,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:08 GMT
+      - Mon, 04 Mar 2019 20:03:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0e9cc481-ebb9-48c9-8c4c-a1afefddebb2
+      - req-175bd60d-adc0-45ae-a8ed-bee352f1dff1
       Content-Length:
       - '4118'
       Connection:
@@ -9804,10 +9408,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:19:08.683486", "expires":
-        "2019-01-08T20:19:08Z", "id": "6c53ec9607da419f9289229073ded938", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:03:59.159083", "expires":
+        "2019-03-04T21:03:59Z", "id": "13d4f0af6c7046859046a5bbc24e0dd7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["7xaVwOkOQHiMpFkYbk9-gg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1TuUzFUNSzeaNsjdtd_RPA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -9851,7 +9455,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -9866,7 +9470,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 046f94610210438ea3bd720b1c3cb84a
+      - a3d9a0c6cfb54d9c920107c3b0c0a078
   response:
     status:
       code: 200
@@ -9895,15 +9499,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx1f0b6f2e18b343cfbb97d-005c34f7ac
+      - txd34b6cd6c33a4c90aa1c5-005c7d84af
       Date:
-      - Tue, 08 Jan 2019 19:19:08 GMT
+      - Mon, 04 Mar 2019 20:03:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -9918,7 +9522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 046f94610210438ea3bd720b1c3cb84a
+      - a3d9a0c6cfb54d9c920107c3b0c0a078
   response:
     status:
       code: 200
@@ -9947,14 +9551,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx806881f7b7a04195a10a6-005c34f7ac
+      - txea677f7e3700406eabd9d-005c7d84af
       Date:
-      - Tue, 08 Jan 2019 19:19:08 GMT
+      - Mon, 04 Mar 2019 20:03:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -9969,7 +9573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5161c16e0178447da5b135a029755196
+      - 4a18f8c2066e43fb9fabb6e74a797b10
   response:
     status:
       code: 200
@@ -9982,22 +9586,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975149.13636'
+      - '1551729839.68365'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975149.13636'
+      - '1551729839.68365'
       X-Trans-Id:
-      - tx430dbb02a100475ca6eb8-005c34f7ad
+      - tx729247d5a1a94d4696cb7-005c7d84af
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:03:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -10012,7 +9616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 52f57a9203094a2fbb3d5541ff24d96e
+      - 8ae2ce5ab76d4877a96ab925eef49b08
   response:
     status:
       code: 200
@@ -10025,22 +9629,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975149.29631'
+      - '1551729839.84430'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975149.29631'
+      - '1551729839.84430'
       X-Trans-Id:
-      - tx89e8290116594b40b812d-005c34f7ad
+      - tx2dc45694a8484b66ac5c0-005c7d84af
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:03:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:03:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -10055,7 +9659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c53ec9607da419f9289229073ded938
+      - 13d4f0af6c7046859046a5bbc24e0dd7
   response:
     status:
       code: 200
@@ -10068,22 +9672,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975149.45046'
+      - '1551729840.00008'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975149.45046'
+      - '1551729840.00008'
       X-Trans-Id:
-      - txb98c25f88b39410f8db2c-005c34f7ad
+      - tx6478f01729184c97a3ff9-005c7d84af
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:04:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -10098,7 +9702,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 046f94610210438ea3bd720b1c3cb84a
+      - a3d9a0c6cfb54d9c920107c3b0c0a078
   response:
     status:
       code: 200
@@ -10119,9 +9723,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbe29c1d58fbb43c4a6094-005c34f7ad
+      - tx817d024b6afa49d89ec82-005c7d84b0
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:04:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -10131,7 +9735,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -10146,7 +9750,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 046f94610210438ea3bd720b1c3cb84a
+      - a3d9a0c6cfb54d9c920107c3b0c0a078
   response:
     status:
       code: 200
@@ -10167,14 +9771,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txcff81b2486f840a880c87-005c34f7ad
+      - tx17ae9c6168a44c88bd459-005c7d84b0
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:04:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -10189,7 +9793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 046f94610210438ea3bd720b1c3cb84a
+      - a3d9a0c6cfb54d9c920107c3b0c0a078
   response:
     status:
       code: 200
@@ -10210,12 +9814,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txf490aa6265404afaa8560-005c34f7ad
+      - txace23ddbd620446d8af95-005c7d84b0
       Date:
-      - Tue, 08 Jan 2019 19:19:09 GMT
+      - Mon, 04 Mar 2019 20:04:00 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:17 GMT
+      - Mon, 04 Mar 2019 20:06:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2386d85e-c78c-4fe1-ab0b-3ceee708be45
+      - req-af5fb2ff-b7c3-4a17-a165-d9f89368b0f4
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:17.697673Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:59.974932Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JM7ERsdKTUuS6vAeZJkGsQ"],
-        "issued_at": "2019-01-08T19:19:17.697693Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TXYvctj7QquMIh0bOd8k6g"],
+        "issued_at": "2019-03-04T20:06:59.974956Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:17 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,171 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-828eec4c-2d4e-45db-aecf-71c408f2a4b0
+      - req-da65de72-b676-4595-b3a6-e782f8891519
       Date:
-      - Tue, 08 Jan 2019 19:19:17 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:17 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Jan 2019 19:19:18 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-bf7c89f6-bfd6-4561-a260-dc0df1597407
-      Content-Length:
-      - '7311'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:18.152691Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VcuVVampSz6waBwL-SOr6Q"],
-        "issued_at": "2019-01-08T19:19:18.152713Z"}}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:18 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-951b5808-fdc7-40e4-b1d0-2fd34a1d95cb
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '82'
-      X-Openstack-Request-Id:
-      - req-951b5808-fdc7-40e4-b1d0-2fd34a1d95cb
-      Date:
-      - Tue, 08 Jan 2019 19:19:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
-        "nova"}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -364,15 +208,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:18 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bb461e29101e4ebc83247bd4ce52a74c
+      - 8837d832946f4b90b1127fc941d12636
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7ef8bc41-c296-4209-b41b-37ada032b1b2
+      - req-bf84a333-deda-407e-9870-e3ba0f6183c8
       Content-Length:
       - '297'
       Connection:
@@ -381,12 +225,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:19:18.628633Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:07:00.406869Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cVrrL0XeQ6y6x7x6U22-ZQ"],
-        "issued_at": "2019-01-08T19:19:18.628651Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PWtctKElQBa8Aq2JQw89zA"],
+        "issued_at": "2019-03-04T20:07:00.406888Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -401,20 +245,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bb461e29101e4ebc83247bd4ce52a74c
+      - 8837d832946f4b90b1127fc941d12636
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:18 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eabb20d0-f68b-468a-9988-446672139563
+      - req-c69347c6-0218-4991-9d9a-38becb5be2d9
       Content-Length:
       - '2475'
       Connection:
@@ -447,7 +291,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -465,15 +309,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:18 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d7a3b1ca-bcd6-4fd2-83c7-b285bfaa9c7e
+      - req-0c00834d-3793-4541-9048-4fde59f30883
       Content-Length:
       - '7278'
       Connection:
@@ -485,7 +329,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:18.970405Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:00.752482Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -564,10 +408,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZcxvvOyASTG0KKbS6QHHKw"],
-        "issued_at": "2019-01-08T19:19:18.970424Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["60zSlIPEQLKP4l_JtjfLdQ"],
+        "issued_at": "2019-03-04T20:07:00.752504Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -582,7 +426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
   response:
     status:
       code: 200
@@ -593,7 +437,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -602,7 +446,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -620,15 +464,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dc2eea51-b24d-4ea1-ab90-3aa547944279
+      - req-47a12216-2b5c-49bb-a284-0f1df1d72cf2
       Content-Length:
       - '7278'
       Connection:
@@ -640,7 +484,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:19.259354Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:01.061418Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -719,10 +563,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-FZgQbuwR8GYk5qLgc6xzw"],
-        "issued_at": "2019-01-08T19:19:19.259373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m_cWib-YR4q3mIOs6gArYQ"],
+        "issued_at": "2019-03-04T20:07:01.061443Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -737,7 +581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
   response:
     status:
       code: 200
@@ -748,7 +592,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -757,7 +601,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -775,15 +619,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61e70e15-30d5-43bd-a56b-602c2eb061a4
+      - req-19a7c44f-5024-4d1e-8fd8-4cd5a2e4ec15
       Content-Length:
       - '7264'
       Connection:
@@ -795,7 +639,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:19.549788Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:01.354054Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -874,10 +718,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8VP-otf7TK-e8Ct-OPeneg"],
-        "issued_at": "2019-01-08T19:19:19.549806Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6QfXzXO5QwiNobxRsMRtCw"],
+        "issued_at": "2019-03-04T20:07:01.354072Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -892,7 +736,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
   response:
     status:
       code: 200
@@ -903,7 +747,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -912,7 +756,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -930,15 +774,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fbb93e25-9d22-4217-b601-28d96152ef36
+      - req-7764ebe9-f110-4b3b-b0e8-5d9a6e37d12a
       Content-Length:
       - '7278'
       Connection:
@@ -950,7 +794,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:19.831450Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:01.646059Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1029,10 +873,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["U2QPCiz2TGeDzt562HIKnA"],
-        "issued_at": "2019-01-08T19:19:19.831469Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WHIrHTszSNuU1zwRPWLlSQ"],
+        "issued_at": "2019-03-04T20:07:01.646077Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1047,7 +891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
   response:
     status:
       code: 200
@@ -1058,7 +902,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:19 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1067,7 +911,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1085,15 +929,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e1030009-df5d-4caa-b9a6-faa2560d5387
+      - req-27a906bc-3ac6-4151-a36c-0a19b04942b8
       Content-Length:
       - '7265'
       Connection:
@@ -1105,7 +949,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:20.119275Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:01.946756Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1184,10 +1028,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e0OTJ7RbR0SQk3T_CN4zZA"],
-        "issued_at": "2019-01-08T19:19:20.119295Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TWxSveKzRbSpas_I_SsXsA"],
+        "issued_at": "2019-03-04T20:07:01.946777Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1202,7 +1046,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
   response:
     status:
       code: 200
@@ -1213,7 +1057,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1222,7 +1066,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1240,15 +1084,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35ac66e1-0d8d-4689-a9cb-cbaac3aaa22e
+      - req-4e76bf9d-9e74-4bcc-baee-477f61a645d2
       Content-Length:
       - '7278'
       Connection:
@@ -1260,7 +1104,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:20.422774Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:02.262481Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1339,10 +1183,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jrYJDcBwQRqrxVtltde9Xw"],
-        "issued_at": "2019-01-08T19:19:20.422800Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["klL_5LHpRwm9enFWX2eySQ"],
+        "issued_at": "2019-03-04T20:07:02.262504Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1357,7 +1201,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
   response:
     status:
       code: 200
@@ -1368,7 +1212,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1377,7 +1221,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000
@@ -1392,7 +1236,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1405,26 +1249,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-1fe857ec-c62d-491f-99fc-d9b3d3cfb680
+      - req-e36daa71-e8e1-4933-a972-9cb996f3b072
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-services?limit=1000&marker=6
@@ -1439,7 +1283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1452,26 +1296,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7f2e19a9-6e80-46e5-93af-c457273ce2fc
+      - req-004d41fb-0e22-4b00-9242-dc599b66af3b
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000
@@ -1486,7 +1330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1499,26 +1343,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c21a9191-4577-4d34-ac38-82cd4ba22eea
+      - req-ec7190a5-b095-49c2-92f6-0338edad8aea
       Date:
-      - Tue, 08 Jan 2019 19:19:20 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-services?limit=1000&marker=6
@@ -1533,7 +1377,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1546,26 +1390,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-b30271b1-c427-4621-adae-a13f598be566
+      - req-b392594a-f45c-4927-9897-5134e354a8f4
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000
@@ -1580,7 +1424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1593,26 +1437,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2e620b15-0197-43f9-82e7-996d71daab7e
+      - req-fee86b85-47e2-4d48-894b-1247120806a6
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-services?limit=1000&marker=6
@@ -1627,7 +1471,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1640,26 +1484,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-bfc368d4-dd98-437a-b62d-94729ed95429
+      - req-461311c0-bc67-499f-af0f-1f13cc0132ab
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000
@@ -1674,7 +1518,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1687,26 +1531,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-0620a349-0bec-4bee-aba0-faa0528891e7
+      - req-fd38f5cc-8703-45dc-92b0-1094ee57cf7c
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-services?limit=1000&marker=6
@@ -1721,7 +1565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1734,26 +1578,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-fcd5c2e3-a891-4854-81a3-a84393eb713a
+      - req-520b1880-a98d-4f81-9f83-746cf141291b
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000
@@ -1768,7 +1612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1781,26 +1625,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-15425d63-2103-4ce3-8b52-b485d009c314
+      - req-32ba7d9b-ed03-4ccc-8d7c-9d9854f56753
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?limit=1000&marker=6
@@ -1815,7 +1659,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1828,26 +1672,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-31c7e31c-1cda-47f3-a01f-974f7712ff86
+      - req-fb238d3b-6faa-4148-9d5d-c99eab5f6f89
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000
@@ -1862,7 +1706,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1875,26 +1719,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-5e74060a-375b-4fb8-a386-55fbd0739f8a
+      - req-d8fc03fa-fc0a-420d-8ffe-f8662b90023b
       Date:
-      - Tue, 08 Jan 2019 19:19:21 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-services?limit=1000&marker=6
@@ -1909,7 +1753,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1922,26 +1766,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a3d936ae-7673-4084-8bca-0999b2625638
+      - req-23242db9-9aee-4e5f-a183-955bef2dc72d
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000
@@ -1956,7 +1800,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1969,26 +1813,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-198e80e3-e1e4-46cd-bc34-15e301cf96d5
+      - req-5c276b1c-d4c8-4336-895a-703ec1fa90fe
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-services?limit=1000&marker=6
@@ -2003,7 +1847,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2016,26 +1860,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-adeb933b-654a-4bd1-89c8-13044c71f760
+      - req-66f0b4c8-fc92-4c15-9e9c-771ee1b4c7ee
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:19:20.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:55.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:19:14.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:56.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:19:17.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:07:02.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:19:19.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:58.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:19:14.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:56.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -2050,7 +1894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2063,9 +1907,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-ddee47d7-54ff-4743-80de-e50522ad58f4
+      - req-dc05ddbe-41f3-45ee-8655-a9d4b2e3b2e8
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -2079,7 +1923,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -2094,7 +1938,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2107,9 +1951,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-47cadf2f-ffba-4b8b-93fa-204d32805150
+      - req-9ddf9df8-3460-4e3d-8664-2eaddebdb401
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -2123,7 +1967,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -2138,7 +1982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2151,9 +1995,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-44685838-6ea7-4f67-9841-53d7ed5bd79d
+      - req-c00bfc74-4864-4187-9ba4-725c2bcf7707
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -2168,7 +2012,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -2183,7 +2027,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2196,9 +2040,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-a2e20362-69fe-4359-b13e-e7fb1e0859ad
+      - req-6161dca7-92cd-4d9a-8029-8c1bd74be3c8
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -2208,7 +2052,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -2223,7 +2067,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2236,15 +2080,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-d741c4ad-9497-4b35-8cd4-b6d9dd69d2c1
+      - req-95ee7709-c12e-4c94-be3b-be396cf3d6c9
       Date:
-      - Tue, 08 Jan 2019 19:19:22 GMT
+      - Mon, 04 Mar 2019 20:07:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2262,15 +2106,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:23 GMT
+      - Mon, 04 Mar 2019 20:07:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6b84b8c6eca94a80a6505491e857bfb9
+      - 1a39a8a7d5ce44118807d7dcc07506e8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59fa52a8-0d16-47b6-8565-65a242578d44
+      - req-f59feeee-20e0-42cb-8a73-b5ec65e6dc54
       Content-Length:
       - '7311'
       Connection:
@@ -2282,7 +2126,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:23.133712Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:05.270412Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2361,10 +2205,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_4FgTRvcQMywe3DASkCs4g"],
-        "issued_at": "2019-01-08T19:19:23.133738Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o4jcA2aiTC-Z44BqWXRLfg"],
+        "issued_at": "2019-03-04T20:07:05.270434Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2382,15 +2226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:23 GMT
+      - Mon, 04 Mar 2019 20:07:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f3aee07e77a044449356aa65e6b11d95
+      - 227439dae6954d669bb72cbe9f8c0de1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-68a0a576-8355-40dc-a23f-09be45b10622
+      - req-96b2d1ff-47cc-457b-979d-836d1d52c42a
       Content-Length:
       - '7278'
       Connection:
@@ -2402,7 +2246,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:23.345001Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:05.485369Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2481,10 +2325,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ABzUc1y6TuufzsHsTaW3UQ"],
-        "issued_at": "2019-01-08T19:19:23.345023Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rSXFPD9_SYGLiZ2w1s3lUw"],
+        "issued_at": "2019-03-04T20:07:05.485393Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2502,15 +2346,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:23 GMT
+      - Mon, 04 Mar 2019 20:07:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 51033e236d31439e90d942fc4401b285
+      - 9a5e3473b3704c68abc8bc4b6686513b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-596b48f6-8b6d-4ce2-a163-995e73b7e0e3
+      - req-ce1a1ab4-11d9-4ec1-9d73-7683462505a5
       Content-Length:
       - '7278'
       Connection:
@@ -2522,7 +2366,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:23.570088Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:05.719078Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2601,10 +2445,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6GDLOe5dQLur7SLikCglJQ"],
-        "issued_at": "2019-01-08T19:19:23.570107Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ColW8i2ZTSaeB2ir6ToC7Q"],
+        "issued_at": "2019-03-04T20:07:05.719110Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2622,15 +2466,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:23 GMT
+      - Mon, 04 Mar 2019 20:07:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 120b2209456a4412acccf93b4bf7e7af
+      - 9a265c56bc5c4aa99891556bd7c521c7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03f4d6c1-e624-4239-b58c-f5f25e7fa541
+      - req-0458bcca-458d-4efe-87b2-eb0c6503485d
       Content-Length:
       - '7264'
       Connection:
@@ -2642,7 +2486,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:23.775015Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:05.939965Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2721,10 +2565,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z35252z8Sj6JBt2VwQE1ig"],
-        "issued_at": "2019-01-08T19:19:23.775034Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N62jayDZTJiR7fV_H6eTJw"],
+        "issued_at": "2019-03-04T20:07:05.939989Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2742,15 +2586,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:23 GMT
+      - Mon, 04 Mar 2019 20:07:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ff13f72f66004dfba2e0b3d8082e1e05
+      - d5ae500c53f841aaa0cdf7742b859d29
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-594eb2c3-6afc-494b-9d57-4d7280042dc7
+      - req-9557f73d-17c5-403c-97c2-8aa1c025cd7d
       Content-Length:
       - '7278'
       Connection:
@@ -2762,7 +2606,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:23.985372Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:06.161910Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2841,10 +2685,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j52JjGGeS76gDAqPVniH2A"],
-        "issued_at": "2019-01-08T19:19:23.985391Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["uoB5uXiVT76h6jnKeol-NA"],
+        "issued_at": "2019-03-04T20:07:06.161933Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2862,15 +2706,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3da28cb2327f4b9695b85da9b8487560
+      - 11c83d3055b942e3b184395ec522ce6b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-523c3bfd-663c-4548-9088-52a2c01dcc45
+      - req-7e22f839-11c2-4a40-aeb4-55ac5683e9c3
       Content-Length:
       - '7265'
       Connection:
@@ -2882,7 +2726,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:24.186528Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:06.377394Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2961,10 +2805,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WosLCjhgQAKjz0UQSLWd2A"],
-        "issued_at": "2019-01-08T19:19:24.186547Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["n_LluoICQsGXQ49aEXmq1Q"],
+        "issued_at": "2019-03-04T20:07:06.377416Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2982,15 +2826,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5ab9382dddeb447096dd95ffbe68b3cd
+      - 0017267b415444128e30dbec989876d5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a924c5c5-41e4-46fe-aa55-74afff39e937
+      - req-78f64249-5676-4a1d-bbb2-7c49e6d4b108
       Content-Length:
       - '7278'
       Connection:
@@ -3002,7 +2846,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:24.387417Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:06.586129Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3081,10 +2925,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4GISo2GOTt-O1bCl1ZrXew"],
-        "issued_at": "2019-01-08T19:19:24.387441Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L2vfE4OvQs2HrfkpHf1ntg"],
+        "issued_at": "2019-03-04T20:07:06.586151Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3099,7 +2943,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3aee07e77a044449356aa65e6b11d95
+      - 227439dae6954d669bb72cbe9f8c0de1
   response:
     status:
       code: 200
@@ -3110,9 +2954,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cd03e68a-be24-4cfb-815b-6f93f39d9752
+      - req-ec30b5b9-240f-4d07-9474-eed64d6a8279
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3154,7 +2998,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3169,7 +3013,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f3aee07e77a044449356aa65e6b11d95
+      - 227439dae6954d669bb72cbe9f8c0de1
   response:
     status:
       code: 200
@@ -3180,14 +3024,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7d12bca5-fe7d-4be0-a88c-8a461515eba5
+      - req-cc7696de-b209-4b69-9a35-cbb34a98fcf8
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3202,7 +3046,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51033e236d31439e90d942fc4401b285
+      - 9a5e3473b3704c68abc8bc4b6686513b
   response:
     status:
       code: 200
@@ -3213,9 +3057,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-9add8470-851e-49b8-a967-b863832fc0fa
+      - req-2a71eed3-d5a8-48b9-b911-68392f7493f3
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3257,7 +3101,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3272,7 +3116,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 51033e236d31439e90d942fc4401b285
+      - 9a5e3473b3704c68abc8bc4b6686513b
   response:
     status:
       code: 200
@@ -3283,14 +3127,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b83f977f-6548-459a-b1f2-73845c88e589
+      - req-43308de7-d9c7-4f01-8ec5-0b440204c356
       Date:
-      - Tue, 08 Jan 2019 19:19:24 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3305,7 +3149,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 120b2209456a4412acccf93b4bf7e7af
+      - 9a265c56bc5c4aa99891556bd7c521c7
   response:
     status:
       code: 200
@@ -3316,9 +3160,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f399e0a6-21ef-424d-8e37-d1db942317a9
+      - req-98288d96-6910-41d7-ae2c-b21fc0b24ab9
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3360,7 +3204,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3375,7 +3219,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 120b2209456a4412acccf93b4bf7e7af
+      - 9a265c56bc5c4aa99891556bd7c521c7
   response:
     status:
       code: 200
@@ -3386,14 +3230,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-fc7ae0de-4329-46d8-8bba-c9fc1b188f18
+      - req-356f43a9-e13c-4b6e-9074-81e28ca954d2
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3408,7 +3252,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff13f72f66004dfba2e0b3d8082e1e05
+      - d5ae500c53f841aaa0cdf7742b859d29
   response:
     status:
       code: 200
@@ -3419,9 +3263,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-19ea55cf-5773-4359-afef-a061deb81761
+      - req-8ff59f73-ce36-4ff6-91c5-ee80ea8aae4b
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3463,7 +3307,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3478,7 +3322,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff13f72f66004dfba2e0b3d8082e1e05
+      - d5ae500c53f841aaa0cdf7742b859d29
   response:
     status:
       code: 200
@@ -3489,14 +3333,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-fa3dbd70-b725-4425-b63c-d0029dc7a2bb
+      - req-d62fd898-46a7-40fc-8fdb-53e37d317293
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3511,7 +3355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b84b8c6eca94a80a6505491e857bfb9
+      - 1a39a8a7d5ce44118807d7dcc07506e8
   response:
     status:
       code: 200
@@ -3522,9 +3366,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-8dd10ab5-8089-4448-ad3d-66e1f70c399c
+      - req-c710c616-50f8-4bed-82c6-196b209b5f03
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3566,7 +3410,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3581,7 +3425,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b84b8c6eca94a80a6505491e857bfb9
+      - 1a39a8a7d5ce44118807d7dcc07506e8
   response:
     status:
       code: 200
@@ -3592,14 +3436,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-1c56a485-8f5b-4050-aea7-0e2ed9eaa59c
+      - req-a9a9cb9d-0534-4804-a0dc-9d6cb3ee392e
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3614,7 +3458,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3da28cb2327f4b9695b85da9b8487560
+      - 11c83d3055b942e3b184395ec522ce6b
   response:
     status:
       code: 200
@@ -3625,9 +3469,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-97233be2-2474-47d1-90b0-053885288115
+      - req-6c617897-c20a-48fb-bab3-f7d29b3fc941
       Date:
-      - Tue, 08 Jan 2019 19:19:25 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3669,7 +3513,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3684,7 +3528,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3da28cb2327f4b9695b85da9b8487560
+      - 11c83d3055b942e3b184395ec522ce6b
   response:
     status:
       code: 200
@@ -3695,14 +3539,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-2ce911eb-71bb-4b19-9b11-6c0412fbe69d
+      - req-2028b131-91f4-415c-932c-3744a96f88a4
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000
@@ -3717,7 +3561,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ab9382dddeb447096dd95ffbe68b3cd
+      - 0017267b415444128e30dbec989876d5
   response:
     status:
       code: 200
@@ -3728,9 +3572,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-01010d48-d62d-40d7-af7f-32b92ef8e9fd
+      - req-45c7accb-8de4-4cd1-a7d0-abee34b83743
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3772,7 +3616,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?limit=1000&marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -3787,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ab9382dddeb447096dd95ffbe68b3cd
+      - 0017267b415444128e30dbec989876d5
   response:
     status:
       code: 200
@@ -3798,14 +3642,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-3d376303-573d-42ac-894b-0fc40e28f927
+      - req-7331f7dd-9b38-4342-97e6-4cf724c3ceb5
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000
@@ -3820,7 +3664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3833,9 +3677,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f330fbad-46fc-46d4-88c1-4eba04969783
+      - req-f57365cc-ea78-4fbf-8923-d7c89d18c51d
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3845,7 +3689,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3860,7 +3704,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3873,9 +3717,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-37fd840c-797c-48a7-98f0-ea9d7be6e943
+      - req-39d2452c-0720-4c7e-861d-236588500f54
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3885,7 +3729,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000
@@ -3900,7 +3744,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3913,9 +3757,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-1aac0e08-b194-4876-ac43-08817319cb12
+      - req-c4c9d26b-288a-44d1-9325-9912870c984d
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3925,7 +3769,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -3940,7 +3784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3797,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f941b437-3b3a-4f40-8e19-b92dfe15c862
+      - req-b89fef91-2dbd-45da-b211-4c2c2832c639
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -3965,7 +3809,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000
@@ -3980,7 +3824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3993,9 +3837,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-2e1c6e8f-f83e-48af-ad15-1a65240dd540
+      - req-4acc1d7d-7614-4cb5-a418-0804057fb1fa
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4005,7 +3849,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4020,7 +3864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4033,9 +3877,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-18176ef8-ca40-4c75-8988-3fb043c63126
+      - req-f704de59-18d3-4a97-acce-e0bd1ed3e61c
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4045,7 +3889,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000
@@ -4060,7 +3904,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4073,9 +3917,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-d12488ca-367a-4de9-ae46-ec76981bb97c
+      - req-ec69a817-7304-4032-9b9b-a585ea8670aa
       Date:
-      - Tue, 08 Jan 2019 19:19:26 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4085,7 +3929,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4100,7 +3944,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4113,9 +3957,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-03d1289a-81dc-46bf-9ee4-b930a6676ba1
+      - req-4a0d1750-b9ee-4b12-83bd-f8ac325c3c0b
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4125,7 +3969,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000
@@ -4140,7 +3984,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4153,9 +3997,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-cd6e641d-0c3a-41ea-830b-ac12c42eae85
+      - req-5065cf43-c809-4a39-8c13-3427a7d7a2e8
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4165,7 +4009,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4180,7 +4024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4193,9 +4037,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-e1611a39-f2eb-4034-b80a-2dcb42e61f8b
+      - req-e4241da8-7835-496f-b524-1821cff5cb42
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4205,7 +4049,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000
@@ -4220,7 +4064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4233,9 +4077,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-e11377f0-4aa0-4abc-af7d-34df54d7d4ed
+      - req-347280db-f3de-4624-b9c7-422ab0e97a8d
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4245,7 +4089,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4260,7 +4104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4273,9 +4117,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-ba683614-9ca9-408f-9618-eaa15823f3bf
+      - req-efc201a0-3736-46b6-a764-a475026fddb7
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4285,7 +4129,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000
@@ -4300,7 +4144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4313,9 +4157,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-66861638-cff1-4ade-8ffd-0041001775bc
+      - req-3b086376-efa4-489c-8a90-1692d2c1d952
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4325,7 +4169,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4340,7 +4184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4353,9 +4197,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-a2727034-c678-4dce-b12b-6d7784940217
+      - req-aab97125-a7f5-40c0-bb20-d68152fa0cce
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4365,7 +4209,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4383,15 +4227,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d3ec052eb24c4c259a865883cfd4d357
+      - 170f9a12f7144e2b9ddb7e3af7759c75
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8ebafac9-0dfc-4617-9f5a-b32a33dd2788
+      - req-832674b3-ddf7-466e-b340-671e15db49ec
       Content-Length:
       - '7311'
       Connection:
@@ -4403,7 +4247,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:27.807278Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:11.216150Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4482,10 +4326,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["J6CrSeYYRRaRhG36SkE00g"],
-        "issued_at": "2019-01-08T19:19:27.807297Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["A1jrh_WGSyqlrwL-Q0RbMA"],
+        "issued_at": "2019-03-04T20:07:11.216169Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4503,15 +4347,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:27 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fa8ebd464ca5462cb505312cf44bcdd8
+      - 91d592b028204779896b806059418984
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-11558f8e-a35a-4a34-ade6-937061a9b613
+      - req-0781f3d1-04cf-40eb-92a3-68eee4a6efa0
       Content-Length:
       - '7278'
       Connection:
@@ -4523,7 +4367,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:28.007084Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:11.414708Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4602,10 +4446,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6mk41OWwRIimgfzKAMXsbg"],
-        "issued_at": "2019-01-08T19:19:28.007102Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DZ47gQAPSOODbLhG0U0EfA"],
+        "issued_at": "2019-03-04T20:07:11.414725Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4623,15 +4467,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:28 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3553739bf14c4bbd9090231bb65aabd4
+      - '07287e98ff0c4807a82215df4171cf20'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6547c749-22fe-4055-acfe-e39eff51ff05
+      - req-57275263-dd55-4dfc-9fee-88f6d8b29645
       Content-Length:
       - '7278'
       Connection:
@@ -4643,7 +4487,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:28.220718Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:11.615498Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4722,10 +4566,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zeeaXlH_TnOg-_BneRPBqg"],
-        "issued_at": "2019-01-08T19:19:28.220737Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zd7fbnccSZSczdu6YSi8RQ"],
+        "issued_at": "2019-03-04T20:07:11.615516Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4743,15 +4587,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:28 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5128d39f-b9fa-4c90-874b-e87314260d54
+      - req-c4101349-9428-4e58-88d7-4502380b31a8
       Content-Length:
       - '7264'
       Connection:
@@ -4763,7 +4607,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:28.421043Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:11.818511Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4842,10 +4686,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ii5rHV2fQZi23b4f_xY0kg"],
-        "issued_at": "2019-01-08T19:19:28.421060Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["s4o020MMSo2ib3w_Q7NbXw"],
+        "issued_at": "2019-03-04T20:07:11.818529Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4863,15 +4707,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:28 GMT
+      - Mon, 04 Mar 2019 20:07:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 14464d29a58f4acb8d55708c9c8a2683
+      - 29ab88ae56ab42c692d04ac62f97e707
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-137d1d24-c667-44f7-ad7d-824237801730
+      - req-0a8aec1a-da9b-4434-b9c5-9e3f0a05e923
       Content-Length:
       - '7278'
       Connection:
@@ -4883,7 +4727,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:28.621238Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:12.022278Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4962,10 +4806,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OH1f0p9HTN2ML4AL0vHAYQ"],
-        "issued_at": "2019-01-08T19:19:28.621257Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vAlld_2YTcGNls33GzdYGg"],
+        "issued_at": "2019-03-04T20:07:12.022296Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4983,15 +4827,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:28 GMT
+      - Mon, 04 Mar 2019 20:07:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 94b9fc43cb6c42fe9ad6f4b5bac22020
+      - 3783c26d2994484ab465f1cea0bea63b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-613790a1-11af-4222-90a0-65b3228deef4
+      - req-26003a40-eb5a-47ab-972a-69747eabece0
       Content-Length:
       - '7265'
       Connection:
@@ -5003,7 +4847,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:28.823887Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:12.220705Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5082,10 +4926,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["6kQG5NXJSNW4PS6Etu84GA"],
-        "issued_at": "2019-01-08T19:19:28.823904Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["as-pN48XTW6yfKyihNoRYw"],
+        "issued_at": "2019-03-04T20:07:12.220723Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5103,15 +4947,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:28 GMT
+      - Mon, 04 Mar 2019 20:07:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 81fcced73d3e4973a83bc734592da8be
+      - 107d178cfd6746ff9d63fbce4961f89f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-66b69773-8e52-480d-8765-8a9c8f90ee37
+      - req-0aa9bc47-9d42-49ed-ba80-769b26bd5a1a
       Content-Length:
       - '7278'
       Connection:
@@ -5123,7 +4967,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:29.028633Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:12.461032Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5202,10 +5046,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5H_RDvUnTNq5NzWSoi9TBg"],
-        "issued_at": "2019-01-08T19:19:29.028651Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ODLR-AJIT2WU6cjivsuf1A"],
+        "issued_at": "2019-03-04T20:07:12.461049Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5220,7 +5064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fa8ebd464ca5462cb505312cf44bcdd8
+      - 91d592b028204779896b806059418984
   response:
     status:
       code: 200
@@ -5231,14 +5075,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4c7555fa-3693-44ce-a5b4-03ca22af932d
+      - req-ada53947-bb37-49a7-90b3-afcf18bacb96
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5253,7 +5097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3553739bf14c4bbd9090231bb65aabd4
+      - '07287e98ff0c4807a82215df4171cf20'
   response:
     status:
       code: 200
@@ -5264,14 +5108,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-4aebd4b1-daae-44ee-b5b6-785f731ca91c
+      - req-988f8b99-fc4c-4ba0-a569-2de81a70cd34
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5286,7 +5130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5297,9 +5141,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-3044a093-a15b-440b-a494-6f0ea4dfbac3
+      - req-5b73cc6b-eda7-4301-b333-edee09015a35
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5333,7 +5177,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5348,7 +5192,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5359,14 +5203,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-61d27304-54d3-411e-8c6f-7e83553c1b0c
+      - req-8ba715d6-55f5-4bae-9092-e5ae7f613da5
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5381,7 +5225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 14464d29a58f4acb8d55708c9c8a2683
+      - 29ab88ae56ab42c692d04ac62f97e707
   response:
     status:
       code: 200
@@ -5392,14 +5236,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-c278a48c-5694-4287-91f1-7aa1bd01328d
+      - req-88088045-5e4f-4d75-80eb-b23bc5843c82
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5414,7 +5258,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d3ec052eb24c4c259a865883cfd4d357
+      - 170f9a12f7144e2b9ddb7e3af7759c75
   response:
     status:
       code: 200
@@ -5425,14 +5269,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5bf63ffe-643e-46ba-9817-dc49a8afc1c0
+      - req-a4e5fb9b-0b79-4778-8a64-4f07e6686e3c
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5447,7 +5291,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 94b9fc43cb6c42fe9ad6f4b5bac22020
+      - 3783c26d2994484ab465f1cea0bea63b
   response:
     status:
       code: 200
@@ -5458,14 +5302,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-44dd001e-31e7-42bd-a4e3-951899834597
+      - req-53b07fb8-0b58-40e8-9f69-327e84ec030e
       Date:
-      - Tue, 08 Jan 2019 19:19:29 GMT
+      - Mon, 04 Mar 2019 20:07:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5480,7 +5324,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 81fcced73d3e4973a83bc734592da8be
+      - 107d178cfd6746ff9d63fbce4961f89f
   response:
     status:
       code: 200
@@ -5491,14 +5335,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6677852c-6b9a-4224-8c3b-ab8be927e231
+      - req-b825edfb-67bb-47bd-8779-229940936248
       Date:
-      - Tue, 08 Jan 2019 19:19:30 GMT
+      - Mon, 04 Mar 2019 20:07:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5513,7 +5357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5524,9 +5368,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-f1747197-ad3c-41a3-8059-07050377f6d0
+      - req-359fe537-aae9-4ae2-9707-87de011bd25a
       Date:
-      - Tue, 08 Jan 2019 19:19:30 GMT
+      - Mon, 04 Mar 2019 20:07:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5553,7 +5397,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5568,7 +5412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5579,9 +5423,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-8fb69cc9-8b91-4c5c-881d-a57389151c6f
+      - req-a754fd75-ad70-4fcd-973d-bb5e66b17e47
       Date:
-      - Tue, 08 Jan 2019 19:19:30 GMT
+      - Mon, 04 Mar 2019 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5608,7 +5452,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5623,7 +5467,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5634,9 +5478,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bcd9489e-5161-4136-a712-2e576cad89bc
+      - req-11933d5d-7795-4d43-a59b-bf24a284c4b1
       Date:
-      - Tue, 08 Jan 2019 19:19:30 GMT
+      - Mon, 04 Mar 2019 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5663,7 +5507,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5678,7 +5522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5689,9 +5533,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-cd53087e-1261-4b8b-a5c2-2ff5280822e4
+      - req-9d8c908a-70b1-46ce-9f2e-13c6ee900816
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5747,7 +5591,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5762,7 +5606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -5773,9 +5617,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4382e450-88fd-458b-829d-630a11421253
+      - req-669aba90-7e23-409f-8033-07051d3a1d8f
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5787,7 +5631,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3/servers/detail?limit=1000
@@ -5802,7 +5646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5815,14 +5659,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-d5a3571b-e49e-4f31-a557-3608624b523d
+      - req-09178b71-c096-4e4b-aef0-3552915ef38c
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74/servers/detail?limit=1000
@@ -5837,7 +5681,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5850,14 +5694,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-4de7721f-85ab-4b74-8f1a-aca5082887e0
+      - req-2c8b96a0-64b1-468e-b25c-c6704e3ded9b
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000
@@ -5872,7 +5716,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5885,9 +5729,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-da397e92-ba48-491f-b5b4-bc2c12932435
+      - req-80c97172-6955-4765-b7d4-68dd10d5f968
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -5933,7 +5777,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -5948,7 +5792,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5961,9 +5805,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-e04b230a-d691-4f35-8e93-09f85bb85848
+      - req-9a89284d-7ec5-43e7-a250-e1b8b490b23e
       Date:
-      - Tue, 08 Jan 2019 19:19:31 GMT
+      - Mon, 04 Mar 2019 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6009,7 +5853,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6024,7 +5868,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6037,9 +5881,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-5ec8dbf1-0644-467d-bc5c-fade8b7303ad
+      - req-6a379c0c-753d-44ab-8d33-02a2276af00a
       Date:
-      - Tue, 08 Jan 2019 19:19:32 GMT
+      - Mon, 04 Mar 2019 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6087,7 +5931,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:17 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6102,7 +5946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6115,9 +5959,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-804fa6fa-7e9f-4726-b72e-f2f1410c97ae
+      - req-6577f429-aea9-4caa-9eaf-645b43b6affd
       Date:
-      - Tue, 08 Jan 2019 19:19:32 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6159,7 +6003,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/detail?limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6174,7 +6018,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6187,9 +6031,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-6768b39d-6b20-4f1a-8778-aae99c318d3a
+      - req-92fc8fe4-f106-4f3e-97cc-de3da3298bdf
       Date:
-      - Tue, 08 Jan 2019 19:19:32 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6212,7 +6056,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5/servers/detail?limit=1000
@@ -6227,7 +6071,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6240,14 +6084,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-512e5085-7172-4ef4-b127-dc6e3c839b68
+      - req-d3ba327b-0d54-452f-9fc4-27c4acdfc79a
       Date:
-      - Tue, 08 Jan 2019 19:19:32 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?limit=1000
@@ -6262,7 +6106,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6275,14 +6119,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-1d1dd4db-bf90-4953-a3a0-72e70769b6f3
+      - req-bb3253e3-88c1-4ca6-8255-0f80bf69d17d
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23/servers/detail?limit=1000
@@ -6297,7 +6141,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6310,14 +6154,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-0928cf42-4a06-46e7-85c3-5ff663db3394
+      - req-cf66b269-bf67-4422-8bf3-80f79b0bf9e4
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/servers/detail?limit=1000
@@ -6332,7 +6176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6345,14 +6189,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-7b0bee27-709b-48a7-a0d3-75f56bf5b888
+      - req-4b0a1606-af47-4fb2-b875-9cdc94bd7c5b
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:18 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6367,7 +6211,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -6378,9 +6222,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-7587d460-539c-4a3f-a620-80f9e7cff242
+      - req-3c299013-3959-4702-83e5-1a4562017212
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6436,7 +6280,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -6451,7 +6295,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -6462,9 +6306,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b4089a4b-4b27-4d45-a6fa-483de407855c
+      - req-2f9cafc3-5b86-46aa-bb4a-714062cbdd58
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6476,7 +6320,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6491,7 +6335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -6502,9 +6346,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-2bc4dec4-61a5-4162-a5b9-42bd2cde24ab
+      - req-eca0c426-ebf9-4cbc-a16e-1e3c14d5c6fa
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6560,7 +6404,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6575,7 +6419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4328be0af5664ef99778cce225d100e8
+      - 3bb31c5791fe4fde8ba1feb952daff45
   response:
     status:
       code: 200
@@ -6586,9 +6430,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f6e1e3c8-22f9-4525-a05c-308eef0788fc
+      - req-e406ee60-dd4a-4350-9542-aef28387a26a
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6600,7 +6444,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6615,7 +6459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - be7cc0b4a4704a0aaf8d672af530d406
+      - ef21fc368fdc405aaea3dec4ed62e121
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6628,9 +6472,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b17a9e0c-2426-42a4-9737-d02001f00bd8
+      - req-b07400bf-8d7d-4bf9-a147-d5d5765d78f9
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6639,7 +6483,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -6654,7 +6498,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5958dd86f2334edcb903b3a4706785b7
+      - 92384288e4f741e5ab8bf56036843da9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6667,9 +6511,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-4cbe3e09-afb5-4ec7-bcce-1c7bc691eb2b
+      - req-d0522cf5-5f36-4b86-8890-229ad1d34548
       Date:
-      - Tue, 08 Jan 2019 19:19:33 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6678,7 +6522,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -6693,7 +6537,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6706,9 +6550,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-1a202001-4cca-4905-8818-c2ff733dc96e
+      - req-97a1e85e-81f5-442a-9a85-202dbd1efdbc
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6717,7 +6561,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -6732,7 +6576,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 413d0a852c5844d5ac3e2a745704e3da
+      - 3708846fb0a04616970210cb3f2de2c5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6745,9 +6589,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-01fab64e-e052-46bb-aaec-847323f96137
+      - req-d101ebba-31cb-419f-95e0-76b5aad11d14
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6756,7 +6600,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -6771,7 +6615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6784,9 +6628,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-7f626b64-a272-43b5-89a6-51ab26e44968
+      - req-4cba66c9-7bb0-4d80-a750-2d1c5477729c
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6795,7 +6639,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -6810,7 +6654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7003b12e7ede4ff0826f6b7238ac9dd1
+      - 94a0b85fbec44f7aa8ac2c2603e9b86d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6823,9 +6667,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3993f2ad-3620-4db5-abed-76f7273d15f8
+      - req-cfb5c754-8bdb-4cb7-9afe-4a55c59f6715
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6834,7 +6678,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6849,7 +6693,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6230ac98da2f48fc86077890e002e673
+      - 4287587034f74d799a8ffa86c639915f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,9 +6706,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-3249fe54-19f7-4e64-9a42-da4fd53a7b1d
+      - req-30a67be2-1827-4717-8686-cd1062b31d8b
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -6873,7 +6717,127 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v3/auth/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 Mar 2019 20:07:20 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Subject-Token:
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-0116674d-2190-4172-bd7f-5cf265b4c7af
+      Content-Length:
+      - '7311'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
+        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
+        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:20.340746Z", "project":
+        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
+        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
+        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
+        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
+        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
+        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
+        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
+        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
+        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
+        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
+        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
+        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
+        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
+        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
+        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
+        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
+        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
+        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
+        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
+        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
+        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
+        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
+        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
+        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
+        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
+        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
+        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
+        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
+        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
+        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
+        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
+        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
+        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
+        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
+        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
+        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XCjSQ5RsTbubPCSLB_M-rQ"],
+        "issued_at": "2019-03-04T20:07:20.340776Z"}}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6891,15 +6855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0f3e7b7-1411-4f18-9f97-3354060cc138
+      - req-39935c27-e152-4b16-b22e-187285ccd7d2
       Content-Length:
       - '7278'
       Connection:
@@ -6911,7 +6875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:34.639572Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:20.539033Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6990,10 +6954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7Ly7itt3SBusjdzsIHJEVQ"],
-        "issued_at": "2019-01-08T19:19:34.639592Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7WpP2q22TP-_jvU1TsP6-g"],
+        "issued_at": "2019-03-04T20:07:20.539050Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7011,15 +6975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59a89188-45a0-4ede-a340-651dfb52e704
+      - req-6e7dd142-193c-4c6b-8ffe-e05387d58cc5
       Content-Length:
       - '7278'
       Connection:
@@ -7031,7 +6995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:34.845736Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:20.745648Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7110,10 +7074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["L9SmqVMOTWq2cgfQD6FTXw"],
-        "issued_at": "2019-01-08T19:19:34.845753Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j4FDbJNAQEeVdtJr0siNTA"],
+        "issued_at": "2019-03-04T20:07:20.745666Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7131,15 +7095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:34 GMT
+      - Mon, 04 Mar 2019 20:07:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdec2b59-99f9-4eff-b3ea-78030572b582
+      - req-de0791c6-5040-48b0-b430-2b50abaeb0b2
       Content-Length:
       - '7264'
       Connection:
@@ -7151,7 +7115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:35.044635Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:20.975698Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7230,10 +7194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oFmf1I4xQ8WqKb4onRuKUw"],
-        "issued_at": "2019-01-08T19:19:35.044653Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0kBTuqv_QB6pQ9a6_-_KUg"],
+        "issued_at": "2019-03-04T20:07:20.975717Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:20 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7251,15 +7215,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:35 GMT
+      - Mon, 04 Mar 2019 20:07:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6149beb8-3d5c-4432-a00e-87ec50539965
+      - req-59282d71-f075-4ba9-aa89-036f1fe253b0
       Content-Length:
       - '7278'
       Connection:
@@ -7271,7 +7235,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:35.241734Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:21.194847Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7350,10 +7314,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BD3Te6TGTbOIfXAe_0-eUg"],
-        "issued_at": "2019-01-08T19:19:35.241751Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QO915nLyR3SG1BUDoQpybQ"],
+        "issued_at": "2019-03-04T20:07:21.194872Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7371,15 +7335,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:35 GMT
+      - Mon, 04 Mar 2019 20:07:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d5edb20c-5899-4df3-83ce-5dd369ba0bd3
+      - req-2252afe6-b124-4cb5-9741-9dee41f78257
       Content-Length:
       - '7265'
       Connection:
@@ -7391,7 +7355,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:35.443947Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:21.407635Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7470,10 +7434,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Unldni1jSSOyIN6mTRowCw"],
-        "issued_at": "2019-01-08T19:19:35.443964Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EwKAIccnQSGhdFuNzp6AbA"],
+        "issued_at": "2019-03-04T20:07:21.407658Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7491,15 +7455,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:35 GMT
+      - Mon, 04 Mar 2019 20:07:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-454baed7-65ce-4854-b4d6-95d472c7e4dc
+      - req-68dde797-6f87-43c8-8504-04040055c983
       Content-Length:
       - '7278'
       Connection:
@@ -7511,7 +7475,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:35.644034Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:21.621759Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7590,10 +7554,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7iBn5B-hQP-xX5NZKBxRgw"],
-        "issued_at": "2019-01-08T19:19:35.644052Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z6j7DBB7SzChvQKNfRE8ww"],
+        "issued_at": "2019-03-04T20:07:21.621792Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -7608,22 +7572,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-69b305df-1194-4b68-9c96-6aa58deb4425
+      - req-bc2397a9-388b-4a14-9c3e-0ee06a36ec8e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-69b305df-1194-4b68-9c96-6aa58deb4425
+      - req-bc2397a9-388b-4a14-9c3e-0ee06a36ec8e
       Date:
-      - Tue, 08 Jan 2019 19:19:35 GMT
+      - Mon, 04 Mar 2019 20:07:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7633,7 +7597,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -7648,22 +7612,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73c87240-c9ad-46c3-8da7-58f18c0cbe61
+      - req-06840249-6278-43bc-a144-0a47cdcc50a4
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-73c87240-c9ad-46c3-8da7-58f18c0cbe61
+      - req-06840249-6278-43bc-a144-0a47cdcc50a4
       Date:
-      - Tue, 08 Jan 2019 19:19:36 GMT
+      - Mon, 04 Mar 2019 20:07:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7673,7 +7637,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -7688,22 +7652,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a2f82855-4311-46fc-a31f-d73c126e6a28
+      - req-eda69f2d-5b48-4c79-b57d-e38dfded3ff3
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-a2f82855-4311-46fc-a31f-d73c126e6a28
+      - req-eda69f2d-5b48-4c79-b57d-e38dfded3ff3
       Date:
-      - Tue, 08 Jan 2019 19:19:36 GMT
+      - Mon, 04 Mar 2019 20:07:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7713,7 +7677,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -7728,22 +7692,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2349d411-47c9-4c97-939b-e9b1035b7674
+      - req-fa8eca02-a07f-48d7-9d8a-0d404c1cdf4b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-2349d411-47c9-4c97-939b-e9b1035b7674
+      - req-fa8eca02-a07f-48d7-9d8a-0d404c1cdf4b
       Date:
-      - Tue, 08 Jan 2019 19:19:36 GMT
+      - Mon, 04 Mar 2019 20:07:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7753,7 +7717,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -7768,22 +7732,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-226c6923-cc2d-4888-81cd-2568760b5e0e
+      - req-f1fdfdec-e072-4c88-8b12-08617cd55cf2
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-226c6923-cc2d-4888-81cd-2568760b5e0e
+      - req-f1fdfdec-e072-4c88-8b12-08617cd55cf2
       Date:
-      - Tue, 08 Jan 2019 19:19:36 GMT
+      - Mon, 04 Mar 2019 20:07:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7793,7 +7757,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -7808,22 +7772,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b568192a-5f8d-4ced-a292-34b007e84064
+      - req-3e3d925b-01f5-49b5-8477-86178df32056
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-b568192a-5f8d-4ced-a292-34b007e84064
+      - req-3e3d925b-01f5-49b5-8477-86178df32056
       Date:
-      - Tue, 08 Jan 2019 19:19:37 GMT
+      - Mon, 04 Mar 2019 20:07:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7833,7 +7797,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -7848,22 +7812,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-21829707-2533-4c33-859d-39fdf835b234
+      - req-96fdb556-cb92-4c7e-8367-8033af8b8db6
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-21829707-2533-4c33-859d-39fdf835b234
+      - req-96fdb556-cb92-4c7e-8367-8033af8b8db6
       Date:
-      - Tue, 08 Jan 2019 19:19:37 GMT
+      - Mon, 04 Mar 2019 20:07:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -7873,7 +7837,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7891,15 +7855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:37 GMT
+      - Mon, 04 Mar 2019 20:07:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 934c9c5f9110456da4651316477d6c00
+      - 865866197f684d96abf3c151013bfa81
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-25b74cc3-36ac-4845-861c-3093c68955f3
+      - req-0c9d47b6-fa3c-4061-9b6d-2c2ecadf3f4c
       Content-Length:
       - '7311'
       Connection:
@@ -7911,7 +7875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:37.563816Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:24.417752Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7990,10 +7954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mgIQ8WXPRjunhxaRSaqCBg"],
-        "issued_at": "2019-01-08T19:19:37.563835Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qM3YWtOfTU-TXeZQ6jtM3w"],
+        "issued_at": "2019-03-04T20:07:24.417782Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8011,15 +7975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:37 GMT
+      - Mon, 04 Mar 2019 20:07:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - abf866985c314561a01f7cb143b716c4
+      - 9ce616d12b6d419b8dec2e80230e39d2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d840cc45-016f-4140-82b7-e52eecd46c98
+      - req-eb356b42-f2bc-4f00-9183-b29f83ca7f40
       Content-Length:
       - '7278'
       Connection:
@@ -8031,7 +7995,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:37.766568Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:24.620872Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8110,10 +8074,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WjQrL_x5T2GtD6iFh8U8bA"],
-        "issued_at": "2019-01-08T19:19:37.766588Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HgeBxQUCR-yg6HTzWuAB_w"],
+        "issued_at": "2019-03-04T20:07:24.620890Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8131,15 +8095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:37 GMT
+      - Mon, 04 Mar 2019 20:07:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 15e1150c6e0946288677e9ca61d0cab9
+      - 932892a3625947b58a1d6e649a93b5ed
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5d75d98d-45c4-4638-aff0-9056e9966241
+      - req-608a3184-f0e9-4d60-b3d6-429ba4ea83bd
       Content-Length:
       - '7278'
       Connection:
@@ -8151,7 +8115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:37.976177Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:24.828882Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8230,10 +8194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["W74RDfAQQvKsVvbtZgvEww"],
-        "issued_at": "2019-01-08T19:19:37.976195Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["cV77f54DTUmpmGUHcq5cXQ"],
+        "issued_at": "2019-03-04T20:07:24.828901Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8251,15 +8215,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:38 GMT
+      - Mon, 04 Mar 2019 20:07:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6e9bf3793595452385f1e268dc05579b
+      - c1cebbcc4fed434183908e70f56d65d0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-38dbf560-06c6-4fd1-b6be-ee57ef3cf569
+      - req-862e6af9-5fae-4de9-bcf0-1987e7a85da1
       Content-Length:
       - '7264'
       Connection:
@@ -8271,7 +8235,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:38.173593Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:25.042684Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8350,10 +8314,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["LsYe6w7YTki_Llfac_BIfA"],
-        "issued_at": "2019-01-08T19:19:38.173611Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TdvWlymVRXibNK7PdwP-Ww"],
+        "issued_at": "2019-03-04T20:07:25.042703Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8371,15 +8335,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:38 GMT
+      - Mon, 04 Mar 2019 20:07:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ce276f958f1a45c6a3a2862293afe51e
+      - a874425bd5d64e0db880eca6bbd0bf42
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-48a6ec79-2f86-498d-9197-488d82ebb4bc
+      - req-7df87790-1eca-4239-9586-49c6ca3645a0
       Content-Length:
       - '7278'
       Connection:
@@ -8391,7 +8355,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:38.367792Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:25.252136Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8470,10 +8434,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nJz47YB_RN6yPSgLagtCKQ"],
-        "issued_at": "2019-01-08T19:19:38.367810Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yh9GnkcSRtSLvmA7v3XXcg"],
+        "issued_at": "2019-03-04T20:07:25.252154Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8491,15 +8455,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:38 GMT
+      - Mon, 04 Mar 2019 20:07:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bf0b895057de46e6b40b61d7e1f5efee
+      - c24469696e74485cb687f96a34cffd26
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa975650-6dce-4d96-bd59-e6045fbbc00c
+      - req-dcacaee4-38ae-4fdd-9bdf-c7aa44ddc8a3
       Content-Length:
       - '7265'
       Connection:
@@ -8511,7 +8475,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:38.577445Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:25.471996Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8590,10 +8554,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Rr6PQnM7QvietAEIvoYX6A"],
-        "issued_at": "2019-01-08T19:19:38.577464Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Age2IhprQIq01AgHcvFguA"],
+        "issued_at": "2019-03-04T20:07:25.472014Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8611,15 +8575,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6e0b269f5f744d4e84340364af6e0b11
+      - 65b30d5a35404ce1be601bfb3ed4f4f0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aa0e94e2-851d-4ea4-b6c9-8f530840e72d
+      - req-33904fbb-2f41-4885-a53e-d6cc09ed09dc
       Content-Length:
       - '7278'
       Connection:
@@ -8631,7 +8595,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:39.149452Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:25.681094Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8710,10 +8674,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zI3zXhaITZ2nfbrswG8r6g"],
-        "issued_at": "2019-01-08T19:19:39.149471Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xcaKRrD7SxCyErX7x7E4Lw"],
+        "issued_at": "2019-03-04T20:07:25.681112Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -8728,7 +8692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - abf866985c314561a01f7cb143b716c4
+      - 9ce616d12b6d419b8dec2e80230e39d2
   response:
     status:
       code: 200
@@ -8739,16 +8703,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b1214d69-d363-435e-8fc4-5ba3a31c738d
+      - req-e69c79dc-658c-48f7-85e3-e033a6ad85dd
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -8763,7 +8727,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 15e1150c6e0946288677e9ca61d0cab9
+      - 932892a3625947b58a1d6e649a93b5ed
   response:
     status:
       code: 200
@@ -8774,16 +8738,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d6ceefa0-3ee6-4b74-aaa3-aed787da1956
+      - req-c04fc0d4-12d4-46e6-ba4c-d0e422af6dca
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -8798,7 +8762,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e9bf3793595452385f1e268dc05579b
+      - c1cebbcc4fed434183908e70f56d65d0
   response:
     status:
       code: 200
@@ -8809,16 +8773,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7abf4f07-e0fe-4737-8363-8e4fb11a301c
+      - req-1b3ce7d6-23eb-44cd-a145-3988f39d6ed0
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -8833,7 +8797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ce276f958f1a45c6a3a2862293afe51e
+      - a874425bd5d64e0db880eca6bbd0bf42
   response:
     status:
       code: 200
@@ -8844,16 +8808,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-60f0b5d0-6801-4003-8114-05993469629e
+      - req-73351a4a-d64c-4c28-8a73-15e6ad4b32e1
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -8868,7 +8832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 934c9c5f9110456da4651316477d6c00
+      - 865866197f684d96abf3c151013bfa81
   response:
     status:
       code: 200
@@ -8879,16 +8843,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-bfb3103c-cd21-4c5b-a8d9-f1766e5db336
+      - req-a4e598e8-580a-49e1-8db5-fa7a2398ebf8
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -8903,7 +8867,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf0b895057de46e6b40b61d7e1f5efee
+      - c24469696e74485cb687f96a34cffd26
   response:
     status:
       code: 200
@@ -8914,16 +8878,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ca4a50f2-f832-4c85-92cc-693c8993690d
+      - req-99b61be1-fbd2-40b7-98dc-b02bee7900a6
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -8938,7 +8902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6e0b269f5f744d4e84340364af6e0b11
+      - 65b30d5a35404ce1be601bfb3ed4f4f0
   response:
     status:
       code: 200
@@ -8949,16 +8913,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9d718133-8595-404a-96ef-6ab9a141bdfb
+      - req-a7288586-6e59-47ff-96a9-4243611440af
       Date:
-      - Tue, 08 Jan 2019 19:19:39 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -8973,7 +8937,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -8986,15 +8950,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-e446deb1-f50b-4c75-82cb-2df32abb04e6
+      - req-47160f1e-dd81-48f8-99b6-d346c597d165
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -9009,7 +8973,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 525527faf278436e8230e25a940fd7ed
+      - f891e6d45875454390714d6e349f55be
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9022,15 +8986,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-6599f3d6-3759-4291-9030-07e60b094faf
+      - req-74e9a682-e7b3-4d62-8744-112e5612fc89
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9048,15 +9012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 65124a0897394e7ba6971843147735d2
+      - ca786a7cc4974c8da63630ce61edc3b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2180f656-5c33-4778-836f-b846003cd58f
+      - req-ce02af40-89e3-4bae-a394-0e5624ede08c
       Content-Length:
       - '7311'
       Connection:
@@ -9068,7 +9032,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:40.478369Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:26.987694Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9147,10 +9111,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SWUhNpP4SIiHtIZGYl_Q8A"],
-        "issued_at": "2019-01-08T19:19:40.478393Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["isH9gKb8RG-nFScWio0Gxw"],
+        "issued_at": "2019-03-04T20:07:26.987719Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9168,15 +9132,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1fa0016f893c440991d26aa558572f9e
+      - 7af13c2ff7df4c93b42a05ecb0764e95
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cf3e309a-3ef2-4939-b087-9cfe25d77aa9
+      - req-47d8d793-ba76-45b2-81d1-70c501a2f10a
       Content-Length:
       - '7311'
       Connection:
@@ -9188,7 +9152,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:40.680644Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:27.220162Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9267,10 +9231,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wnXh1kKeS_O6bamMPsQSUw"],
-        "issued_at": "2019-01-08T19:19:40.680663Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4hzqThetSFKG92BTov4vSA"],
+        "issued_at": "2019-03-04T20:07:27.220181Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -9285,7 +9249,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4cf592d7af0474d83861403d542d85f
+      - 97e5f5e6a6474506bdf2651dfa99c2d1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -9298,14 +9262,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-44a6d2fe-9f55-4151-8b04-4003bf69179c
+      - req-24452663-c912-4532-ab8d-3d3bbac5eb0c
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000&status=available
@@ -9320,27 +9284,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8f5964e-2cdf-4713-bc49-48644e2ebe4c
+      - req-4b4b749c-1b28-4dc5-8ff1-285e04877bc9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f8f5964e-2cdf-4713-bc49-48644e2ebe4c
+      - req-4b4b749c-1b28-4dc5-8ff1-285e04877bc9
       Date:
-      - Tue, 08 Jan 2019 19:19:40 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000&status=available
@@ -9355,27 +9319,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6b52033d-3aff-45b8-a358-98234a83e810
+      - req-3820b3c7-7bba-41a0-8d03-af85a3403911
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6b52033d-3aff-45b8-a358-98234a83e810
+      - req-3820b3c7-7bba-41a0-8d03-af85a3403911
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available
@@ -9390,22 +9354,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68c87e11-45dd-49b3-9efd-b766ff5263ca
+      - req-c0282016-6c80-4429-b3af-e1ac794da26e
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-68c87e11-45dd-49b3-9efd-b766ff5263ca
+      - req-c0282016-6c80-4429-b3af-e1ac794da26e
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -9438,7 +9402,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -9453,22 +9417,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-96e78362-9391-46ff-99fc-aa8b57c92abb
+      - req-f6aa8d05-0713-496f-b86e-a4c54b0c84e9
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-96e78362-9391-46ff-99fc-aa8b57c92abb
+      - req-f6aa8d05-0713-496f-b86e-a4c54b0c84e9
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -9485,7 +9449,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000&status=available
@@ -9500,27 +9464,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-54e7777c-aefe-437f-9956-f7b69ef18570
+      - req-b9a491a2-3e11-4360-a0ab-957ac5aacfed
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-54e7777c-aefe-437f-9956-f7b69ef18570
+      - req-b9a491a2-3e11-4360-a0ab-957ac5aacfed
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000&status=available
@@ -9535,27 +9499,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7dd234d8-9480-4f3f-8eb5-7d46b80df9dd
+      - req-2846de2f-9360-4891-becf-004045e27593
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7dd234d8-9480-4f3f-8eb5-7d46b80df9dd
+      - req-2846de2f-9360-4891-becf-004045e27593
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000&status=available
@@ -9570,27 +9534,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cc8f0db8-954b-4bc9-891d-9c2f0166ad81
+      - req-f6d23437-119e-41d4-a042-bf3a7d18c094
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cc8f0db8-954b-4bc9-891d-9c2f0166ad81
+      - req-f6d23437-119e-41d4-a042-bf3a7d18c094
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000&status=available
@@ -9605,27 +9569,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-98386108-1a7c-4129-9ab6-3f90953c21cd
+      - req-7057ee2e-24ae-4d84-833e-e6f8ba8c44c9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-98386108-1a7c-4129-9ab6-3f90953c21cd
+      - req-7057ee2e-24ae-4d84-833e-e6f8ba8c44c9
       Date:
-      - Tue, 08 Jan 2019 19:19:41 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -9640,27 +9604,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab09212b-107f-46ae-9ed6-f4105d6c7185
+      - req-c27d280a-d2fb-4fef-ad7f-023ceaa42bde
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ab09212b-107f-46ae-9ed6-f4105d6c7185
+      - req-c27d280a-d2fb-4fef-ad7f-023ceaa42bde
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000&status=available
@@ -9675,27 +9639,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f00edabb-1172-4f02-ba41-43368a8d0c59
+      - req-e20a8a1f-d247-4fa8-ad10-7685921cff3b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f00edabb-1172-4f02-ba41-43368a8d0c59
+      - req-e20a8a1f-d247-4fa8-ad10-7685921cff3b
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -9710,27 +9674,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19b1d7a5-fa1c-4fe9-83d7-f71854bac144
+      - req-206f17a4-1440-41d2-bad5-e84c14cf56f7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-19b1d7a5-fa1c-4fe9-83d7-f71854bac144
+      - req-206f17a4-1440-41d2-bad5-e84c14cf56f7
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000&status=available
@@ -9745,27 +9709,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb43fbee-8fec-430d-a2fa-ee72338571bc
+      - req-9b7a61a8-cd11-43f5-be11-2cce5cacf4f5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fb43fbee-8fec-430d-a2fa-ee72338571bc
+      - req-9b7a61a8-cd11-43f5-be11-2cce5cacf4f5
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -9780,22 +9744,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-af8f7f2e-429b-4e97-b11f-d6e8baec3cd5
+      - req-05f51216-081b-4875-810a-4f7d639eed28
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-af8f7f2e-429b-4e97-b11f-d6e8baec3cd5
+      - req-05f51216-081b-4875-810a-4f7d639eed28
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -9810,7 +9774,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available
@@ -9825,22 +9789,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-843b7f3a-fc61-4192-9a3e-78a11bf165e6
+      - req-aa5f7b16-5531-4771-92ec-26478f7a666b
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-843b7f3a-fc61-4192-9a3e-78a11bf165e6
+      - req-aa5f7b16-5531-4771-92ec-26478f7a666b
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -9855,7 +9819,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -9870,27 +9834,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-10c524bd-8106-4954-91d7-2b64ef7e7dbd
+      - req-edb56671-1d29-4e16-b518-87c936189849
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-10c524bd-8106-4954-91d7-2b64ef7e7dbd
+      - req-edb56671-1d29-4e16-b518-87c936189849
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000&status=available
@@ -9905,27 +9869,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0b9bdd55-18ad-4d70-8453-f26b532fb163
+      - req-8c2d3aab-9912-4187-8836-f2da69f19528
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0b9bdd55-18ad-4d70-8453-f26b532fb163
+      - req-8c2d3aab-9912-4187-8836-f2da69f19528
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -9940,27 +9904,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-87625c0d-3227-4fba-8c6e-4ab9e5ec70d9
+      - req-64661588-6058-4a97-a8ce-9265fa15e14c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-87625c0d-3227-4fba-8c6e-4ab9e5ec70d9
+      - req-64661588-6058-4a97-a8ce-9265fa15e14c
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000&status=available
@@ -9975,27 +9939,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7175ab70-43ab-49e0-a638-f90fa1bedbed
+      - req-ff5a5954-6b17-46ad-8081-c1221daf494f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7175ab70-43ab-49e0-a638-f90fa1bedbed
+      - req-ff5a5954-6b17-46ad-8081-c1221daf494f
       Date:
-      - Tue, 08 Jan 2019 19:19:42 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -10010,27 +9974,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0d496a9a-ada6-479a-9922-ba7c677f82ea
+      - req-de1ec983-af2f-451c-aefe-111254528708
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-0d496a9a-ada6-479a-9922-ba7c677f82ea
+      - req-de1ec983-af2f-451c-aefe-111254528708
       Date:
-      - Tue, 08 Jan 2019 19:19:43 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000&status=available
@@ -10045,27 +10009,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-897e74fd-aa32-4629-9526-d11decf17e6a
+      - req-2612661b-6fae-4462-8822-fb7f9427e5d0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-897e74fd-aa32-4629-9526-d11decf17e6a
+      - req-2612661b-6fae-4462-8822-fb7f9427e5d0
       Date:
-      - Tue, 08 Jan 2019 19:19:44 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -10080,27 +10044,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-071a8597-f809-43c6-91cc-0ae6b34acb93
+      - req-2fa96c05-542f-4b1f-95dd-3c57475d856c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-071a8597-f809-43c6-91cc-0ae6b34acb93
+      - req-2fa96c05-542f-4b1f-95dd-3c57475d856c
       Date:
-      - Tue, 08 Jan 2019 19:19:44 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000&status=available
@@ -10115,27 +10079,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2199a117-e1e2-479d-8198-4156da076fe0
+      - req-41b249d3-c9d1-4ee3-949b-b3d7aa0c8acd
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2199a117-e1e2-479d-8198-4156da076fe0
+      - req-41b249d3-c9d1-4ee3-949b-b3d7aa0c8acd
       Date:
-      - Tue, 08 Jan 2019 19:19:44 GMT
+      - Mon, 04 Mar 2019 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10150,27 +10114,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8950320902ea421e822eb253aa547172
+      - 7820b2968d404fb58ec7f163cfce4ea3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-824ee458-83e1-468b-b999-cd822a515048
+      - req-5d6d774a-2bfe-4c3b-bf4c-5d6d62481e19
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-824ee458-83e1-468b-b999-cd822a515048
+      - req-5d6d774a-2bfe-4c3b-bf4c-5d6d62481e19
       Date:
-      - Tue, 08 Jan 2019 19:19:44 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10185,27 +10149,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7b129d74d75e41e7a9628a12bf7c408c
+      - a31afe5f2f3e4c049df9d9d5e56828b9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4e916b55-6880-402b-af92-eb7959cc9bdf
+      - req-213e2832-c3dc-47b2-bd26-6160712a499e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4e916b55-6880-402b-af92-eb7959cc9bdf
+      - req-213e2832-c3dc-47b2-bd26-6160712a499e
       Date:
-      - Tue, 08 Jan 2019 19:19:44 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10220,22 +10184,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-74c5906f-f0c1-4c56-bbae-4eb1737ccc65
+      - req-f0b11400-096b-4efb-be65-91d75345f536
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-74c5906f-f0c1-4c56-bbae-4eb1737ccc65
+      - req-f0b11400-096b-4efb-be65-91d75345f536
       Date:
-      - Tue, 08 Jan 2019 19:19:45 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10268,7 +10232,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10283,22 +10247,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7924a179-2b58-401d-836d-416f75f15d16
+      - req-ebc5af07-678f-45bb-af94-a4f6d4c96e28
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-7924a179-2b58-401d-836d-416f75f15d16
+      - req-ebc5af07-678f-45bb-af94-a4f6d4c96e28
       Date:
-      - Tue, 08 Jan 2019 19:19:46 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -10339,7 +10303,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -10354,22 +10318,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f78dd71b-66ad-495b-a462-4f29b33cdcd6
+      - req-8f3a6f6a-7224-4270-9f99-d9a9c2d43ea8
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-f78dd71b-66ad-495b-a462-4f29b33cdcd6
+      - req-8f3a6f6a-7224-4270-9f99-d9a9c2d43ea8
       Date:
-      - Tue, 08 Jan 2019 19:19:46 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -10403,7 +10367,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -10418,27 +10382,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b2ac284854741baa0b53ed4688fcecd
+      - 37e0ecb2a01d4260a25712343e399f38
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1bae3f90-a5d6-40f2-bf6a-aef2dd49e431
+      - req-edc66d19-c61a-41c6-bd83-ee97a3aed1bc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1bae3f90-a5d6-40f2-bf6a-aef2dd49e431
+      - req-edc66d19-c61a-41c6-bd83-ee97a3aed1bc
       Date:
-      - Tue, 08 Jan 2019 19:19:46 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -10453,27 +10417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9660263abd194bae82fbf9378b985184
+      - 7db6ca52265e4c30be3f040d9296df36
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cd8138db-dfa7-461a-99be-9da438e54388
+      - req-7a73cd1f-5631-48a7-8eab-eabe58672a87
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cd8138db-dfa7-461a-99be-9da438e54388
+      - req-7a73cd1f-5631-48a7-8eab-eabe58672a87
       Date:
-      - Tue, 08 Jan 2019 19:19:46 GMT
+      - Mon, 04 Mar 2019 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -10488,27 +10452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b99cbef9f7e4fbc81af90a1a3cb46b1
+      - 24ae231d2bde4df0b0fe0ab2ce93474b
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-178af25e-b53b-42f0-ad00-53065d1ec72e
+      - req-9ba89330-deb4-4184-90f4-f8591dd30abb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-178af25e-b53b-42f0-ad00-53065d1ec72e
+      - req-9ba89330-deb4-4184-90f4-f8591dd30abb
       Date:
-      - Tue, 08 Jan 2019 19:19:46 GMT
+      - Mon, 04 Mar 2019 20:07:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -10523,27 +10487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25a8c7af6a2c432588ccb66dbd65a67b
+      - afb1ecd9ac544561927b8b4b48527132
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b8cdf055-a682-408f-896e-9c99c2aafa10
+      - req-b36d258e-2243-4b75-802a-ae64345ddfd8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b8cdf055-a682-408f-896e-9c99c2aafa10
+      - req-b36d258e-2243-4b75-802a-ae64345ddfd8
       Date:
-      - Tue, 08 Jan 2019 19:19:47 GMT
+      - Mon, 04 Mar 2019 20:07:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -10558,27 +10522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e8ea6d596c634b33a8825548ab47d7fe
+      - d7a9fcaf8c0c48d99b79f31c09c4a63c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a4080159-aa61-40b8-bca2-c55e1c2be769
+      - req-9fecc350-01a2-4fb3-bd78-ca9d454d7158
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a4080159-aa61-40b8-bca2-c55e1c2be769
+      - req-9fecc350-01a2-4fb3-bd78-ca9d454d7158
       Date:
-      - Tue, 08 Jan 2019 19:19:47 GMT
+      - Mon, 04 Mar 2019 20:07:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10596,15 +10560,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:48 GMT
+      - Mon, 04 Mar 2019 20:07:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2d99f405963d42d485c851a32cefc54b
+      - 1086d5ca7b1f43a69e6346bb8dc8d538
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d72f4284-90e7-42db-aafa-0da85bdf6986
+      - req-f2f82b45-0246-4880-95d4-73e72fc5e052
       Content-Length:
       - '7311'
       Connection:
@@ -10616,7 +10580,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:48.655312Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:32.696579Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10695,10 +10659,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["n9KB61cQSaapefC3w4gtqQ"],
-        "issued_at": "2019-01-08T19:19:48.655331Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iDyn367qQ5aB2jrzk2uN8w"],
+        "issued_at": "2019-03-04T20:07:32.696598Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10716,15 +10680,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:48 GMT
+      - Mon, 04 Mar 2019 20:07:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d6f15e2d-ed8f-4f05-bb87-1339cb2bd5d3
+      - req-23b1c702-f58d-492d-809a-7dcae8ce292d
       Content-Length:
       - '7311'
       Connection:
@@ -10736,7 +10700,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:48.859359Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:32.913931Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10815,10 +10779,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TADCWLF5SxeKwZHAk0R1kA"],
-        "issued_at": "2019-01-08T19:19:48.859376Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RxfsrIoySGOMf5W2ewyeSA"],
+        "issued_at": "2019-03-04T20:07:32.913953Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -10833,7 +10797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -10844,37 +10808,22 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-15906111-ef53-4a46-a0a2-99cac2769dae
+      - req-abfab999-95ed-4141-9e99-758bfe96eb8e
       Date:
-      - Tue, 08 Jan 2019 19:19:49 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
-        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
-        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
-        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        13}, {"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
         "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -10909,14 +10858,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
+        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+        "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "3be7c490-3820-43ad-8bc4-00d0367b8d21"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "91eed80f-14a3-41a1-8acb-558dd451ecec", "provider:segmentation_id":
+        59}, {"status": "ACTIVE", "subnets": ["75e7a9c8-eeaf-4cd0-80da-05165f897e69"],
+        "name": "EmsRefreshSpec-NetworkPublic_10", "provider:physical_network": "public_net_1",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10934,15 +10898,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:52 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1b111d09528f40eb850d25ac634a2490
+      - d6c565b6626c46c5a45bdd3168562a7a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-74fa90a0-001a-4841-83f0-266801198504
+      - req-fc141e27-a192-47d6-8203-7cabd561b2c4
       Content-Length:
       - '7311'
       Connection:
@@ -10954,7 +10918,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:19:53.030706Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:33.282207Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11033,10 +10997,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5dS6uLgnQMucb0NzRiui-Q"],
-        "issued_at": "2019-01-08T19:19:53.030724Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xag0oUVBQCawzT_nB-vO3A"],
+        "issued_at": "2019-03-04T20:07:33.282227Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11054,15 +11018,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:54 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 05c1d2fb0def49e5b828f84e1dbd9cd1
+      - edd0f2b51b5c432c9315d340191a8d4c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-459eab57-904b-4171-964c-b9d572f1b65f
+      - req-6564be44-c981-41c5-a592-81fde01922d0
       Content-Length:
       - '297'
       Connection:
@@ -11071,12 +11035,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:19:54.256176Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:07:33.452572Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qb7VVAhuT82BjQyIdCzHjQ"],
-        "issued_at": "2019-01-08T19:19:54.256195Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_o8kqEauRFyJPl-AligNzw"],
+        "issued_at": "2019-03-04T20:07:33.452590Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:33 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -11091,20 +11055,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05c1d2fb0def49e5b828f84e1dbd9cd1
+      - edd0f2b51b5c432c9315d340191a8d4c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:54 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8704b5f4-39f1-4d9a-8a68-cab782f343f0
+      - req-0c0db29d-1be1-48b1-b046-1f8659a2c8cc
       Content-Length:
       - '2475'
       Connection:
@@ -11137,7 +11101,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11155,15 +11119,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:54 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eee7a397727c45a9acb3bed1a4c4c85b
+      - fb5df10c2918448f9312d53fc00cc51b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-69be5c34-7e1a-4da0-8d11-3e018ab32c36
+      - req-80e69e16-910a-413e-a38d-59802ecc0b30
       Content-Length:
       - '7278'
       Connection:
@@ -11175,7 +11139,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:54.599388Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:33.804800Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11254,10 +11218,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bOTW0h3SRnq_PAfsbGIbaA"],
-        "issued_at": "2019-01-08T19:19:54.599407Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2M2lgbs1S2CwgNt-wQQBWQ"],
+        "issued_at": "2019-03-04T20:07:33.804819Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11275,15 +11239,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:54 GMT
+      - Mon, 04 Mar 2019 20:07:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - faedac9a8eb44c8693fbf5afe09fc86d
+      - b3e94a0a787a45678d8f68bd72631485
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d617d7e3-f1fc-4f06-bca3-f71a145714c6
+      - req-83ac487b-a10a-45cc-921a-dfcd09bef900
       Content-Length:
       - '7278'
       Connection:
@@ -11295,7 +11259,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:54.813690Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:34.007036Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11374,10 +11338,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VqCGsPNhRGalDMpWN4KwJw"],
-        "issued_at": "2019-01-08T19:19:54.813709Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jve42vjNRd6pGDUhH0pFCw"],
+        "issued_at": "2019-03-04T20:07:34.007054Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11395,15 +11359,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:54 GMT
+      - Mon, 04 Mar 2019 20:07:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-49c45e98-0ff9-4be6-b229-fe601a33a226
+      - req-6aa87e21-9d79-4cea-98cb-8bddf3498928
       Content-Length:
       - '7264'
       Connection:
@@ -11415,7 +11379,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:55.020030Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:34.206839Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11494,10 +11458,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["yUVz4CFdQBi8uVRqOZP25A"],
-        "issued_at": "2019-01-08T19:19:55.020048Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_hvB4qlZSQW0wANcj_XvsA"],
+        "issued_at": "2019-03-04T20:07:34.206858Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11515,15 +11479,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:55 GMT
+      - Mon, 04 Mar 2019 20:07:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d02e21c930b347298ab26f82b398b036
+      - 3e2b7556f4074e938be4426af065e2cc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-26bfda42-15af-4d79-938b-77cd6a9d51e2
+      - req-dcf167d3-39b4-407a-b51b-8896d43fb444
       Content-Length:
       - '7278'
       Connection:
@@ -11535,7 +11499,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:55.226573Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:34.409761Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11614,10 +11578,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DCqHetCOT1CSylOXzazORA"],
-        "issued_at": "2019-01-08T19:19:55.226590Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WSHSL67lR_W3P2LaaKytEg"],
+        "issued_at": "2019-03-04T20:07:34.409790Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11635,15 +11599,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:55 GMT
+      - Mon, 04 Mar 2019 20:07:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f294f5eb8ea24652bb63aab5b1d0eac9
+      - 5835c282f1774549958423ca0931c99a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ffefefb2-34d9-4a48-a6f2-fb0764facf86
+      - req-68554fa3-3159-4288-9cb3-32bf8716c850
       Content-Length:
       - '7265'
       Connection:
@@ -11655,7 +11619,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:55.499086Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:34.604425Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11734,10 +11698,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aTTvt-EgQ1OhTdk1QnxCVA"],
-        "issued_at": "2019-01-08T19:19:55.499104Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["G45zMpS6T1ywbSMu897ruQ"],
+        "issued_at": "2019-03-04T20:07:34.604443Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11755,15 +11719,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 286b36c5b1f747499652bb271f60efa6
+      - 84c76a99b7334623b72a4101962c7e6c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-83c7c774-8047-4727-b2db-91d1ec0cd368
+      - req-21db7fcf-5388-4672-9c8b-701701e29f75
       Content-Length:
       - '7278'
       Connection:
@@ -11775,7 +11739,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:56.152345Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:34.811917Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11854,10 +11818,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["djiEuBBZSWyq_aVb5TDCZg"],
-        "issued_at": "2019-01-08T19:19:56.152373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KeUz_ncHQ1S6PKaMXBAHug"],
+        "issued_at": "2019-03-04T20:07:34.811936Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -11872,7 +11836,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eee7a397727c45a9acb3bed1a4c4c85b
+      - fb5df10c2918448f9312d53fc00cc51b
   response:
     status:
       code: 200
@@ -11883,14 +11847,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a35c279f-4095-440e-b148-66989fa1f17f
+      - req-0fbbe2f9-55ca-40d7-a5b7-5cdf9be260a2
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -11905,7 +11869,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - faedac9a8eb44c8693fbf5afe09fc86d
+      - b3e94a0a787a45678d8f68bd72631485
   response:
     status:
       code: 200
@@ -11916,14 +11880,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b4ddc4f4-aa76-4434-823f-5774f44a1872
+      - req-1d02a994-81c5-4bf4-86db-437e3c991bac
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -11938,7 +11902,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -11949,9 +11913,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-57a224a2-ce53-4160-b2c0-aa06945fb54d
+      - req-fcca9aca-8882-49ff-bc05-a508ce3872fa
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -11985,7 +11949,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -12000,7 +11964,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12011,14 +11975,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bb7679b8-fcfb-4631-89cd-589854f7f8ce
+      - req-ab2aee26-3cb0-467d-bcdf-b3729563a129
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -12033,7 +11997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d02e21c930b347298ab26f82b398b036
+      - 3e2b7556f4074e938be4426af065e2cc
   response:
     status:
       code: 200
@@ -12044,14 +12008,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-732ffa67-ae9a-4855-902e-2dd860187265
+      - req-ccc2e8a3-1a37-4e58-93d8-e1ee5d8067e0
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -12066,7 +12030,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1b111d09528f40eb850d25ac634a2490
+      - d6c565b6626c46c5a45bdd3168562a7a
   response:
     status:
       code: 200
@@ -12077,14 +12041,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d08e1f29-c431-4880-bac5-5b15c8f90dd5
+      - req-8233bf85-fea1-43ef-8fed-ff98bd7b31aa
       Date:
-      - Tue, 08 Jan 2019 19:19:56 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -12099,7 +12063,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f294f5eb8ea24652bb63aab5b1d0eac9
+      - 5835c282f1774549958423ca0931c99a
   response:
     status:
       code: 200
@@ -12110,14 +12074,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3bf52a65-4018-465c-8e63-86ed0f0c2edb
+      - req-3fea278d-5e72-4d65-ae10-aebb71bab19e
       Date:
-      - Tue, 08 Jan 2019 19:19:57 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -12132,7 +12096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 286b36c5b1f747499652bb271f60efa6
+      - 84c76a99b7334623b72a4101962c7e6c
   response:
     status:
       code: 200
@@ -12143,14 +12107,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-a28f3a0e-2f22-4eb1-ab10-b7e24f01dd88
+      - req-d8d18cbc-0190-41d7-b279-7f7cce862f66
       Date:
-      - Tue, 08 Jan 2019 19:19:57 GMT
+      - Mon, 04 Mar 2019 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -12165,7 +12129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12176,9 +12140,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-e1917098-dc85-41e0-9c4c-6f9de387d293
+      - req-5e72c70f-644e-4629-93d1-ee29b9805f69
       Date:
-      - Tue, 08 Jan 2019 19:19:57 GMT
+      - Mon, 04 Mar 2019 20:07:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12205,7 +12169,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -12220,7 +12184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12231,9 +12195,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-73ff67ea-91ba-4e26-a46e-91e2734bdcf6
+      - req-5bd7bb32-846e-4505-9447-50a3137eafcf
       Date:
-      - Tue, 08 Jan 2019 19:19:57 GMT
+      - Mon, 04 Mar 2019 20:07:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12260,7 +12224,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -12275,7 +12239,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12286,9 +12250,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b6cc0a57-e784-498d-a1a7-3d1a94b499a0
+      - req-b92dcfef-9f10-4b74-b07b-64e1eed2ac57
       Date:
-      - Tue, 08 Jan 2019 19:19:58 GMT
+      - Mon, 04 Mar 2019 20:07:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -12315,7 +12279,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -12330,7 +12294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12341,9 +12305,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-fe20379d-eb86-434b-8f68-592ad3d871f7
+      - req-1e856d82-2b21-4bf7-aecd-e5465584ba13
       Date:
-      - Tue, 08 Jan 2019 19:19:58 GMT
+      - Mon, 04 Mar 2019 20:07:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12355,7 +12319,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -12370,7 +12334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12381,9 +12345,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-622153cb-dcfa-4bf0-a183-ef3df8174e97
+      - req-8e315894-b97c-4f22-8c1a-d4ae3540de56
       Date:
-      - Tue, 08 Jan 2019 19:19:58 GMT
+      - Mon, 04 Mar 2019 20:07:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12395,7 +12359,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -12410,7 +12374,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - febd837cfe874e6a8d73ef139abeba74
+      - 3da18a01fbae4e77ab1c1b859fe83c5b
   response:
     status:
       code: 200
@@ -12421,9 +12385,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-f01c2622-7852-4189-b59d-409cfea312ac
+      - req-27ff5320-56f0-4f1b-bca4-55314df72b01
       Date:
-      - Tue, 08 Jan 2019 19:19:58 GMT
+      - Mon, 04 Mar 2019 20:07:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -12435,7 +12399,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12453,15 +12417,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:59 GMT
+      - Mon, 04 Mar 2019 20:07:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6287847b-13a6-4ded-b30b-6465af029233
+      - req-6cd480b9-cdef-4ab4-989b-6854cd100eb9
       Content-Length:
       - '7278'
       Connection:
@@ -12473,7 +12437,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:59.097554Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:37.277252Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12552,10 +12516,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H2di4f83ScWaNM2XmJVsuQ"],
-        "issued_at": "2019-01-08T19:19:59.097573Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Hgimo9aCR0qpo6rgHJM7Ug"],
+        "issued_at": "2019-03-04T20:07:37.277271Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12573,15 +12537,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:59 GMT
+      - Mon, 04 Mar 2019 20:07:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ca48ff9c-7ae1-4a11-bdfc-4b7becebf56c
+      - req-8f6e8f0f-c91e-403a-a47f-4844d34b1474
       Content-Length:
       - '7278'
       Connection:
@@ -12593,7 +12557,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:59.305534Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:37.481440Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12672,10 +12636,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CqFfa5sGRsidyD6q9Y4mJg"],
-        "issued_at": "2019-01-08T19:19:59.305552Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["34D9BWONTQ2_a_opBY8Owg"],
+        "issued_at": "2019-03-04T20:07:37.481459Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12693,15 +12657,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:59 GMT
+      - Mon, 04 Mar 2019 20:07:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5db2c692-b950-4a1b-a81a-d4bb19975812
+      - req-94afef56-e276-43e9-a39f-9d2e785ce07c
       Content-Length:
       - '7264'
       Connection:
@@ -12713,7 +12677,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:59.516443Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:37.696623Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12792,10 +12756,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-56msnnfTG-9lUkquNPsEA"],
-        "issued_at": "2019-01-08T19:19:59.516462Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["t_yp56NNQROG_xnVdAinTQ"],
+        "issued_at": "2019-03-04T20:07:37.696642Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12813,15 +12777,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:59 GMT
+      - Mon, 04 Mar 2019 20:07:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e4e952cc-316e-4717-8322-c6aef1cee990
+      - req-d048dfb9-96db-45e2-92a1-7a7a246f8649
       Content-Length:
       - '7278'
       Connection:
@@ -12833,7 +12797,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:59.723144Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:37.902768Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12912,10 +12876,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["B0TT3GGmS1S56rCEEx1gsg"],
-        "issued_at": "2019-01-08T19:19:59.723161Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Oy-M8OTfTZue6nk_UdyN4w"],
+        "issued_at": "2019-03-04T20:07:37.902788Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:19:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12933,15 +12897,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:19:59 GMT
+      - Mon, 04 Mar 2019 20:07:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79f904c6-2ae2-42b2-9f51-9989f67114c8
+      - req-ee46f9e5-4930-42f2-9741-8e215b2a816e
       Content-Length:
       - '7265'
       Connection:
@@ -12953,7 +12917,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:19:59.942097Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:38.103914Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13032,10 +12996,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AOcBnajNShC87omXG73NOA"],
-        "issued_at": "2019-01-08T19:19:59.942115Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p__G0kh5Qru7ybDDxWsMnw"],
+        "issued_at": "2019-03-04T20:07:38.103933Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13053,15 +13017,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:00 GMT
+      - Mon, 04 Mar 2019 20:07:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c874d636-055b-497c-ad81-ef6a4e60276d
+      - req-7ed0fab4-53d6-4e15-987f-6d1f60473005
       Content-Length:
       - '7278'
       Connection:
@@ -13073,7 +13037,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:00.410955Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:07:38.315605Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13152,10 +13116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iUrvxCx-Q8Otexj3YoXEaQ"],
-        "issued_at": "2019-01-08T19:20:00.410974Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0UxXrxKwQGejzjqn1kBCRQ"],
+        "issued_at": "2019-03-04T20:07:38.315624Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
@@ -13170,7 +13134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -13181,1330 +13145,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-8e4395e0-268b-4ba5-a40a-5245743c3a67
+      - req-ed5b3673-bc3a-46d7-9ace-001d3f7c7354
       Date:
-      - Tue, 08 Jan 2019 19:20:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ff5ed06c-21af-4c0d-92a1-005615791838
-      Date:
-      - Tue, 08 Jan 2019 19:20:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2ef61782-63f8-4d5b-b0f0-1ed74e107932
-      Date:
-      - Tue, 08 Jan 2019 19:20:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:00 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-19d9cd4e-38cc-4674-8246-759408afa9b6
-      Date:
-      - Tue, 08 Jan 2019 19:20:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-983cd41f-cda4-4e80-9eef-bbe24494944d
-      Date:
-      - Tue, 08 Jan 2019 19:20:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a6976ce2-2345-4e03-9ab6-45c092dece31
-      Date:
-      - Tue, 08 Jan 2019 19:20:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-87d2d0a0-f7f6-4bed-b3b5-8624408122cf
-      Date:
-      - Tue, 08 Jan 2019 19:20:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-53ac285f-4127-469d-bab3-7112342e3112
-      Date:
-      - Tue, 08 Jan 2019 19:20:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:01 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ca72cd49-3de9-4ce7-a034-0924c835617d
-      Date:
-      - Tue, 08 Jan 2019 19:20:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-100375a3-4f27-417b-8b34-cdcc66c187d5
-      Date:
-      - Tue, 08 Jan 2019 19:20:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-43686c9b-f857-4f55-bd92-1f2b9715c11b
-      Date:
-      - Tue, 08 Jan 2019 19:20:02 GMT
+      - Mon, 04 Mar 2019 20:07:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -14608,7 +13251,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -14623,7 +13266,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -14634,29 +13277,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ea9da3c5-a724-4a49-bfc0-3e1d3e1fcb13
+      - req-6afb881c-cf00-447b-a439-9a9800ce9949
       Date:
-      - Tue, 08 Jan 2019 19:20:02 GMT
+      - Mon, 04 Mar 2019 20:07:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -14696,356 +13322,6 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
         "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
         "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4ee0f959-d5e7-4994-b8d1-1b69e1b40ecc
-      Date:
-      - Tue, 08 Jan 2019 19:20:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3c310b17-9a2a-4769-9fa4-d0fd33743aaf
-      Date:
-      - Tue, 08 Jan 2019 19:20:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:03 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-60d02020-eb0b-41b1-a060-0c857f42855a
-      Date:
-      - Tue, 08 Jan 2019 19:20:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
@@ -15094,6 +13370,67 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:38 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a585959667af4f6986ef5d49c860c616
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-886d7417-596f-40e6-a5f0-07cbeb825371
+      Date:
+      - Mon, 04 Mar 2019 20:07:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -15124,6 +13461,47 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
         "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -15137,7 +13515,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -15152,7 +13530,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -15163,9 +13541,801 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-11013ce6-5433-40db-b3ea-18782fce0e96
+      - req-0c303fe8-051a-4396-94f1-5311db0b66de
       Date:
-      - Tue, 08 Jan 2019 19:20:04 GMT
+      - Mon, 04 Mar 2019 20:07:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a585959667af4f6986ef5d49c860c616
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5c413e97-bb3b-45cb-83ae-45f3f1a6c786
+      Date:
+      - Mon, 04 Mar 2019 20:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 706752f4b98449b2a15db5378b12a706
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cefef546-5b97-4628-b57e-79110a98abcb
+      Date:
+      - Mon, 04 Mar 2019 20:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 706752f4b98449b2a15db5378b12a706
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0dad54bb-2f94-40ea-8833-b6642b9b2700
+      Date:
+      - Mon, 04 Mar 2019 20:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ec4c6699f7f94d6aabbfdc299fdfc726
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1693ac18-2c4b-4fe9-a29c-14facf57ccbf
+      Date:
+      - Mon, 04 Mar 2019 20:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ec4c6699f7f94d6aabbfdc299fdfc726
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-372b34db-4d56-4b13-9f8b-ef3313d7b608
+      Date:
+      - Mon, 04 Mar 2019 20:07:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
+        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:39 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3569679cfd124a1da6418832a71c465f
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b5ee709a-31ea-4e72-a12b-225d73fbe952
+      Date:
+      - Mon, 04 Mar 2019 20:07:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
@@ -15269,10 +14439,10 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
 - request:
     method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
     body:
       encoding: US-ASCII
       string: ''
@@ -15284,7 +14454,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -15295,29 +14465,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-79c1bc11-c27d-43f9-b6ff-9a04e83c5459
+      - req-9d1147ab-26e9-4da4-bd81-c4ae5cf97f8f
       Date:
-      - Tue, 08 Jan 2019 19:20:04 GMT
+      - Mon, 04 Mar 2019 20:07:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -15388,20 +14541,37 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
@@ -15416,7 +14586,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -15427,9 +14597,405 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1cba50b8-6c67-430d-911a-740f59438445
+      - req-8f9e0212-f2cf-4496-8c17-f6334ebbe7a1
       Date:
-      - Tue, 08 Jan 2019 19:20:04 GMT
+      - Mon, 04 Mar 2019 20:07:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 759da4b2d6264b4c9b00112683235574
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-69399b5d-92f2-4737-bce3-dfcf30adecb8
+      Date:
+      - Mon, 04 Mar 2019 20:07:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 759da4b2d6264b4c9b00112683235574
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d3665686-b7ff-4da3-8ee4-8f86f56afeee
+      Date:
+      - Mon, 04 Mar 2019 20:07:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a497ca9bf3e948ffbdadccb73c2619a4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-18218f64-f95d-4ada-b156-85e377b85078
+      Date:
+      - Mon, 04 Mar 2019 20:07:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -15520,20 +15086,548 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a497ca9bf3e948ffbdadccb73c2619a4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-984304ce-9c96-4f9c-a417-5eb7ddc27fce
+      Date:
+      - Mon, 04 Mar 2019 20:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a497ca9bf3e948ffbdadccb73c2619a4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1b84d004-7c08-4511-9436-b92340faefc5
+      Date:
+      - Mon, 04 Mar 2019 20:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ff564bb342ca4287a421643425e72081
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b4f236a5-fbd7-48e5-a48b-9a62f8fc2a91
+      Date:
+      - Mon, 04 Mar 2019 20:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ff564bb342ca4287a421643425e72081
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7b15c921-fb13-4043-a9fa-4bcb67b59629
+      Date:
+      - Mon, 04 Mar 2019 20:07:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -15548,7 +15642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -15559,9 +15653,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-75414569-64bc-403f-8e9e-74fc06ffdbd1
+      - req-c170fd37-6390-4a25-9fb4-1e57f774b5e2
       Date:
-      - Tue, 08 Jan 2019 19:20:05 GMT
+      - Mon, 04 Mar 2019 20:07:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15603,7 +15697,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -15618,7 +15712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -15629,9 +15723,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-d7c26059-934f-48d5-8158-ca03003e08dc
+      - req-5bff477c-45a6-4160-9e70-69d11e658344
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15673,7 +15767,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -15688,7 +15782,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -15699,9 +15793,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-52d2b02f-5e26-4915-b8a5-6b09226bb8b7
+      - req-d590036a-c73b-42ca-83af-6b86e4b80df5
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15743,7 +15837,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -15758,7 +15852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -15769,9 +15863,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3bed1910-f982-4d19-a024-7b283d97fe63
+      - req-611a7661-4ab4-4c03-a73f-e7b3814439ae
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15813,7 +15907,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -15828,7 +15922,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -15839,9 +15933,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-db1558b0-f609-4946-80d6-d4826d15df8c
+      - req-31eed9ca-861c-4fc5-b290-c9eac7ee665f
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15883,7 +15977,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -15898,7 +15992,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -15909,9 +16003,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-a10fd6ae-130c-4770-a4c3-1d6c4374acc0
+      - req-9d430723-ab9e-44da-b025-36b45d797e9e
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -15953,7 +16047,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -15968,7 +16062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -15979,9 +16073,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-fca1683b-383f-4f9a-b6bf-529635dc8fac
+      - req-d3a60ba0-5a5e-4c7a-84df-199a0f009165
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16023,7 +16117,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16038,7 +16132,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -16049,9 +16143,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-973262c0-a0b3-4d0d-8df3-22cf520c80f2
+      - req-cb96ddb8-92ae-4529-9c28-fbb5dd7f4544
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16093,7 +16187,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16108,7 +16202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -16119,9 +16213,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-860ca71f-a291-4dfa-9320-aff721f69424
+      - req-ec24b927-62a5-42f5-b681-cad924f4c2fa
       Date:
-      - Tue, 08 Jan 2019 19:20:06 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16163,7 +16257,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16178,7 +16272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -16189,9 +16283,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8e23fc5d-cf6e-4331-b7f7-d0d8c84bddcd
+      - req-ea6c0fb4-87ba-4474-9235-9af9ab1dddc3
       Date:
-      - Tue, 08 Jan 2019 19:20:07 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16233,7 +16327,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16248,7 +16342,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -16259,9 +16353,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-681bf366-d08c-47f0-a736-1b1e52fc15e0
+      - req-ae6ee536-1b7b-417b-949f-05b6b385352c
       Date:
-      - Tue, 08 Jan 2019 19:20:08 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16303,7 +16397,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16318,7 +16412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -16329,9 +16423,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3a4b5090-b32e-4f34-b922-91edefb38b92
+      - req-ffc54b5a-28df-4c03-9baa-f9208927627f
       Date:
-      - Tue, 08 Jan 2019 19:20:08 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16373,7 +16467,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000
@@ -16388,7 +16482,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -16399,9 +16493,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-19aaaf4d-ae4f-4807-ba60-5da05fce0bab
+      - req-12b9932e-88c3-4796-8662-edc450319f77
       Date:
-      - Tue, 08 Jan 2019 19:20:08 GMT
+      - Mon, 04 Mar 2019 20:07:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16443,7 +16537,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -16458,7 +16552,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -16469,9 +16563,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-8a8ca631-6446-4f28-8097-930e7f46d914
+      - req-b3eadcad-2bf8-4ce8-930d-23e78c7ce71a
       Date:
-      - Tue, 08 Jan 2019 19:20:08 GMT
+      - Mon, 04 Mar 2019 20:07:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -16513,7 +16607,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -16528,7 +16622,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -16539,9 +16633,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-5a88add6-da87-488f-a841-458175709455
+      - req-18319670-1616-4e9c-8866-d7beb5307505
       Date:
-      - Tue, 08 Jan 2019 19:20:08 GMT
+      - Mon, 04 Mar 2019 20:07:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -16944,7 +17038,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -16959,7 +17053,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -16970,9 +17064,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-321561b0-7bc4-433d-b54b-2fa2ef8be5c2
+      - req-0983e528-6258-46fb-9c36-187a18cfe127
       Date:
-      - Tue, 08 Jan 2019 19:20:09 GMT
+      - Mon, 04 Mar 2019 20:07:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -17375,7 +17469,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -17390,7 +17484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -17401,9 +17495,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-e38f7db6-05de-41ce-96be-081c360bd4fd
+      - req-4b6a5818-b7d7-4b14-b5a4-ff56b2235ff8
       Date:
-      - Tue, 08 Jan 2019 19:20:10 GMT
+      - Mon, 04 Mar 2019 20:07:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -17806,7 +17900,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:43 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -17821,7 +17915,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -17832,9 +17926,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-2256573e-62e3-4b62-aabe-7c9e8485533c
+      - req-0b814f8f-8380-4888-af13-97509078589f
       Date:
-      - Tue, 08 Jan 2019 19:20:10 GMT
+      - Mon, 04 Mar 2019 20:07:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18237,7 +18331,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -18252,7 +18346,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -18263,9 +18357,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8beb3677-bf99-4470-b7d0-cbf66a6c2235
+      - req-49d275d9-3004-4d83-b9c0-da66554758a7
       Date:
-      - Tue, 08 Jan 2019 19:20:10 GMT
+      - Mon, 04 Mar 2019 20:07:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -18668,7 +18762,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -18683,7 +18777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -18694,9 +18788,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bf421648-c045-4f6a-a333-af6999627a0f
+      - req-e512b59b-86ba-4bf2-a419-7ebf91e6c798
       Date:
-      - Tue, 08 Jan 2019 19:20:10 GMT
+      - Mon, 04 Mar 2019 20:07:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19099,7 +19193,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19114,7 +19208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -19125,9 +19219,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-31a699e3-1730-4a90-b261-69790bd9ade6
+      - req-c530cfca-d89b-4774-a9d3-e5cab684c1bf
       Date:
-      - Tue, 08 Jan 2019 19:20:13 GMT
+      - Mon, 04 Mar 2019 20:07:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19530,7 +19624,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:44 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -19545,7 +19639,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -19556,9 +19650,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-59f8ddee-f35f-4c14-8fde-af10943c5295
+      - req-eadd38b6-d4b7-4d43-a8a9-1073ab27964d
       Date:
-      - Tue, 08 Jan 2019 19:20:13 GMT
+      - Mon, 04 Mar 2019 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -19961,7 +20055,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -19976,7 +20070,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -19987,9 +20081,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bb89df10-31be-4942-9d8d-5394016e24b6
+      - req-d8916ec5-1343-4960-8368-6845f27f5757
       Date:
-      - Tue, 08 Jan 2019 19:20:13 GMT
+      - Mon, 04 Mar 2019 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20392,7 +20486,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -20407,7 +20501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -20418,9 +20512,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ef2c3057-060c-4780-b753-3315dd927436
+      - req-8a263d56-0668-4cab-bc10-d12912945e02
       Date:
-      - Tue, 08 Jan 2019 19:20:13 GMT
+      - Mon, 04 Mar 2019 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -20823,7 +20917,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -20838,7 +20932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -20849,9 +20943,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-bd69fc0c-a749-4cf2-a903-39b1e77631c7
+      - req-9aec7b6a-71d6-4bab-8257-836201ae7e1d
       Date:
-      - Tue, 08 Jan 2019 19:20:13 GMT
+      - Mon, 04 Mar 2019 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21254,7 +21348,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -21269,7 +21363,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -21280,9 +21374,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-2e0af267-939c-4658-bf5d-b947b8af4146
+      - req-19c1c3f8-df2c-4547-b8c3-3327df678410
       Date:
-      - Tue, 08 Jan 2019 19:20:14 GMT
+      - Mon, 04 Mar 2019 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -21685,7 +21779,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000
@@ -21700,7 +21794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -21711,9 +21805,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-65680a66-d234-4dbf-859c-7dce1112d93a
+      - req-66f0fd0f-1d4c-4767-8051-920951b7f2b5
       Date:
-      - Tue, 08 Jan 2019 19:20:14 GMT
+      - Mon, 04 Mar 2019 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22116,7 +22210,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -22131,7 +22225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -22142,9 +22236,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-21ee4787-19ec-4a8d-9bfd-0396602ed8df
+      - req-47f4cece-e193-4fe1-9866-de1aec4d2f24
       Date:
-      - Tue, 08 Jan 2019 19:20:14 GMT
+      - Mon, 04 Mar 2019 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -22547,7 +22641,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -22562,7 +22656,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -22573,9 +22667,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-60e8b628-ec41-4300-aec4-077c0436e061
+      - req-d5482125-c905-45cf-8ae5-7f6b49bd1f64
       Date:
-      - Tue, 08 Jan 2019 19:20:14 GMT
+      - Mon, 04 Mar 2019 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22607,7 +22701,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -22622,7 +22716,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -22633,9 +22727,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-c7a2792c-ab3d-41f8-ad62-ff0a4e0ae87b
+      - req-bb6eb353-1525-411b-9256-da77582c0ba3
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22667,7 +22761,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -22682,7 +22776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -22693,9 +22787,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-2eaea567-43df-4dc9-aa8a-e32eb53bccfb
+      - req-cb0ef7bd-e487-452e-b359-8d316de7b7e6
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22727,7 +22821,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -22742,7 +22836,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -22753,9 +22847,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9d654df9-6bdb-4286-823f-3b445bb90797
+      - req-cfe862d9-73b8-49d2-8f46-5c847ef9ce29
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22787,7 +22881,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -22802,7 +22896,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -22813,9 +22907,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ff0c0308-de42-4957-a496-4909201bf879
+      - req-c159c538-1429-4e87-bbf0-cb458941dcbf
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22847,7 +22941,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -22862,7 +22956,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -22873,9 +22967,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fa0c916f-35ed-41af-81bd-075ff4168aab
+      - req-c26913e0-dcf4-4126-be1c-2cb1a124196b
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22907,7 +23001,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -22922,7 +23016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -22933,9 +23027,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b6dd54ed-a159-443d-9fd2-16df84fc7d12
+      - req-7d88873b-af74-435f-b3d0-c4fd8fe78648
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -22967,7 +23061,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -22982,7 +23076,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -22993,9 +23087,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b8f617c0-8231-4e28-87f9-f8017ca35b0f
+      - req-d42a745c-e0d8-47aa-ac58-b73de335a2eb
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23027,7 +23121,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23042,7 +23136,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -23053,9 +23147,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-cf1121eb-f5a0-46ce-9e16-70a21a6ee1dd
+      - req-80b71852-63b9-4110-9cdc-3c8ca91ece7b
       Date:
-      - Tue, 08 Jan 2019 19:20:15 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23087,7 +23181,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23102,7 +23196,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -23113,9 +23207,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-f683bba5-7618-41f3-8532-e1e49745755f
+      - req-6d86cff9-21ba-4b83-90af-3bbd4a6b5c85
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23147,7 +23241,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23162,7 +23256,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -23173,9 +23267,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-8bafc336-bc27-408a-8894-5e8fb1431cbf
+      - req-edfc8653-8c47-4b7b-8971-5a700e169ab0
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23207,7 +23301,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23222,7 +23316,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -23233,9 +23327,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-9bb23ad1-1313-4307-ab0a-f78bcb4d6c3c
+      - req-9c5cb898-ab3d-4fad-a6f6-b8ab874525d9
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23267,7 +23361,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000
@@ -23282,7 +23376,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -23293,9 +23387,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b18b000c-c073-4e0e-859e-0da3786e34f5
+      - req-f513ff66-140e-4ec2-a4f9-c69d917802ac
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23327,7 +23421,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -23342,7 +23436,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -23353,9 +23447,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b5bf6b75-b6a6-452f-a172-96b6b9a02be5
+      - req-9d580b13-c87e-430c-a20b-c8abb65d6c6b
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -23387,7 +23481,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -23402,7 +23496,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23413,9 +23507,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-4ff97b6d-511f-495f-b312-e66980e1af28
+      - req-c2643c05-7db9-4efe-8659-27eebdaf4a01
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -23450,7 +23544,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -23465,7 +23559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23476,9 +23570,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-28ad732f-2349-4fdc-886b-59b17f08883a
+      - req-c2a3a63a-656f-4248-aabe-ab1ea9536f20
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -23521,7 +23615,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -23536,7 +23630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23547,9 +23641,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-adb4f061-edf2-4db9-9f24-89980e1bbba6
+      - req-527a32c2-111b-40ae-a2a0-9989c13704ae
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -23592,7 +23686,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -23607,7 +23701,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23618,9 +23712,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-5e8e8603-a092-44ca-b04c-5db36ba11cb5
+      - req-2c126944-5ee0-4b07-ad8f-d68a886fa465
       Date:
-      - Tue, 08 Jan 2019 19:20:16 GMT
+      - Mon, 04 Mar 2019 20:07:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -23727,7 +23821,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -23742,7 +23836,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23753,9 +23847,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0019b212-07ec-4db5-917a-b85ab7084b37
+      - req-05433960-f3fc-4b7a-910c-3dc44b2a0862
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -23797,7 +23891,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -23812,7 +23906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 71a264afc5924b20adc14d0cb3c4d636
+      - a585959667af4f6986ef5d49c860c616
   response:
     status:
       code: 200
@@ -23823,15 +23917,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-cd7faa57-9eed-46aa-b56f-ff8459af63f2
+      - req-77785f9d-d87b-40f7-873d-e19dca0c780f
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -23846,7 +23940,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -23857,9 +23951,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-5e12d830-becb-42dd-a624-de9eba7a8700
+      - req-793caed4-7c0a-405b-8076-49a446009310
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -23894,7 +23988,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -23909,7 +24003,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -23920,9 +24014,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-82979c75-3300-4002-af9e-63be1bbe28f5
+      - req-fcae43ec-a5c6-465c-af9e-68f996b55112
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -23965,7 +24059,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -23980,7 +24074,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -23991,9 +24085,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-bc817c65-f942-48c2-b85e-0130a6d7df28
+      - req-42cbab86-38bd-4f04-8aaf-24b0fe5a6fd3
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24036,7 +24130,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24051,7 +24145,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -24062,9 +24156,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-b41e5686-0c19-4c2e-b2ee-3f2f4810b1d2
+      - req-1c63959c-720e-4734-a5fe-d6ca0ff5940f
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24171,7 +24265,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24186,7 +24280,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -24197,9 +24291,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0b5274b6-5ca6-4dfc-bb2e-b62a5b9bd708
+      - req-94854b64-7610-4e62-b3e3-51b71e8be4bb
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24241,7 +24335,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24256,7 +24350,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fb85a944c90940fc9dfdf5c0a874a68b
+      - 706752f4b98449b2a15db5378b12a706
   response:
     status:
       code: 200
@@ -24267,15 +24361,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-5e4e9272-fb3c-47eb-b94d-8e0e0b295633
+      - req-00809cb6-b7a8-480c-80ac-037fac95a80c
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24290,7 +24384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24301,9 +24395,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-977c945d-08ba-486e-a5c4-42ba95108dff
+      - req-0e0a65f9-5843-4957-afa2-06467a075659
       Date:
-      - Tue, 08 Jan 2019 19:20:17 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24338,7 +24432,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24353,7 +24447,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24364,9 +24458,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-a699f27d-2ed4-4316-b960-1b6cf301c0f9
+      - req-ed7494db-72ec-4194-978d-c95d4d68e781
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24409,7 +24503,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24424,7 +24518,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24435,9 +24529,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-cd8fc778-4259-44e0-a710-10d9e260e53b
+      - req-a62f70b4-d9ce-4ac7-af7e-9dc7cf795ff4
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24480,7 +24574,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24495,7 +24589,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24506,9 +24600,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-a9a10ea9-829d-4ee8-a4e7-08a7480aacd3
+      - req-37eac32c-37ed-4f13-b633-01858a2ed3d2
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -24615,7 +24709,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -24630,7 +24724,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24641,9 +24735,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-6dded323-522f-473a-b9bf-24907543d87a
+      - req-ad164417-e957-4b2e-866f-3a5fd1c839d5
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -24685,7 +24779,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -24700,7 +24794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7c7d5ba09b849888be18cfc6e66e5ae
+      - ec4c6699f7f94d6aabbfdc299fdfc726
   response:
     status:
       code: 200
@@ -24711,15 +24805,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-8ce49fe7-9c78-4f96-94ca-4c80c2db8f90
+      - req-553d6536-8702-41be-85ca-572e2e99d479
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -24734,7 +24828,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -24745,9 +24839,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-ead2b825-d8a6-42d5-bac1-d067bb392074
+      - req-7ccc99f1-d3b3-427a-8a30-bed7ffab943e
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -24782,7 +24876,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -24797,7 +24891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -24808,9 +24902,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-aaac84d0-0ad1-41d8-b705-dcbcf370e02c
+      - req-6714104c-2409-4eb4-96cd-0629d4763dac
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -24853,7 +24947,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -24868,7 +24962,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -24879,9 +24973,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c32c7622-ea59-4e69-b832-5eb94eec5479
+      - req-01d28c16-03e9-429f-88ee-fded1d1c87ad
       Date:
-      - Tue, 08 Jan 2019 19:20:18 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -24924,7 +25018,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -24939,7 +25033,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -24950,9 +25044,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-5c7ecb1e-62d5-479b-8583-3e0d7a2e9bdb
+      - req-8d0531f7-ecbe-4f1e-a430-cd8f98b6aae5
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25059,7 +25153,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25074,7 +25168,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -25085,9 +25179,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-9116fac2-d876-403e-a9a2-245d2d2cc78d
+      - req-6ed6cc28-c643-4e54-a555-1c596b9fa5da
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25129,7 +25223,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25144,7 +25238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fe3dacf7322d4e35aadfd2fb92674014
+      - 3569679cfd124a1da6418832a71c465f
   response:
     status:
       code: 200
@@ -25155,15 +25249,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-1317a056-177b-4276-b0fd-1547bcc4df5a
+      - req-8edc90bc-16b8-463c-a047-480d21e2d528
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25178,7 +25272,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25189,9 +25283,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-f02958a7-d1ee-43dc-88c1-db5fcf569264
+      - req-4907ac79-ae74-4737-8e12-14e66c44963c
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25226,7 +25320,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25241,7 +25335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25252,9 +25346,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-0e17436e-7d96-4b9f-ab19-b92596bbfa5b
+      - req-fbd118fe-53db-4907-9d14-8180dfafe5ee
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25297,7 +25391,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25312,7 +25406,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25323,9 +25417,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-b841565e-2b9f-4db0-9ca2-73406f72a5a8
+      - req-2040f4d0-106b-4c8d-a15c-5b45005e8c8f
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25368,7 +25462,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25383,7 +25477,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25394,9 +25488,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-4f5bf7e1-05a3-4544-8ef0-bc9587d7060c
+      - req-411e926d-ae69-4799-8171-44002a13b755
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25503,7 +25597,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25518,7 +25612,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25529,9 +25623,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-3526011a-57bc-4ea4-9a5d-9b8d9b52b2b6
+      - req-5c267f91-d696-45cd-b888-8cf94d5839fb
       Date:
-      - Tue, 08 Jan 2019 19:20:19 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -25573,7 +25667,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -25588,7 +25682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4cfb61231d094ea897a95a94528e7f9a
+      - 759da4b2d6264b4c9b00112683235574
   response:
     status:
       code: 200
@@ -25599,15 +25693,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-6b46c609-861d-41c5-a4ae-146ef17eba9e
+      - req-0940c673-911a-4d22-9c02-a10de6d5270b
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -25622,7 +25716,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -25633,9 +25727,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-fbcf9b9c-72d6-4f14-bcff-ffc7e6316645
+      - req-7e3475b5-59ea-44ed-b2e6-8a72a30700d7
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -25670,7 +25764,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -25685,7 +25779,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -25696,9 +25790,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-59d2c97b-fb36-4a3f-9413-76ef17be9c60
+      - req-9969968f-28ef-4ad0-8d28-0c85b9b74e72
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -25741,7 +25835,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -25756,7 +25850,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -25767,9 +25861,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-dada728c-ceef-4eaf-8864-ff404fc1ac78
+      - req-05397ee6-4c49-4be0-8b73-edf6e247a1ab
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -25812,7 +25906,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -25827,7 +25921,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -25838,9 +25932,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-09a34c3e-aabc-4de6-bee2-ea193f379b6c
+      - req-2f68fc56-a5f7-44b3-a6de-3a395708dfcb
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -25947,7 +26041,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -25962,7 +26056,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -25973,9 +26067,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-7825dd2d-f005-4c13-a490-e15e5d86cfe4
+      - req-c1c77a7f-295c-4ba4-ad7d-217979d10d00
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26017,7 +26111,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26032,7 +26126,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 447e002b762445ffa3ad9018f8159ee6
+      - a497ca9bf3e948ffbdadccb73c2619a4
   response:
     status:
       code: 200
@@ -26043,15 +26137,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-cf2e1275-a9f3-45c1-8242-b8450561887d
+      - req-cdcad2d6-0f39-4f45-9de8-b1f9481799a1
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000
@@ -26066,7 +26160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26077,9 +26171,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-e91e01f3-9d00-4085-a936-b4a9941316f0
+      - req-1cf1d597-3ab3-4b30-ad62-ff0d245406a8
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -26114,7 +26208,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:55 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -26129,7 +26223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26140,9 +26234,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-eb9a7d5d-a05f-4a84-b928-88d0cffdfc6d
+      - req-684c226a-7e7a-42e0-a85d-de65d84d85e6
       Date:
-      - Tue, 08 Jan 2019 19:20:20 GMT
+      - Mon, 04 Mar 2019 20:07:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -26185,7 +26279,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -26200,7 +26294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26211,9 +26305,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-902e6c9b-16e9-47a8-a2ba-61bf0e7bee7b
+      - req-4dcedc66-0fc9-421b-9e94-a1bedda34458
       Date:
-      - Tue, 08 Jan 2019 19:20:21 GMT
+      - Mon, 04 Mar 2019 20:07:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -26256,7 +26350,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -26271,7 +26365,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26282,9 +26376,9 @@ http_interactions:
       Content-Length:
       - '8737'
       X-Openstack-Request-Id:
-      - req-f4304165-226d-4d57-9d4a-f4770f4a8cc1
+      - req-c47b9a88-d657-40f2-ac52-21456dfca5c2
       Date:
-      - Tue, 08 Jan 2019 19:20:21 GMT
+      - Mon, 04 Mar 2019 20:07:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -26391,7 +26485,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -26406,7 +26500,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26417,9 +26511,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-d8c811ba-721b-42cc-ab11-6d1fdbe6ce62
+      - req-24566482-cf9e-4a08-9785-11e4758d9348
       Date:
-      - Tue, 08 Jan 2019 19:20:21 GMT
+      - Mon, 04 Mar 2019 20:07:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -26461,7 +26555,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:56 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -26476,7 +26570,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fe91b39633b4487af2787dba492cc41
+      - ff564bb342ca4287a421643425e72081
   response:
     status:
       code: 200
@@ -26487,15 +26581,15 @@ http_interactions:
       Content-Length:
       - '156'
       X-Openstack-Request-Id:
-      - req-778b448c-1cee-41a0-862c-d54f3412cea0
+      - req-a0d5cb4c-d351-49d6-9168-bd477f218406
       Date:
-      - Tue, 08 Jan 2019 19:20:21 GMT
+      - Mon, 04 Mar 2019 20:07:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -26513,15 +26607,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:22 GMT
+      - Mon, 04 Mar 2019 20:07:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0374a8698f7a42e4a43657f14470785d
+      - a44cb5db98874e7385865723ed95c62d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ff19430-f3dc-4592-acd7-059989392bdf
+      - req-1ddc11dc-45e3-4b39-88c1-7e08f53d4c02
       Content-Length:
       - '7311'
       Connection:
@@ -26533,7 +26627,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:22.580297Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:57.421312Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -26612,10 +26706,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P9m5EklfRRi3JKYthkzWIQ"],
-        "issued_at": "2019-01-08T19:20:22.580316Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5Qk945JNS8SLYywYO8eRaA"],
+        "issued_at": "2019-03-04T20:07:57.421334Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -26633,15 +26727,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:22 GMT
+      - Mon, 04 Mar 2019 20:07:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03611f37-421c-41a9-b700-98c1c5c83af3
+      - req-67ad0c9d-0566-402a-b1ef-e1f9483881bc
       Content-Length:
       - '7311'
       Connection:
@@ -26653,7 +26747,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:22.782377Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:07:57.633649Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -26732,10 +26826,46 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v0B7uv32R52gzGBzUMfh6Q"],
-        "issued_at": "2019-01-08T19:20:22.782394Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gm5KrZL6TdmcMUZk41shVg"],
+        "issued_at": "2019-03-04T20:07:57.633670Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:57 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 06aa90a8d21f4f709c15effff2988927
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-c198caa1-e4e7-45fb-84a4-b61913c83e16
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-c198caa1-e4e7-45fb-84a4-b61913c83e16
+      Date:
+      - Mon, 04 Mar 2019 20:07:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:07:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -26753,15 +26883,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:23 GMT
+      - Mon, 04 Mar 2019 20:07:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8ed64e86590f48cab9639951be3f0dea
+      - aab12f0774c145b1ae50d82d599734cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-35530599-8a2c-4b5f-b06a-0123fe7e274c
+      - req-de11bd5f-5679-4a4b-a76a-54c6e569e726
       Content-Length:
       - '297'
       Connection:
@@ -26770,12 +26900,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:20:23.241034Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:07:57.955974Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TofU-TtUQwmNUTiuNTHF4Q"],
-        "issued_at": "2019-01-08T19:20:23.241052Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9VKrgTlNS4yYeUEmSHWk5w"],
+        "issued_at": "2019-03-04T20:07:57.956019Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:07:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -26790,20 +26920,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ed64e86590f48cab9639951be3f0dea
+      - aab12f0774c145b1ae50d82d599734cb
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:23 GMT
+      - Mon, 04 Mar 2019 20:08:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5a758eb0-aef0-4e1c-81ca-eab19dab2b9b
+      - req-874002bf-ad7b-41b2-8a3b-4abe0e61158d
       Content-Length:
       - '2475'
       Connection:
@@ -26836,7 +26966,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -26854,15 +26984,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:23 GMT
+      - Mon, 04 Mar 2019 20:08:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e44ead27-7451-4a4f-af97-5130fff7869a
+      - req-5643a826-7d01-4353-af6b-769f71832ef7
       Content-Length:
       - '7278'
       Connection:
@@ -26874,7 +27004,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:23.584524Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:03.348719Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -26953,10 +27083,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y7UhRyZvQ-ancNCqKNCjpw"],
-        "issued_at": "2019-01-08T19:20:23.584543Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IAYCKEzLQAie9-p9clvCdg"],
+        "issued_at": "2019-03-04T20:08:03.348738Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -26974,15 +27104,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:23 GMT
+      - Mon, 04 Mar 2019 20:08:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8561e93a-97bb-4a0a-b1b9-17cf2310fced
+      - req-1eee9d18-bace-4318-ae1a-de87e66b1675
       Content-Length:
       - '7278'
       Connection:
@@ -26994,7 +27124,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:23.789293Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:03.553742Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27073,10 +27203,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r5nG7_JpT7qirvGDHFHitg"],
-        "issued_at": "2019-01-08T19:20:23.789315Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mfFErunjT3-iCSCwNTIu5g"],
+        "issued_at": "2019-03-04T20:08:03.553759Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27094,15 +27224,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:23 GMT
+      - Mon, 04 Mar 2019 20:08:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2c9ff294-f139-4860-84ad-835cdf232bc1
+      - req-1c082316-bff0-4deb-a6de-6637de69b92b
       Content-Length:
       - '7264'
       Connection:
@@ -27114,7 +27244,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:23.994449Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:03.771007Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27193,10 +27323,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["iz0nILpGSjOM_2C8n0jo0A"],
-        "issued_at": "2019-01-08T19:20:23.994474Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JpW23oXRT4Sp0UbIeMZ91A"],
+        "issued_at": "2019-03-04T20:08:03.771026Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27214,15 +27344,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:24 GMT
+      - Mon, 04 Mar 2019 20:08:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3bc6d86a-1c79-40fc-a09b-8968ad4987eb
+      - req-1c74b217-93eb-4bce-9dd3-4089de2a3a4d
       Content-Length:
       - '7278'
       Connection:
@@ -27234,7 +27364,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:24.200933Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:04.031397Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27313,10 +27443,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["R38qL9TGSTOw8V4C9KRVaA"],
-        "issued_at": "2019-01-08T19:20:24.200959Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["my3WmCC7TOiZo9hCqQiwAQ"],
+        "issued_at": "2019-03-04T20:08:04.031426Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27334,15 +27464,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:24 GMT
+      - Mon, 04 Mar 2019 20:08:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-285f5925-5db5-429b-ab4c-4d6104393942
+      - req-bd38b960-e59c-4d59-881f-4a3605ceaa6b
       Content-Length:
       - '7265'
       Connection:
@@ -27354,7 +27484,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:24.404339Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:04.239159Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -27433,10 +27563,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M64gwvMsSTWUqpDFXUqbHw"],
-        "issued_at": "2019-01-08T19:20:24.404358Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qXDxsFnLR0OI9NiifWhdVA"],
+        "issued_at": "2019-03-04T20:08:04.239179Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -27454,15 +27584,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:24 GMT
+      - Mon, 04 Mar 2019 20:08:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-04b9e47c-d11d-414e-b43b-bafeb02413f4
+      - req-0cefe817-3d81-4282-afa3-ebe034cee803
       Content-Length:
       - '7278'
       Connection:
@@ -27474,7 +27604,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:24.641978Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:04.455777Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -27553,10 +27683,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GtsJ861TRoaaQjr1BQ1a5A"],
-        "issued_at": "2019-01-08T19:20:24.642002Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wEHxuKZvQje6y7Lz9Z6zDQ"],
+        "issued_at": "2019-03-04T20:08:04.455800Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -27571,27 +27701,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7f46a1f3-2279-4046-b261-cc1b8f184d6c
+      - req-c8f7b614-ad4c-4839-8083-478e07d6dd49
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7f46a1f3-2279-4046-b261-cc1b8f184d6c
+      - req-c8f7b614-ad4c-4839-8083-478e07d6dd49
       Date:
-      - Tue, 08 Jan 2019 19:20:24 GMT
+      - Mon, 04 Mar 2019 20:08:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:04 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -27606,27 +27736,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3db4ff4-eeb3-4084-8ea2-cceaffe9e47c
+      - req-1129ba02-79bc-403d-b3f5-a382c70bde7d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f3db4ff4-eeb3-4084-8ea2-cceaffe9e47c
+      - req-1129ba02-79bc-403d-b3f5-a382c70bde7d
       Date:
-      - Tue, 08 Jan 2019 19:20:24 GMT
+      - Mon, 04 Mar 2019 20:08:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -27641,22 +27771,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8e443397-3579-4168-9609-6c7653dbce3b
+      - req-9c7698c0-84be-494b-8798-4ead6d236cce
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-8e443397-3579-4168-9609-6c7653dbce3b
+      - req-9c7698c0-84be-494b-8798-4ead6d236cce
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -27689,7 +27819,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:05 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -27704,22 +27834,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6237ba2a-3a66-488f-84a3-ea7135fe947e
+      - req-2b9f042c-33e1-43ab-a5b3-1fa30b5c4417
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-6237ba2a-3a66-488f-84a3-ea7135fe947e
+      - req-2b9f042c-33e1-43ab-a5b3-1fa30b5c4417
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -27760,7 +27890,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -27775,22 +27905,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05bf9241-178b-45d2-8e56-4491e2bb6587
+      - req-b09ed092-f216-4008-83e7-c517779343ca
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-05bf9241-178b-45d2-8e56-4491e2bb6587
+      - req-b09ed092-f216-4008-83e7-c517779343ca
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -27824,7 +27954,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -27839,27 +27969,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-297114e1-39e7-43ee-9a71-8503b59dbb7c
+      - req-a65d6dae-d943-4008-9875-3a97a8695f4a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-297114e1-39e7-43ee-9a71-8503b59dbb7c
+      - req-a65d6dae-d943-4008-9875-3a97a8695f4a
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -27874,27 +28004,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0ed70574-4825-4394-b4b9-ea1e9464e92c
+      - req-c08e6368-34cb-4847-80d4-3ccfcef2a551
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0ed70574-4825-4394-b4b9-ea1e9464e92c
+      - req-c08e6368-34cb-4847-80d4-3ccfcef2a551
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -27909,27 +28039,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7dcad97c-c9e5-4dc6-a3bd-e559f2acbf05
+      - req-3513d092-399c-4909-8def-e37a52803122
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7dcad97c-c9e5-4dc6-a3bd-e559f2acbf05
+      - req-3513d092-399c-4909-8def-e37a52803122
       Date:
-      - Tue, 08 Jan 2019 19:20:25 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -27944,27 +28074,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1d577658-434e-476f-a8d8-3d31a54ec226
+      - req-b3fca1af-5680-4652-bd79-c3525f2dac6d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1d577658-434e-476f-a8d8-3d31a54ec226
+      - req-b3fca1af-5680-4652-bd79-c3525f2dac6d
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -27979,27 +28109,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dc825e64-5ba4-42c9-8625-15761500c08b
+      - req-a94c4b4d-82f6-412e-b646-4d7a2721aa6c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dc825e64-5ba4-42c9-8625-15761500c08b
+      - req-a94c4b4d-82f6-412e-b646-4d7a2721aa6c
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -28014,27 +28144,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dccf6ad6-3413-4cec-aab6-f24775d27ca1
+      - req-d5eb706a-ddb9-49b2-9326-f03e67a16ad0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-dccf6ad6-3413-4cec-aab6-f24775d27ca1
+      - req-d5eb706a-ddb9-49b2-9326-f03e67a16ad0
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -28049,27 +28179,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-166bf270-8ff9-463a-a226-e44b8e65e334
+      - req-474f0081-4e04-4b2b-b473-ca0f2dd423ea
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-166bf270-8ff9-463a-a226-e44b8e65e334
+      - req-474f0081-4e04-4b2b-b473-ca0f2dd423ea
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -28084,27 +28214,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe493299-470b-4b26-8063-7907947cbf20
+      - req-37718336-f180-4df2-b672-c4b621267955
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fe493299-470b-4b26-8063-7907947cbf20
+      - req-37718336-f180-4df2-b672-c4b621267955
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -28119,27 +28249,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7accf071-f8ee-4329-8418-670a8563bb4f
+      - req-9b8bee5d-745a-4955-bf6a-ef713bb7fcdf
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7accf071-f8ee-4329-8418-670a8563bb4f
+      - req-9b8bee5d-745a-4955-bf6a-ef713bb7fcdf
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -28154,22 +28284,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aaf7546f-245f-4677-b818-87dfc8656664
+      - req-429b6c1d-bf6d-42d3-b282-56566d178f6b
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-aaf7546f-245f-4677-b818-87dfc8656664
+      - req-429b6c1d-bf6d-42d3-b282-56566d178f6b
       Date:
-      - Tue, 08 Jan 2019 19:20:26 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -28184,7 +28314,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -28199,22 +28329,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-00baa674-1efa-4bc1-9c50-245ba1e15245
+      - req-3b6e5af3-f2c4-4edf-af71-3e8e37302dd9
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-00baa674-1efa-4bc1-9c50-245ba1e15245
+      - req-3b6e5af3-f2c4-4edf-af71-3e8e37302dd9
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -28229,7 +28359,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -28244,27 +28374,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6dada3a3-0db9-438b-9070-5a31b252e272
+      - req-997755cb-a5b1-46da-91e1-479dfaf7e28f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-6dada3a3-0db9-438b-9070-5a31b252e272
+      - req-997755cb-a5b1-46da-91e1-479dfaf7e28f
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -28279,27 +28409,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d0e9ad7a-4609-4a51-8451-a36feb603644
+      - req-5dfd5d20-09bb-4e53-af60-d9af957835cc
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d0e9ad7a-4609-4a51-8451-a36feb603644
+      - req-5dfd5d20-09bb-4e53-af60-d9af957835cc
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -28314,27 +28444,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c319a94a-7fdc-45c9-b4c1-8460e806afde
+      - req-c3d40563-f103-427e-b371-864b6e328710
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c319a94a-7fdc-45c9-b4c1-8460e806afde
+      - req-c3d40563-f103-427e-b371-864b6e328710
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -28349,27 +28479,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c38364b7-ef5d-4c94-bc34-0bcbf7c2eba3
+      - req-26116db4-72a5-4bf7-8962-32a1cd758b93
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c38364b7-ef5d-4c94-bc34-0bcbf7c2eba3
+      - req-26116db4-72a5-4bf7-8962-32a1cd758b93
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -28384,27 +28514,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1b47767f-8174-466d-990b-e4bcef189084
+      - req-27ce41e1-41bb-4f66-9081-005dc53c94f0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1b47767f-8174-466d-990b-e4bcef189084
+      - req-27ce41e1-41bb-4f66-9081-005dc53c94f0
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -28419,27 +28549,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7a2bced2-9dd8-42e0-8be2-cf4615e7b64a
+      - req-98192845-6da5-483b-b678-30e83d153e1b
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-7a2bced2-9dd8-42e0-8be2-cf4615e7b64a
+      - req-98192845-6da5-483b-b678-30e83d153e1b
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -28454,27 +28584,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d37a6286-ee91-4a2e-92c4-7e2456c32ae0
+      - req-6184425b-8beb-4d58-88fe-e7900f7dec2f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d37a6286-ee91-4a2e-92c4-7e2456c32ae0
+      - req-6184425b-8beb-4d58-88fe-e7900f7dec2f
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -28489,27 +28619,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25e0695f-d4e1-43ae-afb2-1f286756c9e1
+      - req-2fcba845-81d0-492a-81f6-980b1d20d27d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-25e0695f-d4e1-43ae-afb2-1f286756c9e1
+      - req-2fcba845-81d0-492a-81f6-980b1d20d27d
       Date:
-      - Tue, 08 Jan 2019 19:20:27 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -28524,27 +28654,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7dbc8c1d-a2d3-4e57-a2dd-ad0367491eb0
+      - req-dd588647-14de-47fd-a4b4-a0b3a1a9e693
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7dbc8c1d-a2d3-4e57-a2dd-ad0367491eb0
+      - req-dd588647-14de-47fd-a4b4-a0b3a1a9e693
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -28559,27 +28689,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a88966fa-7bec-4cfb-aaff-d106ed7d7073
+      - req-ee8e399d-3b71-47c5-a94c-244ee9a9f74a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a88966fa-7bec-4cfb-aaff-d106ed7d7073
+      - req-ee8e399d-3b71-47c5-a94c-244ee9a9f74a
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -28594,27 +28724,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a87d81f3-cda3-4fd2-858b-dffac357cbc8
+      - req-e9f8959f-81b0-4a24-83cd-b4bd7ed1373d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a87d81f3-cda3-4fd2-858b-dffac357cbc8
+      - req-e9f8959f-81b0-4a24-83cd-b4bd7ed1373d
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -28629,27 +28759,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-add51b6c-074b-4d75-aca1-29a16928a0fa
+      - req-5d7a4807-30d2-4579-b1d6-aacb157eda03
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-add51b6c-074b-4d75-aca1-29a16928a0fa
+      - req-5d7a4807-30d2-4579-b1d6-aacb157eda03
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -28664,27 +28794,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b710b874-feac-460b-9a20-ec455fef0eed
+      - req-f83e5165-20f1-4321-8923-8d4b353b2842
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b710b874-feac-460b-9a20-ec455fef0eed
+      - req-f83e5165-20f1-4321-8923-8d4b353b2842
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -28699,27 +28829,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ad0f3f58-ab8e-4bd2-b492-1b2f0df6d548
+      - req-89c36a83-0c30-4806-8e62-14baa151f0cc
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ad0f3f58-ab8e-4bd2-b492-1b2f0df6d548
+      - req-89c36a83-0c30-4806-8e62-14baa151f0cc
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -28734,27 +28864,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-849875f6-e1df-45c6-baa7-19081df5f149
+      - req-9c242cc0-d8f1-4693-808b-34ac25938748
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-849875f6-e1df-45c6-baa7-19081df5f149
+      - req-9c242cc0-d8f1-4693-808b-34ac25938748
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -28769,27 +28899,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-01964311-08cb-4986-9791-ed0fa8da96fc
+      - req-eb74007f-ee4d-442f-a8d0-ba0a748fec55
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-01964311-08cb-4986-9791-ed0fa8da96fc
+      - req-eb74007f-ee4d-442f-a8d0-ba0a748fec55
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -28804,27 +28934,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aca92df4-de84-44a7-b94e-0492cec7e3fc
+      - req-512f12a9-6bd8-44a3-a0e6-b56b899eee73
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-aca92df4-de84-44a7-b94e-0492cec7e3fc
+      - req-512f12a9-6bd8-44a3-a0e6-b56b899eee73
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -28839,27 +28969,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6aac255-d40d-41b1-b04c-7ce72448cb51
+      - req-88421a7a-0912-4eae-880f-3f11c77b2fb8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-d6aac255-d40d-41b1-b04c-7ce72448cb51
+      - req-88421a7a-0912-4eae-880f-3f11c77b2fb8
       Date:
-      - Tue, 08 Jan 2019 19:20:28 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -28874,27 +29004,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-207141af-64ab-41c9-a236-f79030fa2cd9
+      - req-92d83737-5280-4007-a079-e492feb9757c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-207141af-64ab-41c9-a236-f79030fa2cd9
+      - req-92d83737-5280-4007-a079-e492feb9757c
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -28909,27 +29039,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-883e55be-ba3f-472a-baf2-ce117d1d4733
+      - req-9b9f2d10-aa1b-4a2b-ac1b-200a3da59391
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-883e55be-ba3f-472a-baf2-ce117d1d4733
+      - req-9b9f2d10-aa1b-4a2b-ac1b-200a3da59391
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -28944,27 +29074,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e35b1f9c-8dac-4a79-9db2-9f0abf2448b2
+      - req-cc92ae01-f4ca-4293-974b-51b898b6a3d2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e35b1f9c-8dac-4a79-9db2-9f0abf2448b2
+      - req-cc92ae01-f4ca-4293-974b-51b898b6a3d2
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -28979,27 +29109,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2d508a78-87c9-46dc-9afa-5f4bc8a8a39e
+      - req-adabb514-a10b-40d5-b264-f656185701cb
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2d508a78-87c9-46dc-9afa-5f4bc8a8a39e
+      - req-adabb514-a10b-40d5-b264-f656185701cb
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -29014,22 +29144,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a54e7fea-6776-49cf-b25b-3a64ecd137bb
+      - req-bfa20ae9-78d3-4b75-a193-ae914f32be41
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a54e7fea-6776-49cf-b25b-3a64ecd137bb
+      - req-bfa20ae9-78d3-4b75-a193-ae914f32be41
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29041,7 +29171,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29056,22 +29186,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfceabdad88341f8af18dd118038ed0f
+      - 89da76b0585d4c1cb206f1ef988bcbfe
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e46d20b7-859d-4542-af8e-ae854983d62c
+      - req-30be5824-75c8-4beb-9998-9e73025ad68b
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e46d20b7-859d-4542-af8e-ae854983d62c
+      - req-30be5824-75c8-4beb-9998-9e73025ad68b
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29083,7 +29213,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -29098,22 +29228,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0388fe01-8913-4a63-89a9-ea3184f27630
+      - req-40c5cf6e-e2d4-49d7-af96-458c93d75d3f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0388fe01-8913-4a63-89a9-ea3184f27630
+      - req-40c5cf6e-e2d4-49d7-af96-458c93d75d3f
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29125,7 +29255,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29140,22 +29270,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8ab3443d49ba416c99caf97096ae469d
+      - f5112ec0498942f0bdb04235ed396f5e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-27aad7cf-0138-4946-90be-211c02b50a1d
+      - req-6806ce8f-16b9-47a9-9d6c-2caf91caa889
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-27aad7cf-0138-4946-90be-211c02b50a1d
+      - req-6806ce8f-16b9-47a9-9d6c-2caf91caa889
       Date:
-      - Tue, 08 Jan 2019 19:20:29 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29167,7 +29297,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -29182,22 +29312,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-39c137d2-b54e-4201-a69b-b1b8457e73f2
+      - req-6d3cc272-8504-418d-830a-6bb1a92e74c2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-39c137d2-b54e-4201-a69b-b1b8457e73f2
+      - req-6d3cc272-8504-418d-830a-6bb1a92e74c2
       Date:
-      - Tue, 08 Jan 2019 19:20:30 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29209,7 +29339,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29224,22 +29354,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7696848e68df462e8b16ac63f9ca1e41
+      - c3592af313664e518e6965a04c783a1e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-295a56e4-0a8e-4012-b9c0-9e911952008d
+      - req-ea5bf8f2-7a45-4621-88ce-d533ecdcfd74
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-295a56e4-0a8e-4012-b9c0-9e911952008d
+      - req-ea5bf8f2-7a45-4621-88ce-d533ecdcfd74
       Date:
-      - Tue, 08 Jan 2019 19:20:30 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29251,7 +29381,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -29266,22 +29396,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8b832232-329d-4cb8-b8e1-e529d97b16c4
+      - req-21307981-1e93-4d79-8346-b42180014bc8
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8b832232-329d-4cb8-b8e1-e529d97b16c4
+      - req-21307981-1e93-4d79-8346-b42180014bc8
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29293,7 +29423,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29308,22 +29438,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cae73b56ef7545d8afd6f111239d25c2
+      - 667b2077dfc84b498c3a1c9f6322ac83
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-60d54ee1-f477-4070-b8d9-5046cf2020a3
+      - req-92805dca-7683-4aed-a903-aba8cf685854
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-60d54ee1-f477-4070-b8d9-5046cf2020a3
+      - req-92805dca-7683-4aed-a903-aba8cf685854
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29335,7 +29465,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -29350,22 +29480,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-28221fc8-b41d-46d3-9711-1e30b351b603
+      - req-1a5725f2-2123-4737-bae1-66bd1eed91e4
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-28221fc8-b41d-46d3-9711-1e30b351b603
+      - req-1a5725f2-2123-4737-bae1-66bd1eed91e4
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29377,7 +29507,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29392,22 +29522,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7fa170c9e3d648caa6441ec0533bd57c
+      - 06aa90a8d21f4f709c15effff2988927
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5589c39-a444-4b38-9ca9-264a21c15ac2
+      - req-b566b4a5-e451-4589-8e74-634c6959dc6d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e5589c39-a444-4b38-9ca9-264a21c15ac2
+      - req-b566b4a5-e451-4589-8e74-634c6959dc6d
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29419,7 +29549,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -29434,22 +29564,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6e61b838-b67d-48db-8e40-1f0c312ad51f
+      - req-078f30db-2b06-43c3-8384-040f04ef68a5
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6e61b838-b67d-48db-8e40-1f0c312ad51f
+      - req-078f30db-2b06-43c3-8384-040f04ef68a5
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29461,7 +29591,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29476,22 +29606,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db531241698540b487e1e093c4112359
+      - 227ff7d675b84aa28a06c5df5ab66d5d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6ab742e9-d063-46a8-984f-9632a1d82a5f
+      - req-56bd2cdf-0e6f-434e-8dce-549f55a43dec
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6ab742e9-d063-46a8-984f-9632a1d82a5f
+      - req-56bd2cdf-0e6f-434e-8dce-549f55a43dec
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29503,7 +29633,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -29518,22 +29648,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-25245096-7383-4e51-a6be-de5416b155ba
+      - req-529211cd-0b38-4e1f-99df-9171e7e3b46a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-25245096-7383-4e51-a6be-de5416b155ba
+      - req-529211cd-0b38-4e1f-99df-9171e7e3b46a
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29545,7 +29675,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -29560,22 +29690,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e184a7926efc4e80b68a0511d5df1512
+      - 0dda98986263407ca99f04f92e23cbbf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-069265cc-25cd-4db4-97c4-3b02c09aeb2b
+      - req-1f3bdaf7-8f6b-46cf-8501-1bc6d4caaa85
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-069265cc-25cd-4db4-97c4-3b02c09aeb2b
+      - req-1f3bdaf7-8f6b-46cf-8501-1bc6d4caaa85
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -29587,7 +29717,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29605,15 +29735,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:31 GMT
+      - Mon, 04 Mar 2019 20:08:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f8494ea989bd423a9f340a4244448cbe
+      - 3299467f3d064bc085204e7c1c4c074d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1d526dc1-fa24-4e2a-8f3a-1e1c6204610e
+      - req-c0df215d-5311-4644-a9e4-8ba28a6d4961
       Content-Length:
       - '7311'
       Connection:
@@ -29625,7 +29755,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:32.059494Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:12.888794Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29704,10 +29834,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oiJFyyTMTwSmgehCKkvXeg"],
-        "issued_at": "2019-01-08T19:20:32.059519Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nATRGcHgSk6xvi-vIIrugg"],
+        "issued_at": "2019-03-04T20:08:12.888820Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29725,15 +29855,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:32 GMT
+      - Mon, 04 Mar 2019 20:08:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eddbe5b282d3442191ca8290771efb5c
+      - b60bcaac55234c288ab5746bb61c77b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-16c332f0-99da-43fb-910f-c2956fb502ce
+      - req-ff95d828-c10b-424c-b5a0-bdc1ae245fe6
       Content-Length:
       - '7311'
       Connection:
@@ -29745,7 +29875,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:32.322573Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:13.110433Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -29824,10 +29954,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AJ573qtTSlqMRJXzveqUog"],
-        "issued_at": "2019-01-08T19:20:32.322600Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DhNqyUPGTk2a4MtYhuuGfA"],
+        "issued_at": "2019-03-04T20:08:13.110456Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29845,15 +29975,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:32 GMT
+      - Mon, 04 Mar 2019 20:08:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 392b659aa007459ea94bb16748482d51
+      - c00ea55be389497abf43e92fab1c3546
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-78c1626f-bc66-4b43-a985-0a0617a2394a
+      - req-8959b6ed-1af9-4381-b74f-3f0d82cc141e
       Content-Length:
       - '297'
       Connection:
@@ -29862,12 +29992,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:20:32.523281Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:08:13.286986Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ITPXZjTKSciVx6sHlmMkkw"],
-        "issued_at": "2019-01-08T19:20:32.523301Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sGdLSba4R3CYBv7z3raKwg"],
+        "issued_at": "2019-03-04T20:08:13.287007Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:13 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -29882,20 +30012,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 392b659aa007459ea94bb16748482d51
+      - c00ea55be389497abf43e92fab1c3546
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:32 GMT
+      - Mon, 04 Mar 2019 20:08:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8d0886a3-502b-4628-83f9-05105da5f5bc
+      - req-12c5ddcd-877b-48da-90b7-7f68eb73b3b2
       Content-Length:
       - '2475'
       Connection:
@@ -29928,7 +30058,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -29946,15 +30076,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:32 GMT
+      - Mon, 04 Mar 2019 20:08:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfd08d04531a40d5b679f753c33aa53c
+      - cf8c6d220d7f44d38feb242ee93391b1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e33e009d-f291-44d2-b489-ed81ae101a80
+      - req-eca25f67-3d6d-41fa-b703-a211ee602166
       Content-Length:
       - '7278'
       Connection:
@@ -29966,7 +30096,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:32.895636Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:13.636364Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30045,10 +30175,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TRs_ytJySTe3t0J-q6TXSA"],
-        "issued_at": "2019-01-08T19:20:32.895654Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZYlCDbpGQoalrhMsccJpCQ"],
+        "issued_at": "2019-03-04T20:08:13.636387Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30066,15 +30196,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:33 GMT
+      - Mon, 04 Mar 2019 20:08:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e41bfa7da6a8490bba60788a4cecff72
+      - 8a778df525c64b119679a889e67cf87d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-65781c24-9248-457d-a58a-8a8f3d11170d
+      - req-165f7df5-9b7b-40fc-8142-d700bba0db8d
       Content-Length:
       - '7278'
       Connection:
@@ -30086,7 +30216,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:33.117512Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:13.857591Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30165,10 +30295,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["a50U7or_SgSNI-uC2kmQcA"],
-        "issued_at": "2019-01-08T19:20:33.117530Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5R4rJH2fQzyQR8GvURxwrQ"],
+        "issued_at": "2019-03-04T20:08:13.857614Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30186,15 +30316,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:33 GMT
+      - Mon, 04 Mar 2019 20:08:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2d1020ae-bd1d-492a-a668-e778ce8f3bc0
+      - req-76ee084c-ae07-4a0f-b89f-8274be9cce07
       Content-Length:
       - '7264'
       Connection:
@@ -30206,7 +30336,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:33.329913Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:14.111970Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30285,10 +30415,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lwgDVu0cR5-2SoYbztfxYw"],
-        "issued_at": "2019-01-08T19:20:33.329967Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FwKEpNijTSq9QQeEIkA8hA"],
+        "issued_at": "2019-03-04T20:08:14.112013Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30306,15 +30436,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:33 GMT
+      - Mon, 04 Mar 2019 20:08:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - dd122cc8c3344a90aa7cfef05a18df35
+      - fc065cf5627349019914c77d7f62afad
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-00c2b475-af49-4ba6-aa7e-2708d0b14eb6
+      - req-0a39af91-9220-453c-a161-2e09c3e5d548
       Content-Length:
       - '7278'
       Connection:
@@ -30326,7 +30456,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:33.554762Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:19.375821Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30405,10 +30535,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RfZ8w-hSTl2Ha8XNNORJGg"],
-        "issued_at": "2019-01-08T19:20:33.554806Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7N1hHU_QTaK2Gzn-rLmNuQ"],
+        "issued_at": "2019-03-04T20:08:19.375840Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30426,15 +30556,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:33 GMT
+      - Mon, 04 Mar 2019 20:08:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 06dc7d25952440528a35660b28c4508a
+      - c33a9da9b32446d39ac0dc7f42b6b08f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6a197c55-895d-47e4-9f72-e1045ce93759
+      - req-b7c92efc-0bbb-45b2-9291-c3c3664dd880
       Content-Length:
       - '7265'
       Connection:
@@ -30446,7 +30576,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:33.772166Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:19.586562Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -30525,10 +30655,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZMisbZijT16d4NgA3rMQvA"],
-        "issued_at": "2019-01-08T19:20:33.772187Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1pSargovRM6EYF-ni9Q0Ig"],
+        "issued_at": "2019-03-04T20:08:19.586581Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -30546,15 +30676,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:33 GMT
+      - Mon, 04 Mar 2019 20:08:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a189bef0c34d483abbad386bfbc99d05
+      - 211cbd0b243e4963be94ac3ca889b18a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9b5363f1-eca6-4045-9cdf-e2dcac0c0630
+      - req-ec5fa0df-e00a-4393-bd2b-78bf164238c2
       Content-Length:
       - '7278'
       Connection:
@@ -30566,7 +30696,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:33.984387Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:19.797676Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -30645,10 +30775,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bM2eYGq3R1ijleHG8HRCdw"],
-        "issued_at": "2019-01-08T19:20:33.984408Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9Ou2iq4qSAumqY4uvfUstQ"],
+        "issued_at": "2019-03-04T20:08:19.797694Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -30663,7 +30793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfd08d04531a40d5b679f753c33aa53c
+      - cf8c6d220d7f44d38feb242ee93391b1
   response:
     status:
       code: 200
@@ -30676,22 +30806,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.11887'
+      - '1551730099.92983'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.11887'
+      - '1551730099.92983'
       X-Trans-Id:
-      - txf9416f4f39b74c92bcaad-005c34f802
+      - tx07b78103efdf44388cc35-005c7d85b3
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -30706,7 +30836,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e41bfa7da6a8490bba60788a4cecff72
+      - 8a778df525c64b119679a889e67cf87d
   response:
     status:
       code: 200
@@ -30719,22 +30849,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.23630'
+      - '1551730100.04664'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.23630'
+      - '1551730100.04664'
       X-Trans-Id:
-      - tx8de6ad0b64024dc7a008f-005c34f802
+      - txc867f98b9856444f9028f-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -30749,7 +30879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
   response:
     status:
       code: 200
@@ -30778,15 +30908,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx3c334634cca84b4a97b67-005c34f802
+      - tx00c123178d2b48ce91870-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -30801,7 +30931,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
   response:
     status:
       code: 200
@@ -30830,14 +30960,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx7e87b20b4c4a4f84b9260-005c34f802
+      - tx8ffa3801f82a4f02b98f3-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -30852,7 +30982,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dd122cc8c3344a90aa7cfef05a18df35
+      - fc065cf5627349019914c77d7f62afad
   response:
     status:
       code: 200
@@ -30865,22 +30995,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.60283'
+      - '1551730100.38061'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.60283'
+      - '1551730100.38061'
       X-Trans-Id:
-      - tx75b5419c019a4d2793695-005c34f802
+      - tx9a129eb26cdc46f0bf096-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -30895,7 +31025,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eddbe5b282d3442191ca8290771efb5c
+      - b60bcaac55234c288ab5746bb61c77b6
   response:
     status:
       code: 200
@@ -30908,22 +31038,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.72510'
+      - '1551730100.49006'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.72510'
+      - '1551730100.49006'
       X-Trans-Id:
-      - tx7cf61c6f34fa4bfdb71e4-005c34f802
+      - txa74f8b330de04f9da7063-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -30938,7 +31068,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 06dc7d25952440528a35660b28c4508a
+      - c33a9da9b32446d39ac0dc7f42b6b08f
   response:
     status:
       code: 200
@@ -30951,22 +31081,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.84302'
+      - '1551730100.60337'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.84302'
+      - '1551730100.60337'
       X-Trans-Id:
-      - tx1ef3771c63674f5f888fc-005c34f802
+      - tx722fe208a3bb47ebad524-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -30981,7 +31111,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a189bef0c34d483abbad386bfbc99d05
+      - 211cbd0b243e4963be94ac3ca889b18a
   response:
     status:
       code: 200
@@ -30994,22 +31124,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975234.96644'
+      - '1551730100.73390'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975234.96644'
+      - '1551730100.73390'
       X-Trans-Id:
-      - tx45067776f28c44e5a673d-005c34f802
+      - tx1cf030b926104743b6b43-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:34 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -31024,7 +31154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
   response:
     status:
       code: 200
@@ -31045,9 +31175,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx66d8d44ea6e14aec86791-005c34f803
+      - txe2db3b1e4fae4f5eb2a7d-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:35 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -31057,7 +31187,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -31072,7 +31202,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
   response:
     status:
       code: 200
@@ -31093,14 +31223,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx5907fafc64c648d89259d-005c34f803
+      - txb058d43776504241ac73e-005c7d85b4
       Date:
-      - Tue, 08 Jan 2019 19:20:35 GMT
+      - Mon, 04 Mar 2019 20:08:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -31115,7 +31245,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db8597f835c64b4b960b646cc65fde57
+      - dc5c034e90e444e0a02491c642b38c1e
   response:
     status:
       code: 200
@@ -31136,12 +31266,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx37e7fe896ed1490da3e5a-005c34f803
+      - tx5cc85a2e925f4ea7b19f5-005c7d85b5
       Date:
-      - Tue, 08 Jan 2019 19:20:35 GMT
+      - Mon, 04 Mar 2019 20:08:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:56 GMT
+      - Mon, 04 Mar 2019 20:08:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b379b049-2655-4af4-b0aa-a02e99a4b825
+      - req-5fb7bfe7-2c46-4851-ad44-bdb31e5adc29
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:56.361899Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:27.742312Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["SMz-KMGSSVqjLb1NvA-D2A"],
-        "issued_at": "2019-01-08T19:21:56.361940Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vjMoFhrLSB6nCC0fSlcoEQ"],
+        "issued_at": "2019-03-04T20:08:27.742331Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:21:56 GMT
+      - Mon, 04 Mar 2019 20:08:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -169,7 +169,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -182,171 +182,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-31f86735-789c-4da1-b741-41322fccb2ad
+      - req-78bdb3c0-d362-493d-b200-cdddc10c89cc
       Date:
-      - Tue, 08 Jan 2019 19:21:56 GMT
+      - Mon, 04 Mar 2019 20:08:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:56 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v3/auth/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 08 Jan 2019 19:21:56 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      X-Subject-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-9aabd962-741c-471c-b298-17b0922e7922
-      Content-Length:
-      - '7311'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
-        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
-        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:56.791137Z", "project":
-        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
-        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
-        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
-        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
-        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
-        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
-        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
-        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
-        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
-        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
-        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
-        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
-        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
-        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
-        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
-        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
-        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
-        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
-        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
-        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
-        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
-        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
-        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
-        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
-        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
-        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
-        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
-        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
-        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
-        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
-        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
-        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
-        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
-        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
-        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
-        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
-        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
-        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
-        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
-        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
-        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
-        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h07GJZFgSPuB3YeJ5DVpAQ"],
-        "issued_at": "2019-01-08T19:21:56.791155Z"}}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:57 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-56d5b470-841c-465c-9993-660316de0841
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '82'
-      X-Openstack-Request-Id:
-      - req-56d5b470-841c-465c-9993-660316de0841
-      Date:
-      - Tue, 08 Jan 2019 19:21:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
-        "nova"}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -361,7 +205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -374,26 +218,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-9c721677-63fc-4bb2-850b-f58527427263
+      - req-45ed24ce-90a5-4720-953f-be74123678ba
       Date:
-      - Tue, 08 Jan 2019 19:21:57 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:21:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:08:25.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:21:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:08:26.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:21:47.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:08:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:21:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:08:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:21:54.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:08:26.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -408,7 +252,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -421,26 +265,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a9044c26-f2eb-4024-b324-c904f18d06bf
+      - req-093830ba-9bab-4818-a4c5-dd9b690abdd5
       Date:
-      - Tue, 08 Jan 2019 19:21:58 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:21:50.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:08:25.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:21:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:08:26.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:21:57.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:08:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:21:49.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:08:18.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:21:54.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:08:26.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -455,7 +299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -468,9 +312,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-758abf9b-5ebb-4406-9130-1c00a28d5053
+      - req-5a35c278-18d7-4e02-8575-974e1e1a21a4
       Date:
-      - Tue, 08 Jan 2019 19:21:58 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -484,7 +328,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -499,7 +343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -512,9 +356,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-52b95558-1976-4458-9ee1-289321a6a780
+      - req-14ea6dc2-3676-4c6e-b8a8-6b6908e2fa1a
       Date:
-      - Tue, 08 Jan 2019 19:21:58 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -528,7 +372,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -543,7 +387,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -556,9 +400,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-17bea6bd-d350-487f-9741-1b3e4190ce75
+      - req-94cec2c6-d2a0-48b6-a020-14ac7493db5c
       Date:
-      - Tue, 08 Jan 2019 19:21:58 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -573,7 +417,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -588,7 +432,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -601,9 +445,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-7a2e3a77-7aaf-43d7-b349-6702c9c3f83b
+      - req-1564061a-976d-43f3-99b9-62cb3d1ce233
       Date:
-      - Tue, 08 Jan 2019 19:21:59 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -613,7 +457,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -631,15 +475,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:59 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f36f8cd5665d471f86241d49f453e655
+      - f44699452e2f4859a49d4542401ae095
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-85099a3d-f88b-4796-97fb-4d5fd63a3ebc
+      - req-be059a7d-7cf9-4ba2-9727-87d8ad054544
       Content-Length:
       - '297'
       Connection:
@@ -648,12 +492,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:21:59.168403Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:08:28.802261Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KpO2WDu6TJmqBTtkW2ucBQ"],
-        "issued_at": "2019-01-08T19:21:59.168430Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["GppCiNt0QX68xxsH5N1_8Q"],
+        "issued_at": "2019-03-04T20:08:28.802281Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -668,20 +512,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f36f8cd5665d471f86241d49f453e655
+      - f44699452e2f4859a49d4542401ae095
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:59 GMT
+      - Mon, 04 Mar 2019 20:08:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c04d832-c290-4445-b637-ee88a1212320
+      - req-bf0a08f4-7f24-4e60-8049-87582de10585
       Content-Length:
       - '2475'
       Connection:
@@ -714,7 +558,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -729,7 +573,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -742,15 +586,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-1144c1c9-dba5-43eb-9126-ebf41fb3a9a9
+      - req-f9f9b30c-1f7b-4a15-aea1-0ca5527150e9
       Date:
-      - Tue, 08 Jan 2019 19:21:59 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -768,15 +612,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:04 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3be91573029f4c149cce87e4133e3c6e
+      - 38cd543d6cef4e0c8c7d0e1c641d7f9c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ce88209c-cfc4-4e99-bd64-87b72f31078a
+      - req-b540d92b-2c54-4e11-a7b8-c7c9d5eae6e0
       Content-Length:
       - '7311'
       Connection:
@@ -788,7 +632,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:04.677182Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:29.251199Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -867,10 +711,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Fe0MXWm-RIGAY62vLg94bw"],
-        "issued_at": "2019-01-08T19:22:04.677200Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OhaR60UcRdKyksAlWrxfRg"],
+        "issued_at": "2019-03-04T20:08:29.251231Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -885,7 +729,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3be91573029f4c149cce87e4133e3c6e
+      - 38cd543d6cef4e0c8c7d0e1c641d7f9c
   response:
     status:
       code: 200
@@ -896,9 +740,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b0089d93-3447-4275-9ccf-658d719f2cbf
+      - req-3439d968-659c-4cec-b5d9-b539d81c7098
       Date:
-      - Tue, 08 Jan 2019 19:22:04 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -940,7 +784,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?marker=b672acdb-654b-41d7-963c-44a0349bd285
@@ -955,7 +799,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3be91573029f4c149cce87e4133e3c6e
+      - 38cd543d6cef4e0c8c7d0e1c641d7f9c
   response:
     status:
       code: 200
@@ -966,14 +810,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-599c2776-d4c2-4a06-adcc-2f2ce04d5ce1
+      - req-db885886-44c2-4007-8426-27087d0b069e
       Date:
-      - Tue, 08 Jan 2019 19:22:04 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -988,7 +832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1001,9 +845,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f96ac316-0607-4ec2-bc6e-794d30bdae6a
+      - req-cb3f6f4b-c987-4ba3-9e61-797adc1ed4bb
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1013,7 +857,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1028,7 +872,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1041,9 +885,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-f5662da3-072c-4f3e-9166-4a2a73b3dabd
+      - req-d0221b13-7cbd-4d12-82f5-04353ba5db0c
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -1053,7 +897,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1071,15 +915,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:29 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8bef699b72984062bcd4f32b10c8ce84
+      - d7e4b6de4fba4d06ab2b1ee7ed66e8cf
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2a2a7b4c-0844-4a3d-a519-5d4d7ccf3aee
+      - req-60b0d130-7f98-4f6a-96d0-d6957d4baa39
       Content-Length:
       - '7311'
       Connection:
@@ -1091,7 +935,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:05.322378Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:29.934569Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1170,10 +1014,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9VjjwoxoSOWinCSGYLTwRg"],
-        "issued_at": "2019-01-08T19:22:05.322396Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-HYd827iT1aVFF3e_c-k0Q"],
+        "issued_at": "2019-03-04T20:08:29.934588Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:29 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1191,15 +1035,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 23cc70434be04a5896baa207e12aa8ac
+      - '0951a04f82e94d84bd0de42d72e565b5'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-27dd990d-1667-4083-b81c-0638e5636b5b
+      - req-f0c0ce2a-9b37-47aa-823b-52a659da5241
       Content-Length:
       - '7278'
       Connection:
@@ -1211,7 +1055,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:05.523173Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:30.137765Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1290,10 +1134,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OPxr4gr9RtKXJxXZGBTUDg"],
-        "issued_at": "2019-01-08T19:22:05.523191Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9jvzN-X-QvKj4MDnGUR7bg"],
+        "issued_at": "2019-03-04T20:08:30.137785Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1311,15 +1155,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3f0a90959b804247b36d9ee8a2424453
+      - 4f93ca73fa05416d803f1ff5a65d8c80
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e1112669-fa6f-4c5c-a071-ac96e371e0d9
+      - req-6f9e294a-9c78-41fc-b3a3-3864333235f0
       Content-Length:
       - '7278'
       Connection:
@@ -1331,7 +1175,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:05.724379Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:30.346701Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1410,10 +1254,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r9Nnr45cSNOl-o0PpLmBBQ"],
-        "issued_at": "2019-01-08T19:22:05.724396Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UEQwT4GyTGSiuNavBMneGw"],
+        "issued_at": "2019-03-04T20:08:30.346719Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1431,15 +1275,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:05 GMT
+      - Mon, 04 Mar 2019 20:08:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9ce4b3b5-dbd0-44be-aec4-e7b184f2d39c
+      - req-b1de4265-7fe2-4d30-8f42-34dbc7797aa4
       Content-Length:
       - '7264'
       Connection:
@@ -1451,7 +1295,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:05.965300Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:30.554891Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1530,10 +1374,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["anLTY1nTSq6y2hTmWrWmvQ"],
-        "issued_at": "2019-01-08T19:22:05.965320Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ulIf42UGS3myVemz9__9BA"],
+        "issued_at": "2019-03-04T20:08:30.554910Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1551,15 +1395,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:11 GMT
+      - Mon, 04 Mar 2019 20:08:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2b2ec5c15e5a445fa437ea43f840493f
+      - fb6016df445346409021d68173b0c6f5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5bd8efa9-d698-4b63-a7db-0f69e6a948ae
+      - req-8be837d5-f360-4103-a805-6aee80ab33e2
       Content-Length:
       - '7278'
       Connection:
@@ -1571,7 +1415,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:11.234784Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:30.758513Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1650,10 +1494,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["F_L0ziQpQ96pkcvOIARCRg"],
-        "issued_at": "2019-01-08T19:22:11.234803Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PAyRvAEaQE-_gKjyIfxwqg"],
+        "issued_at": "2019-03-04T20:08:30.758531Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1671,15 +1515,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:11 GMT
+      - Mon, 04 Mar 2019 20:08:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '059c579b66fe4ed7bbe9f59dcc69088f'
+      - 43c0ea26eb254722ba8407e0de9e5a9b
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-052b6f40-9990-4195-bf3c-8fb74dddc5f2
+      - req-2421fff3-fccf-4b7a-8273-03d70abdb5e4
       Content-Length:
       - '7265'
       Connection:
@@ -1691,7 +1535,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:11.448068Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:30.996260Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1770,10 +1614,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZtRi84mvTLGrzqAcfr1b0w"],
-        "issued_at": "2019-01-08T19:22:11.448088Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h21aNrTdTnqk0TQ_zDClwg"],
+        "issued_at": "2019-03-04T20:08:30.996281Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1791,15 +1635,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:11 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7208b519cdd241f19135b9d517c9e4bb
+      - bef81236e7b747039cc535daec2a817d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-773b9146-d86c-43b5-b0f1-881b114a2c0b
+      - req-24f59e58-ebc7-49bd-af0d-b80cfa90415f
       Content-Length:
       - '7278'
       Connection:
@@ -1811,7 +1655,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:11.656709Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:31.195322Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1890,10 +1734,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mw5BPQv-T2aqBqJ-LDQwsw"],
-        "issued_at": "2019-01-08T19:22:11.656729Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ruEo72TkTJWIMVZ1ySCDQQ"],
+        "issued_at": "2019-03-04T20:08:31.195340Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -1908,7 +1752,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 23cc70434be04a5896baa207e12aa8ac
+      - '0951a04f82e94d84bd0de42d72e565b5'
   response:
     status:
       code: 200
@@ -1919,14 +1763,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-7cf3a008-8732-4ed9-8295-6256dd2027c7
+      - req-4725208f-97b3-4954-ba2f-d3bcdc9fc81b
       Date:
-      - Tue, 08 Jan 2019 19:22:11 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -1941,7 +1785,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3f0a90959b804247b36d9ee8a2424453
+      - 4f93ca73fa05416d803f1ff5a65d8c80
   response:
     status:
       code: 200
@@ -1952,14 +1796,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-dc87fccf-c9cc-44b5-bbb8-9646df86beab
+      - req-753c0a68-77fc-4542-b587-48f16bb2959a
       Date:
-      - Tue, 08 Jan 2019 19:22:11 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -1974,7 +1818,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -1985,9 +1829,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-16e3d98f-8b98-4843-b9bd-a6d5f84055b4
+      - req-d1a84bfe-7593-4557-a3a3-89a158525ec0
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2021,7 +1865,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -2036,7 +1880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2047,14 +1891,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1fbc67ab-20fb-4e11-9476-8868b183e8ae
+      - req-c36bc880-6bae-4b1d-b22f-533fd1b0064b
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -2069,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2b2ec5c15e5a445fa437ea43f840493f
+      - fb6016df445346409021d68173b0c6f5
   response:
     status:
       code: 200
@@ -2080,14 +1924,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-bda25401-4b68-464b-ac97-e515b40cf22c
+      - req-8ae4eab4-392c-4214-abf5-f2e52b9428df
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -2102,7 +1946,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8bef699b72984062bcd4f32b10c8ce84
+      - d7e4b6de4fba4d06ab2b1ee7ed66e8cf
   response:
     status:
       code: 200
@@ -2113,14 +1957,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-9306f943-1ebb-4788-95f3-42cf3c945e30
+      - req-b8589b76-f8d3-41be-80de-0f5267ed24d7
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -2135,7 +1979,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '059c579b66fe4ed7bbe9f59dcc69088f'
+      - 43c0ea26eb254722ba8407e0de9e5a9b
   response:
     status:
       code: 200
@@ -2146,14 +1990,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-0ac3f66e-d7a8-4f82-a5fe-acec0d1aede6
+      - req-d01f0a39-7626-4046-970d-221e5cfc5e3a
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -2168,7 +2012,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7208b519cdd241f19135b9d517c9e4bb
+      - bef81236e7b747039cc535daec2a817d
   response:
     status:
       code: 200
@@ -2179,14 +2023,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6e2ef34f-9a43-4579-8dda-7335c45e9717
+      - req-357dc2cf-4183-4f75-8392-40f000d47553
       Date:
-      - Tue, 08 Jan 2019 19:22:12 GMT
+      - Mon, 04 Mar 2019 20:08:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -2201,7 +2045,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2212,9 +2056,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-88ca083e-ee17-4ccd-b8a5-36a15d8ddc67
+      - req-5bc9d56d-d08c-4b5b-a66c-b99eff06fa05
       Date:
-      - Tue, 08 Jan 2019 19:22:13 GMT
+      - Mon, 04 Mar 2019 20:08:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2241,7 +2085,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -2256,7 +2100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2267,9 +2111,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-c03a9323-4e16-47ba-9c51-5c8b30c87c04
+      - req-ff2e33dc-cc3a-487e-875e-9aba7503e38c
       Date:
-      - Tue, 08 Jan 2019 19:22:13 GMT
+      - Mon, 04 Mar 2019 20:08:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2296,7 +2140,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -2311,7 +2155,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2322,9 +2166,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-de686522-f98f-4a28-9ee0-e12037212a63
+      - req-bbaa1be1-9fc1-4665-89a6-b03a293e7722
       Date:
-      - Tue, 08 Jan 2019 19:22:13 GMT
+      - Mon, 04 Mar 2019 20:08:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2351,7 +2195,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -2366,7 +2210,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2377,9 +2221,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-15fb252b-9db8-40e7-bb23-4e4fd49a997f
+      - req-5129c26c-9fb6-4017-9075-152d55ef735e
       Date:
-      - Tue, 08 Jan 2019 19:22:13 GMT
+      - Mon, 04 Mar 2019 20:08:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2435,7 +2279,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -2450,7 +2294,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2461,9 +2305,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2a892df7-06bf-4846-9362-fea51bbfc35e
+      - req-cbd469ca-7c54-445d-bee8-4a2189f3283f
       Date:
-      - Tue, 08 Jan 2019 19:22:13 GMT
+      - Mon, 04 Mar 2019 20:08:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2475,7 +2319,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -2490,7 +2334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2503,9 +2347,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-35b5dc68-9460-4d82-abd2-0653ad8eca34
+      - req-c1aaaae6-f3e4-407e-b95e-40ba361f06e8
       Date:
-      - Tue, 08 Jan 2019 19:22:14 GMT
+      - Mon, 04 Mar 2019 20:08:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -2551,7 +2395,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:33 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -2566,7 +2410,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2579,9 +2423,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-1868bee5-45d0-45ee-bc04-6eb37b884751
+      - req-310d5589-2fec-4710-bcc9-8c14a59a5bef
       Date:
-      - Tue, 08 Jan 2019 19:22:14 GMT
+      - Mon, 04 Mar 2019 20:08:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -2627,7 +2471,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:34 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -2642,7 +2486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2655,9 +2499,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-10dc893b-c709-4bd8-8105-de1215a81adf
+      - req-5eb5049f-b5b5-4e8a-b1e6-c4e923760bed
       Date:
-      - Tue, 08 Jan 2019 19:22:14 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -2705,7 +2549,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -2720,7 +2564,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2733,9 +2577,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-9deceeac-c7da-4e75-b3e9-0b3093acd93d
+      - req-bd161d8d-05a8-48dd-a852-4e1f92d370bb
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -2777,7 +2621,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -2792,7 +2636,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2805,9 +2649,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-969ea104-0ddd-4165-be65-b25bfa69294d
+      - req-b88f7429-169c-4442-b529-cf19144e4cf3
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -2830,7 +2674,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -2845,7 +2689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2856,9 +2700,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-4904be79-e4d8-40f3-8c9f-a3aa37a1c998
+      - req-c0e11b50-906c-4255-afc0-b3547b59fe28
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -2914,7 +2758,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -2929,7 +2773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2940,9 +2784,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-47bfbd9a-5820-44d4-9582-f21e835c0cf5
+      - req-29ecba1f-cf11-460d-b3ea-5bb1d3181083
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -2954,7 +2798,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -2969,7 +2813,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -2980,9 +2824,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-94dc3c49-1393-40bb-b77b-821af324f0ed
+      - req-f942a4f4-bf6c-497f-9628-4bdfc581f6c7
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3038,7 +2882,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:35 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -3053,7 +2897,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8d47157f235940c084f7a1ee2d24f728
+      - 4436744341cb424f8c420281f2a88c6f
   response:
     status:
       code: 200
@@ -3064,9 +2908,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-b3bd8deb-fda7-44a2-a96c-dd332eb693ec
+      - req-32b08b30-8cbe-468a-9aa7-6717b088aad4
       Date:
-      - Tue, 08 Jan 2019 19:22:15 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3078,7 +2922,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3096,15 +2940,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f6f223fb39ed4e36aff01bfac14f0cf1
+      - 9b95312d10ca4e9aa45e22a6bd54e87d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7758a7c4-8be7-45d0-9bb7-6be6382216a1
+      - req-7c12d3c7-59ee-41dc-bab9-93ff8f209e4f
       Content-Length:
       - '7278'
       Connection:
@@ -3116,7 +2960,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:17.206680Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:36.295018Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3195,10 +3039,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AY3cNPq3QZqGipHqSn-faA"],
-        "issued_at": "2019-01-08T19:22:17.206701Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RBaYEAmITSmp8hOQ297FNA"],
+        "issued_at": "2019-03-04T20:08:36.295037Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3213,7 +3057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6f223fb39ed4e36aff01bfac14f0cf1
+      - 9b95312d10ca4e9aa45e22a6bd54e87d
   response:
     status:
       code: 200
@@ -3224,7 +3068,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3233,7 +3077,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3251,15 +3095,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b12591ec3c0e4884b4a105bd0d773e6c
+      - c84e0d29a01541f2ba677ee78cb905cb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bf490e71-1711-4c92-8529-7d3a3d8269d7
+      - req-0e019863-d6bd-4703-8185-5c64caab6406
       Content-Length:
       - '7278'
       Connection:
@@ -3271,7 +3115,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:17.510116Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:36.596885Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3350,10 +3194,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QI6yanypRwmOryHZ9s9OmQ"],
-        "issued_at": "2019-01-08T19:22:17.510135Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1wAQl7HqSnWGxa0lKbB63g"],
+        "issued_at": "2019-03-04T20:08:36.596903Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3368,7 +3212,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b12591ec3c0e4884b4a105bd0d773e6c
+      - c84e0d29a01541f2ba677ee78cb905cb
   response:
     status:
       code: 200
@@ -3379,7 +3223,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3388,7 +3232,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3406,15 +3250,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb4cd42488c54ca4b23869cf1214e1d0
+      - 112667cb4a3c4ffb93cee953c5bf40ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fc1096bb-3cd3-469b-80b3-1d34664f2344
+      - req-e46421b4-fa79-4008-965e-4c651317e3fd
       Content-Length:
       - '7264'
       Connection:
@@ -3426,7 +3270,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:17.796285Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:36.906860Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3505,10 +3349,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["eupfdDPxTBasMtqaM0_T4w"],
-        "issued_at": "2019-01-08T19:22:17.796305Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lU9H_TMMSACgIp_LHxxi6w"],
+        "issued_at": "2019-03-04T20:08:36.906884Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:36 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3523,7 +3367,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb4cd42488c54ca4b23869cf1214e1d0
+      - 112667cb4a3c4ffb93cee953c5bf40ae
   response:
     status:
       code: 200
@@ -3534,7 +3378,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:17 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3543,7 +3387,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3561,15 +3405,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 33f6385964a841638a7ce8cb7f90378e
+      - a08f5b953701471eaf7bdced33c43bf7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f5829021-b814-4c83-8da6-41a0b4366f34
+      - req-36d3a577-4263-4a60-87c4-c53346876495
       Content-Length:
       - '7278'
       Connection:
@@ -3581,7 +3425,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:18.081656Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:37.204640Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3660,10 +3504,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["neO2YTejQdy3GXYVT7L4qg"],
-        "issued_at": "2019-01-08T19:22:18.081675Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UsKk94saRCG3Z2cCbLp3ag"],
+        "issued_at": "2019-03-04T20:08:37.204658Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3678,7 +3522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33f6385964a841638a7ce8cb7f90378e
+      - a08f5b953701471eaf7bdced33c43bf7
   response:
     status:
       code: 200
@@ -3689,7 +3533,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3698,7 +3542,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3716,15 +3560,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 499869ad22be4cbd9fcf70023fe66463
+      - 6b08897b82594d49adf5a869a2886ebe
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f91e2c39-578d-4279-a5aa-87d148a3da51
+      - req-1d1dbd8e-db81-4d8b-ba50-8be2f7a9abb3
       Content-Length:
       - '7265'
       Connection:
@@ -3736,7 +3580,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:18.373092Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:37.486777Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3815,10 +3659,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OYo5zEIbTa2VSBMskrTotg"],
-        "issued_at": "2019-01-08T19:22:18.373110Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JCgDOmkETQWOCqmcoewqTg"],
+        "issued_at": "2019-03-04T20:08:37.486796Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3833,7 +3677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499869ad22be4cbd9fcf70023fe66463
+      - 6b08897b82594d49adf5a869a2886ebe
   response:
     status:
       code: 200
@@ -3844,7 +3688,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -3853,7 +3697,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3871,15 +3715,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9192ebee413a4f68803ceb3eb8410b94
+      - 5fac1c7d80694ea290ebf093dde7910f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a42f093f-0f22-474d-8196-53fd27f2749d
+      - req-a43fdc1f-26f5-48d4-8ec1-98c9b21921fe
       Content-Length:
       - '7278'
       Connection:
@@ -3891,7 +3735,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:18.672308Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:37.772964Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3970,10 +3814,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_2ur4GfPTSyDSaIP4ByTYQ"],
-        "issued_at": "2019-01-08T19:22:18.672333Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WvDbvdm2QiWxDAOix6nMFA"],
+        "issued_at": "2019-03-04T20:08:37.772982Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -3988,7 +3832,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9192ebee413a4f68803ceb3eb8410b94
+      - 5fac1c7d80694ea290ebf093dde7910f
   response:
     status:
       code: 200
@@ -3999,7 +3843,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -4008,7 +3852,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:37 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4023,7 +3867,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6f223fb39ed4e36aff01bfac14f0cf1
+      - 9b95312d10ca4e9aa45e22a6bd54e87d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4036,9 +3880,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-15432f5f-0bc0-4738-9d4b-841cbd428eeb
+      - req-c4a3990c-b044-42be-bbe2-2042da852195
       Date:
-      - Tue, 08 Jan 2019 19:22:18 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4047,7 +3891,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -4062,7 +3906,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b12591ec3c0e4884b4a105bd0d773e6c
+      - c84e0d29a01541f2ba677ee78cb905cb
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4075,9 +3919,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2c20512f-184c-46c8-8f5f-af3ace1aceb9
+      - req-eb7c88b4-08a0-4fc2-b114-a32d3bed683f
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4086,7 +3930,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -4101,7 +3945,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb4cd42488c54ca4b23869cf1214e1d0
+      - 112667cb4a3c4ffb93cee953c5bf40ae
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4114,9 +3958,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-312916f0-24df-4666-9b35-775b7d7311c9
+      - req-4b4562d0-c118-4819-aba6-4bda544ab874
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4125,7 +3969,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -4140,7 +3984,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 33f6385964a841638a7ce8cb7f90378e
+      - a08f5b953701471eaf7bdced33c43bf7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4153,9 +3997,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-b677e8f6-7008-41fe-9516-57c674f09219
+      - req-9cd88a28-3d6e-4042-a4d1-65e66f7f71c5
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4164,7 +4008,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -4179,7 +4023,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4192,9 +4036,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-098d0da8-a16d-400f-8658-e654c46cf923
+      - req-06c17bcc-6b2e-4ad8-9d6c-2f1f7403c668
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4203,7 +4047,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -4218,7 +4062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 499869ad22be4cbd9fcf70023fe66463
+      - 6b08897b82594d49adf5a869a2886ebe
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4231,9 +4075,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-e5107cf1-e296-49c0-b15e-4ed21a61aaac
+      - req-7d5f566b-092f-4b33-a632-36093e9993ac
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4242,7 +4086,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4257,7 +4101,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9192ebee413a4f68803ceb3eb8410b94
+      - 5fac1c7d80694ea290ebf093dde7910f
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4270,9 +4114,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-991fbec7-c9c4-4634-89c1-2891dc54d333
+      - req-e9a8b4a2-9e59-4583-a525-8fcbe737ae58
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4281,7 +4125,127 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v3/auth/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"admin","domain":{"id":"default"},"password":"password_2WpEraURh"}}},"scope":{"project":{"name":"admin","domain":{"id":"default"}}}}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 Mar 2019 20:08:38 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      X-Subject-Token:
+      - 894d8480e3e74b29a87209bbeaa64ec0
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-ec125f41-0ce4-4f5c-8552-f50604e94309
+      Content-Length:
+      - '7311'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
+        "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
+        {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:38.896239Z", "project":
+        {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
+        "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
+        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
+        "id": "34cb7f8ea1f0450ab0ec046c9eeb9176"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:35357/v3", "region": "RegionOne", "interface": "admin",
+        "id": "a879cd474f4f45f0acd813ecd67db5b5"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "internal",
+        "id": "c42f0b5755644f0dab41c5baee5a4203"}], "type": "identity", "id": "378e5c74fa504811b10c62d26765f7fb",
+        "name": "keystone"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9292",
+        "region": "RegionOne", "interface": "internal", "id": "240e0fa371c94693a694869ed9dd3190"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne",
+        "interface": "public", "id": "9d8368b60ca34133be09d57bc831e499"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9292", "region": "RegionOne", "interface":
+        "admin", "id": "f8cddd96970c4c15b6d3058753ac64c0"}], "type": "image", "id":
+        "3fc24923e2b34eff8078c8274bfd5ba4", "name": "glance"}, {"endpoints": [{"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface":
+        "public", "id": "0f0f40e5a2f145e2844eee69a7586257"}, {"region_id": "RegionOne",
+        "url": "http://10.8.99.206:8777", "region": "RegionOne", "interface": "admin",
+        "id": "72927918447d45269cfbafed21ea84e0"}, {"region_id": "RegionOne", "url":
+        "http://10.8.99.206:8777", "region": "RegionOne", "interface": "internal",
+        "id": "f0397fadc13245d9b678e1fd2ea4a95f"}], "type": "metering", "id": "43d262cde2b14730ab0a61e201b234ef",
+        "name": "ceilometer"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3",
+        "region": "RegionOne", "interface": "internal", "id": "054d6e2484744480b091a8ea0e6e5477"},
+        {"region_id": "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne",
+        "interface": "admin", "id": "769ff19e965d45a39824d5a055e461ca"}, {"region_id":
+        "RegionOne", "url": "http://127.0.0.1:8774/v3", "region": "RegionOne", "interface":
+        "public", "id": "831ee4d526e7486e89e337febc5d7c58"}], "type": "computev3",
+        "id": "47f8d97599724a198240fc1c87c05abb", "name": "novav3"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "internal", "id": "2c9c27be8c144aca869c79bb064b03a6"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Cloud",
+        "region": "RegionOne", "interface": "public", "id": "e97612a8a6114aaa9bedf36b3987826f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8773/services/Admin",
+        "region": "RegionOne", "interface": "admin", "id": "fdf49d42181440e6807920689cc8c8df"}],
+        "type": "ec2", "id": "5a5f143e5561472ebc13b70863c91118", "name": "nova_ec2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "0126f635192042669a4a4e7151ea4add"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "3b7ed33e12ca475d8d8e6d6be8774760"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "db336e82925142a89e4a9c193066c0fb"}],
+        "type": "volume", "id": "6853145a3cd44ee5b3d23336a01357ce", "name": "cinder"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "2743bb5edbff4fe3a99465295e7686f4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "b269df32dc89471ab84ab10385d314c2"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "d9f5ae421fcf41bb8753261822583aef"}],
+        "type": "compute", "id": "8dff9e9f63224a7fb98f9b0638f2f4d4", "name": "nova"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "1412d9b3e8d64503b8e5e60e07cf338f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "64fae0d703de4d16909d9abd740ac37e"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "d6e70de7d8de4f1cabf141a969d1bcbd"}],
+        "type": "volumev2", "id": "98fbad4787294144b026a89efdb550d6", "name": "cinderv2"},
+        {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:9696",
+        "region": "RegionOne", "interface": "admin", "id": "ac6ad70d28764d2688f1a45592c80f79"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne",
+        "interface": "public", "id": "e4381e1a44a04306b08d4c1d42c6b79c"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:9696", "region": "RegionOne", "interface":
+        "internal", "id": "f1af202638604065b335662a7c48ff11"}], "type": "network",
+        "id": "c44c166b9e3b46e38d646d4080ec1f03", "name": "neutron"}, {"endpoints":
+        [{"region_id": "RegionOne", "url": "http://10.8.99.206:8080", "region": "RegionOne",
+        "interface": "admin", "id": "76a21c541726433ba1d34d74c4410584"}, {"region_id":
+        "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "9b22f81013f249c3a25eb2971b76a1c4"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "c691466ada4a4fedab7cb52c8d78f5f7"}],
+        "type": "object-store", "id": "c77afa5055604ebf902b31a54ca514fa", "name":
+        "swift"}, {"endpoints": [{"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "admin", "id": "2d908c9ff95d45a393a5d54718935b9f"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "internal", "id": "4d1abf0ee917466795b0be07e4508232"},
+        {"region_id": "RegionOne", "url": "http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52",
+        "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
+        "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
+        "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zmRj3-v0TjiwYcpHQARFsg"],
+        "issued_at": "2019-03-04T20:08:38.896261Z"}}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:08:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4299,15 +4263,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e11f9bc4069d4fe8844d7dff74760bd0
+      - 9978fc0eee0c41a0a8ab0bfcf8c3dd90
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c5d8fcf-8ba9-4b89-b626-29aa0f7401c7
+      - req-bd310511-5467-469a-87b4-f2b4803b5a77
       Content-Length:
       - '7278'
       Connection:
@@ -4319,7 +4283,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:19.788828Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:39.102565Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4398,10 +4362,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QRX1A6O-SbaN5QiacvDYgA"],
-        "issued_at": "2019-01-08T19:22:19.788856Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QHCpHxFdQJiaRd00n-SDrg"],
+        "issued_at": "2019-03-04T20:08:39.102585Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4419,15 +4383,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:19 GMT
+      - Mon, 04 Mar 2019 20:08:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 215a25220332465da2e23c733d1d6d4a
+      - 4a18cb26f8ac44d19768912dc072a9ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6b9a1f11-b557-42ff-a4b9-90b347b775c5
+      - req-30f0389d-f89d-484b-9100-92d67fdc6621
       Content-Length:
       - '7278'
       Connection:
@@ -4439,7 +4403,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:20.002113Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:39.376843Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4518,10 +4482,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["aHxqLk-UQiOU2u1_dQZCFg"],
-        "issued_at": "2019-01-08T19:22:20.002132Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_KtJTgsQTnyQGufKFdP4gQ"],
+        "issued_at": "2019-03-04T20:08:39.376861Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4539,15 +4503,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:20 GMT
+      - Mon, 04 Mar 2019 20:08:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db0dc4ccbfc54a79a60ea86defe16ac1
+      - e4417d2a79fb42eeb270ab5bdb6fec63
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f19c8f91-178a-4d2f-a242-09953474efb9
+      - req-59d4ee3f-4d91-438a-8b9b-51a70f9daf19
       Content-Length:
       - '7264'
       Connection:
@@ -4559,7 +4523,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:20.199805Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:39.583191Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4638,10 +4602,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["skLia1ZdQDC6LFfAVL-pzw"],
-        "issued_at": "2019-01-08T19:22:20.199822Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2J9Hh9rMQVqwY3YNIYw5EA"],
+        "issued_at": "2019-03-04T20:08:39.583210Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4659,15 +4623,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:20 GMT
+      - Mon, 04 Mar 2019 20:08:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7a2ad197198a47469b90093e2c4e801f
+      - 6d509a4ba7184bcc8a51d77efe9c790f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-73b766b7-fdf4-475f-9fc4-2612d8d30fbf
+      - req-cb5daa62-34fa-44d2-9e72-a698ceaa704f
       Content-Length:
       - '7278'
       Connection:
@@ -4679,7 +4643,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:20.407158Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:40.680639Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4758,10 +4722,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0s5xiQ5vQeiseMzx5y1rKw"],
-        "issued_at": "2019-01-08T19:22:20.407175Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["699szxILSmiaBSfix4ZgLw"],
+        "issued_at": "2019-03-04T20:08:40.680659Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4779,15 +4743,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:20 GMT
+      - Mon, 04 Mar 2019 20:08:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 62da493a563d48c6a703b37d7298405f
+      - c1b7004a7f2a4a98a1c0105ce8c52dbb
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df070cdd-be4b-4ce4-aa80-b4e961bf56d8
+      - req-7b56148d-a1db-4ec3-9b22-8f11952d21af
       Content-Length:
       - '7265'
       Connection:
@@ -4799,7 +4763,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:20.612846Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:40.910624Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4878,10 +4842,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5lr3Sop4TWC-mVg995x0dg"],
-        "issued_at": "2019-01-08T19:22:20.612866Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ieww0jchQKqugLDF_h5nEw"],
+        "issued_at": "2019-03-04T20:08:40.910650Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4899,15 +4863,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:20 GMT
+      - Mon, 04 Mar 2019 20:08:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9e3fec51031e48f78db1bcc905c9287d
+      - 362242daaf5e49018351fdebcb8d9486
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59d22e22-b450-4e27-ae6e-56437d8bded5
+      - req-10da2b35-39e1-492b-852c-048ae577933a
       Content-Length:
       - '7278'
       Connection:
@@ -4919,7 +4883,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:20.819373Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:41.127617Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4998,10 +4962,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["893VxLTcTZKnUQO3JQi9jw"],
-        "issued_at": "2019-01-08T19:22:20.819391Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hTB7uBo6TdSCJgo5m1BzwQ"],
+        "issued_at": "2019-03-04T20:08:41.127636Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -5016,22 +4980,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e11f9bc4069d4fe8844d7dff74760bd0
+      - 9978fc0eee0c41a0a8ab0bfcf8c3dd90
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-668e210e-e93a-4e9c-9f20-4d1442c2ee00
+      - req-2198501b-16b2-4214-a50e-9f8b8383c19b
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-668e210e-e93a-4e9c-9f20-4d1442c2ee00
+      - req-2198501b-16b2-4214-a50e-9f8b8383c19b
       Date:
-      - Tue, 08 Jan 2019 19:22:21 GMT
+      - Mon, 04 Mar 2019 20:08:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5041,7 +5005,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -5056,22 +5020,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 215a25220332465da2e23c733d1d6d4a
+      - 4a18cb26f8ac44d19768912dc072a9ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b28bb56-5ac9-486f-acce-d05414f10d0e
+      - req-9610ae66-2d6b-43bb-a19a-404eece68926
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-4b28bb56-5ac9-486f-acce-d05414f10d0e
+      - req-9610ae66-2d6b-43bb-a19a-404eece68926
       Date:
-      - Tue, 08 Jan 2019 19:22:21 GMT
+      - Mon, 04 Mar 2019 20:08:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5081,7 +5045,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -5096,22 +5060,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db0dc4ccbfc54a79a60ea86defe16ac1
+      - e4417d2a79fb42eeb270ab5bdb6fec63
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81118488-abff-40cf-8183-2f47d415b580
+      - req-d7dae694-9e51-412d-8fe6-c97c038e869c
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-81118488-abff-40cf-8183-2f47d415b580
+      - req-d7dae694-9e51-412d-8fe6-c97c038e869c
       Date:
-      - Tue, 08 Jan 2019 19:22:21 GMT
+      - Mon, 04 Mar 2019 20:08:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5121,7 +5085,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -5136,22 +5100,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a2ad197198a47469b90093e2c4e801f
+      - 6d509a4ba7184bcc8a51d77efe9c790f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ceefa587-f588-44ae-b1a9-9da84cf63e26
+      - req-e7dc52a9-41e8-4891-bfa9-5d49c38a657e
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ceefa587-f588-44ae-b1a9-9da84cf63e26
+      - req-e7dc52a9-41e8-4891-bfa9-5d49c38a657e
       Date:
-      - Tue, 08 Jan 2019 19:22:21 GMT
+      - Mon, 04 Mar 2019 20:08:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5161,7 +5125,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -5176,22 +5140,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-05e0cb09-0c03-463f-a935-b12c457232ba
+      - req-d199fdb0-dddd-4f2d-b17d-f35582e71435
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-05e0cb09-0c03-463f-a935-b12c457232ba
+      - req-d199fdb0-dddd-4f2d-b17d-f35582e71435
       Date:
-      - Tue, 08 Jan 2019 19:22:22 GMT
+      - Mon, 04 Mar 2019 20:08:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5201,7 +5165,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -5216,22 +5180,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 62da493a563d48c6a703b37d7298405f
+      - c1b7004a7f2a4a98a1c0105ce8c52dbb
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-56afde22-1e7f-444b-a2a5-219e543a7228
+      - req-a717184b-4a07-4e1e-a2b2-bc5f96a59fe5
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-56afde22-1e7f-444b-a2a5-219e543a7228
+      - req-a717184b-4a07-4e1e-a2b2-bc5f96a59fe5
       Date:
-      - Tue, 08 Jan 2019 19:22:22 GMT
+      - Mon, 04 Mar 2019 20:08:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5241,7 +5205,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:42 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -5256,22 +5220,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e3fec51031e48f78db1bcc905c9287d
+      - 362242daaf5e49018351fdebcb8d9486
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fe649b1c-40ea-4f1a-8320-e68a24973fb8
+      - req-5f863211-6075-46dc-98ff-0c19fb3290ba
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-fe649b1c-40ea-4f1a-8320-e68a24973fb8
+      - req-5f863211-6075-46dc-98ff-0c19fb3290ba
       Date:
-      - Tue, 08 Jan 2019 19:22:22 GMT
+      - Mon, 04 Mar 2019 20:08:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -5281,7 +5245,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5299,15 +5263,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:22 GMT
+      - Mon, 04 Mar 2019 20:08:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0fb4f250f8774250b6f7020f48834a0e
+      - 70209e18d10848e7a4b7793d3e4eb88c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-355b3495-cdcc-4785-9efd-38a1e934cdc4
+      - req-59f095da-12d2-4cc4-aa50-26d0a98385dc
       Content-Length:
       - '7311'
       Connection:
@@ -5319,7 +5283,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:22.790571Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:43.095490Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5398,10 +5362,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IUhKi_LpT7KTKYQutibdZQ"],
-        "issued_at": "2019-01-08T19:22:22.790589Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8Q-77iv2SISH3BmFJ3rJfA"],
+        "issued_at": "2019-03-04T20:08:43.095509Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5419,15 +5383,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:22 GMT
+      - Mon, 04 Mar 2019 20:08:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c57bcce1be324934b284eca058289ae5
+      - 6e22e9b97fa844a981fbe3c767c45d58
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4fe33d22-b833-40c2-8488-6e14264b3dd0
+      - req-2b9b8348-2d1c-4b69-9dd4-d16fc77d4c31
       Content-Length:
       - '7278'
       Connection:
@@ -5439,7 +5403,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:22.989034Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:48.356286Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5518,10 +5482,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1COwfl55TP6BVIJcNc-hFw"],
-        "issued_at": "2019-01-08T19:22:22.989052Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["k3VnVa-0QYaVdVQzKgXxUQ"],
+        "issued_at": "2019-03-04T20:08:48.356306Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5539,15 +5503,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:23 GMT
+      - Mon, 04 Mar 2019 20:08:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ec962be2557e4354be0313254a9ab5e9
+      - 6ba35f87b51440f7a15465fa764029e1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50ec2539-f06c-487a-a2d2-9b6bed7e0755
+      - req-00c7635d-dd36-4fbd-8d43-f93f3da51351
       Content-Length:
       - '7278'
       Connection:
@@ -5559,7 +5523,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:23.185876Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:48.565202Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5638,10 +5602,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pjhcFUOXQpm3soLcgTSKOA"],
-        "issued_at": "2019-01-08T19:22:23.185893Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["45YgtuzOTAaG24vXywFVBQ"],
+        "issued_at": "2019-03-04T20:08:48.565221Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5659,15 +5623,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:23 GMT
+      - Mon, 04 Mar 2019 20:08:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1bed9cb65cca4dfbb7dc85d8203de22a
+      - ee21c04fb35e4fd298ffdfda6f7a4e47
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-79f17f27-4f54-4294-b7bf-eb1dd0e3a9d3
+      - req-0988e642-3c84-4d75-9c9b-b3086779f70e
       Content-Length:
       - '7264'
       Connection:
@@ -5679,7 +5643,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:23.393093Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:48.768642Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5758,10 +5722,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["M1Xydb5HTtCDKzj6sMLdkA"],
-        "issued_at": "2019-01-08T19:22:23.393112Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rA4OK62kQy6eTfAA8r5iPw"],
+        "issued_at": "2019-03-04T20:08:48.768661Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:48 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5779,15 +5743,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:23 GMT
+      - Mon, 04 Mar 2019 20:08:48 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cb071c3e2a4543b29e459a2b9501f258
+      - 93e323bb7cc14c66afd8d5abef26c83a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4de8eecb-7098-4490-b679-251d3f021dc7
+      - req-049791f7-6bd7-4076-9875-91b1ba996283
       Content-Length:
       - '7278'
       Connection:
@@ -5799,7 +5763,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:23.595494Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:48.985847Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5878,10 +5842,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BKwirWatTEeEDjXIih7Ntw"],
-        "issued_at": "2019-01-08T19:22:23.595512Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AnPScOYWSmeCYA6vMw6I3A"],
+        "issued_at": "2019-03-04T20:08:48.985874Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5899,15 +5863,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:23 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b1d125a674db44ecbd5442a957dd37ed
+      - 7a5e64dbeb404db1a051db2c905c5297
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-80f071f2-dcd1-4255-bda6-0918e726bf66
+      - req-7c574219-cbe3-4c51-973f-e726c048de5c
       Content-Length:
       - '7265'
       Connection:
@@ -5919,7 +5883,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:23.793160Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:49.190052Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5998,10 +5962,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8LjW9Ew_RKa361ko-_DPIw"],
-        "issued_at": "2019-01-08T19:22:23.793177Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["TSjjBXOIQPGlpcZWxR8B4w"],
+        "issued_at": "2019-03-04T20:08:49.190082Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6019,15 +5983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:23 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - adc7c8b085b04dc0b8becbba2c52e52f
+      - d0ad9722b14046c584dc7b6af694a4c4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-95ad47ee-b5ed-4813-985b-67b31c4b89fc
+      - req-7fdc3be5-c26d-404e-8ca0-bacf87c284a8
       Content-Length:
       - '7278'
       Connection:
@@ -6039,7 +6003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:23.998539Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:49.393446Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -6118,10 +6082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pwFknhvXRPuBf2lwGKcaXA"],
-        "issued_at": "2019-01-08T19:22:23.998557Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ao5JnxgsTZq66bYCM96SHg"],
+        "issued_at": "2019-03-04T20:08:49.393468Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -6136,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c57bcce1be324934b284eca058289ae5
+      - 6e22e9b97fa844a981fbe3c767c45d58
   response:
     status:
       code: 200
@@ -6147,16 +6111,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4c445ef9-ff0b-4c8e-a51f-c194f821b998
+      - req-c4b9a907-c74d-4e89-bf97-888245cd2a47
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -6171,7 +6135,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec962be2557e4354be0313254a9ab5e9
+      - 6ba35f87b51440f7a15465fa764029e1
   response:
     status:
       code: 200
@@ -6182,16 +6146,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-dcfe8d20-b4b8-4eb5-9075-f52c0a878ee8
+      - req-a3f22ac9-fca9-46a8-ad39-e59390bab42d
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -6206,7 +6170,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1bed9cb65cca4dfbb7dc85d8203de22a
+      - ee21c04fb35e4fd298ffdfda6f7a4e47
   response:
     status:
       code: 200
@@ -6217,16 +6181,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d711f65b-e092-4f5a-a8c4-6b99f6bbdf0a
+      - req-b4e21e45-cd9b-4aeb-9f23-70d7f1b52a6a
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -6241,7 +6205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cb071c3e2a4543b29e459a2b9501f258
+      - 93e323bb7cc14c66afd8d5abef26c83a
   response:
     status:
       code: 200
@@ -6252,16 +6216,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-4f0d762a-4f49-466c-9fb2-705ca250002d
+      - req-8d2518eb-ce46-4cc2-9fdd-ab203aa3167b
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -6276,7 +6240,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fb4f250f8774250b6f7020f48834a0e
+      - 70209e18d10848e7a4b7793d3e4eb88c
   response:
     status:
       code: 200
@@ -6287,16 +6251,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-e7971d6b-6f6a-4f09-838d-c9deb6f79e77
+      - req-07e9dbbe-816f-489c-9293-04cc63762f3f
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -6311,7 +6275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1d125a674db44ecbd5442a957dd37ed
+      - 7a5e64dbeb404db1a051db2c905c5297
   response:
     status:
       code: 200
@@ -6322,16 +6286,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-7a2f269f-3f96-49bf-bee4-60d4f860dd3b
+      - req-72f8b115-83fe-4cdd-9f2c-35367a2445cd
       Date:
-      - Tue, 08 Jan 2019 19:22:24 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -6346,7 +6310,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - adc7c8b085b04dc0b8becbba2c52e52f
+      - d0ad9722b14046c584dc7b6af694a4c4
   response:
     status:
       code: 200
@@ -6357,16 +6321,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-8ce5e548-cbdd-4b4a-b1f1-67bc70271ebe
+      - req-d46afdbf-79c4-48f5-b62c-2adf38aa734f
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/98b5cc33-7fb8-42b3-86f0-b35883e902aa/os-volume_attachments
@@ -6381,7 +6345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6394,15 +6358,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-8ef1010c-8e31-4846-86ff-51c6ea177807
+      - req-89b84d27-fd14-48ab-9ddc-8e4bc4054629
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "98b5cc33-7fb8-42b3-86f0-b35883e902aa",
         "id": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39", "volumeId": "032b36d1-3dfc-4ff8-af30-5fa74ff47a39"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/7edb7855-d974-4e45-8ad2-88491541ab91/os-volume_attachments
@@ -6417,7 +6381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6430,15 +6394,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-9734c6a8-8812-4937-860f-a85b38f6a049
+      - req-bd6dec0f-b451-4264-ba82-78985cecb04f
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "7edb7855-d974-4e45-8ad2-88491541ab91",
         "id": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5", "volumeId": "8791e24f-874d-4f1e-99ec-75fdb9d48ca5"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6456,15 +6420,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e0087bb14ed4d48adfe04c76161f100
+      - ae9b205e5cb54b948e218f89828735ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c659753f-b9fd-4695-9e65-4f12d52a6706
+      - req-6a917ac4-59f3-4cec-aebb-6dc463b34acf
       Content-Length:
       - '7311'
       Connection:
@@ -6476,7 +6440,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:25.595230Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:50.732004Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6555,10 +6519,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NLFWs0-ZRqCRbYZ12MFVZg"],
-        "issued_at": "2019-01-08T19:22:25.595255Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["5tIf3rIFRJq8pqTR_5PQeA"],
+        "issued_at": "2019-03-04T20:08:50.732024Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -6576,15 +6540,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:50 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - be658dfb1a9241a7976eb0c4cf5f7cd8
+      - 5b92fe489138431685dd4294b79f6a93
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-72c01ace-0e6d-4c3d-98b1-8ddf2ab331bb
+      - req-7f446b86-1ec4-483f-a3da-3942955a8050
       Content-Length:
       - '7311'
       Connection:
@@ -6596,7 +6560,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:25.794422Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:51.009275Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -6675,10 +6639,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FZz0UUPhQuSPEbu54cez2g"],
-        "issued_at": "2019-01-08T19:22:25.794440Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qQQhJ8uWRt61JGWA0gm5jQ"],
+        "issued_at": "2019-03-04T20:08:51.009300Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -6693,7 +6657,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788d4a4fb7e94fc58f146ff8656832ce
+      - 719fd9c275474c6d83735f0b187a84ee
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6706,14 +6670,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-af385f9f-61d7-4219-923e-010a12e1d391
+      - req-f56fe085-6cac-4e56-9a3b-104f903efe54
       Date:
-      - Tue, 08 Jan 2019 19:22:25 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available
@@ -6728,22 +6692,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81bf5a24-fc2d-4320-ad19-ff0d5147816e
+      - req-3e0b9608-d788-4510-9ff2-0c2ddf31c50e
       Content-Type:
       - application/json
       Content-Length:
       - '2740'
       X-Openstack-Request-Id:
-      - req-81bf5a24-fc2d-4320-ad19-ff0d5147816e
+      - req-3e0b9608-d788-4510-9ff2-0c2ddf31c50e
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&status=available&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -6776,7 +6740,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a&status=available
@@ -6791,22 +6755,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3be19c61-b282-415d-9f4c-dc37d3f34d88
+      - req-1802747e-ee21-4d21-ac53-82958c6e8353
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-3be19c61-b282-415d-9f4c-dc37d3f34d88
+      - req-1802747e-ee21-4d21-ac53-82958c6e8353
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -6823,7 +6787,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-08-19T08:37:13.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -6838,27 +6802,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0c6e1e2-db16-416a-bab5-6de9188a0b94
+      - req-f6034634-9062-448c-a5f1-6e0d437a3f3e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-b0c6e1e2-db16-416a-bab5-6de9188a0b94
+      - req-f6034634-9062-448c-a5f1-6e0d437a3f3e
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available
@@ -6873,22 +6837,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-947351e0-3bb2-42ef-aad7-90678bee057e
+      - req-5876d9fc-d2fa-45db-bff5-eb5aa527ba13
       Content-Type:
       - application/json
       Content-Length:
       - '1098'
       X-Openstack-Request-Id:
-      - req-947351e0-3bb2-42ef-aad7-90678bee057e
+      - req-5876d9fc-d2fa-45db-bff5-eb5aa527ba13
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?all_tenants=True&limit=1000&status=available&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -6903,7 +6867,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000
@@ -6918,22 +6882,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6886ede-dfd5-4adf-84e2-37f85e1fc524
+      - req-34ad0707-e3eb-4ed8-b085-0dbe79f08b68
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-f6886ede-dfd5-4adf-84e2-37f85e1fc524
+      - req-34ad0707-e3eb-4ed8-b085-0dbe79f08b68
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -6966,7 +6930,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -6981,22 +6945,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f94bb922-586c-4964-b845-c947a8f22a4a
+      - req-d40bc292-d814-4ba1-8e96-7c73544b250d
       Content-Type:
       - application/json
       Content-Length:
       - '3301'
       X-Openstack-Request-Id:
-      - req-f94bb922-586c-4964-b845-c947a8f22a4a
+      - req-d40bc292-d814-4ba1-8e96-7c73544b250d
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -7037,7 +7001,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -7052,22 +7016,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1fbe05b3-beea-46fd-98ca-3f00ac46ba85
+      - req-a8975506-cfd2-4088-b895-7a9bfba25006
       Content-Type:
       - application/json
       Content-Length:
       - '2770'
       X-Openstack-Request-Id:
-      - req-1fbe05b3-beea-46fd-98ca-3f00ac46ba85
+      - req-a8975506-cfd2-4088-b895-7a9bfba25006
       Date:
-      - Tue, 08 Jan 2019 19:22:26 GMT
+      - Mon, 04 Mar 2019 20:08:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -7101,7 +7065,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:52 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?all_tenants=True&limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -7116,27 +7080,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 942fb2cfbe8d451791486c9bf8b85a17
+      - 894d8480e3e74b29a87209bbeaa64ec0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-04ecbb6f-6c6e-4467-b87a-59bd02cb1939
+      - req-f53893df-2e30-4362-8671-6c3b5f8881be
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-04ecbb6f-6c6e-4467-b87a-59bd02cb1939
+      - req-f53893df-2e30-4362-8671-6c3b5f8881be
       Date:
-      - Tue, 08 Jan 2019 19:22:27 GMT
+      - Mon, 04 Mar 2019 20:08:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7154,15 +7118,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:28 GMT
+      - Mon, 04 Mar 2019 20:08:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3e452487c0e941f8aa8b64b2bfb8e38a
+      - e13b911e1ef04663a8b4a1429ac10f95
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d659d9c0-0d57-4756-8559-d15170f4a1dd
+      - req-cb84c8cf-3849-43c4-afa4-62e8545d047c
       Content-Length:
       - '7311'
       Connection:
@@ -7174,7 +7138,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:28.388129Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:53.673431Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7253,10 +7217,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HGQzVtoZTsuXXJHxwxkRvA"],
-        "issued_at": "2019-01-08T19:22:28.388150Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QnYs9NHJS9asU3rv2etTDA"],
+        "issued_at": "2019-03-04T20:08:53.673457Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7274,15 +7238,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:28 GMT
+      - Mon, 04 Mar 2019 20:08:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d929c249-1d18-4a25-a912-6e48eb130a43
+      - req-2ef53dd7-3e8d-48a2-b665-2b80f0eed24f
       Content-Length:
       - '7311'
       Connection:
@@ -7294,7 +7258,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:28.590707Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:53.917607Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7373,10 +7337,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["qshKf7hgRmmlmQbNNWhrRQ"],
-        "issued_at": "2019-01-08T19:22:28.590729Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N25KVhAcQW62JZ72FKE7Zg"],
+        "issued_at": "2019-03-04T20:08:53.917626Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7391,7 +7355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -7402,42 +7366,17 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-4b6f358a-6b99-4726-bd3b-bd3d0c28247a
+      - req-901b6826-f5a3-4bff-9c3c-5f6a30b3109c
       Date:
-      - Tue, 08 Jan 2019 19:22:28 GMT
+      - Mon, 04 Mar 2019 20:08:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "a6dc66a9-aac3-4fad-97a6-896dd23fbb10"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
-        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
-        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
-        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
+        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
-        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -7462,19 +7401,44 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
+        null}, {"status": "ACTIVE", "subnets": ["a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "9bb84a96-3a02-45be-9b16-b0db19c167db"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["c53efdb0-e706-4c94-b0e5-a9a2eb84b459"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "provider:segmentation_id":
-        13}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
+        13}, {"status": "ACTIVE", "subnets": ["64f64a1d-46bf-4862-a654-b004310cbd7f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "provider:segmentation_id":
+        64}, {"status": "ACTIVE", "subnets": ["bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b"],
+        "name": "EmsRefreshSpec-NetworkPublic_30", "provider:physical_network": "public_net_3",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f477c0cd-eba7-4f8d-a2cc-b05ece115c43"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
         "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7492,15 +7456,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:28 GMT
+      - Mon, 04 Mar 2019 20:08:55 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5600c489524f4940a3e10f21f198b82d
+      - 264761161b354082801d679fa74d38f4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8c97c870-2529-4484-b810-10f895888961
+      - req-467d36b2-6378-49aa-b316-252f491c6d5c
       Content-Length:
       - '7311'
       Connection:
@@ -7512,7 +7476,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:28.957184Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:08:55.974782Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7591,10 +7555,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["RoP3pBDXQw65BdSngE4TuA"],
-        "issued_at": "2019-01-08T19:22:28.957206Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-F5MJ33tT0KDNNj5bUeM0A"],
+        "issued_at": "2019-03-04T20:08:55.974812Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7612,15 +7576,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:29 GMT
+      - Mon, 04 Mar 2019 20:08:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f8a48bc95aac4f6b8be6854f4541a35f
+      - db392b4665ef4b3fa72d6c280460ad9f
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f8a2e526-478d-4c92-8cd9-d1c716961d19
+      - req-6634a8a3-7910-43ac-9ff2-07433f693378
       Content-Length:
       - '297'
       Connection:
@@ -7629,12 +7593,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:22:29.136141Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:08:56.149055Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hbIQgO3VTLii8Bd0wBqYwQ"],
-        "issued_at": "2019-01-08T19:22:29.136163Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["E5Fg1L6eSpSo7j76znc6UA"],
+        "issued_at": "2019-03-04T20:08:56.149072Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:56 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -7649,20 +7613,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f8a48bc95aac4f6b8be6854f4541a35f
+      - db392b4665ef4b3fa72d6c280460ad9f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:29 GMT
+      - Mon, 04 Mar 2019 20:08:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-10de8e9a-6c06-4ea4-bd7e-e35d79a27b68
+      - req-822433bb-35e6-4d6f-a873-d7ea644627ad
       Content-Length:
       - '2475'
       Connection:
@@ -7695,7 +7659,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7713,15 +7677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:29 GMT
+      - Mon, 04 Mar 2019 20:08:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 524a55320a0f4f5e956b3920e40b56cc
+      - fdc6c9ac158f4b4c94ee532b3d5397f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-071fd697-f509-4d63-9e19-059d53a15712
+      - req-d3636df6-c6a4-4b85-813d-9f640dc8c44b
       Content-Length:
       - '7278'
       Connection:
@@ -7733,7 +7697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:29.493062Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:56.487281Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7812,10 +7776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FxGqj_00ST6mmrW3RG_L9A"],
-        "issued_at": "2019-01-08T19:22:29.493090Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fDyo_ENsQLGiVH5ppz6lBw"],
+        "issued_at": "2019-03-04T20:08:56.487311Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7833,15 +7797,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:29 GMT
+      - Mon, 04 Mar 2019 20:08:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cfa77d40cd8b4afe8d405d6789835b45
+      - e6b28bfa3fda4983ab4d75b4481ed8ba
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e244f538-4044-453c-afbc-049c61db77b8
+      - req-3a556717-8aa6-4db5-9db3-460b3d392b0a
       Content-Length:
       - '7278'
       Connection:
@@ -7853,7 +7817,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:29.704580Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:56.689037Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -7932,10 +7896,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IirziJVvSvOLcPreZTHv_g"],
-        "issued_at": "2019-01-08T19:22:29.704600Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["z0-5zFNRTgeejMizi_O88g"],
+        "issued_at": "2019-03-04T20:08:56.689055Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7953,15 +7917,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:29 GMT
+      - Mon, 04 Mar 2019 20:08:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ecd7679-ae36-4062-b18a-33d8a7c576b4
+      - req-98d4c7db-2b0f-4fee-b8c9-aab116c19ef9
       Content-Length:
       - '7264'
       Connection:
@@ -7973,7 +7937,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:29.912117Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:56.893854Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8052,10 +8016,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Bbq9sU2DRECApWRooYx9BQ"],
-        "issued_at": "2019-01-08T19:22:29.912135Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EWPPwVN8RNSFA2cuUOk30Q"],
+        "issued_at": "2019-03-04T20:08:56.893879Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8073,15 +8037,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98e1a5196dda49838f2d3256e7661577
+      - 762c55c49d32497682864db87d446fc4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a7fdd7f8-470c-4721-a9cd-2afddf015264
+      - req-52f141e0-71e6-4043-8b55-9f27f384a7b4
       Content-Length:
       - '7278'
       Connection:
@@ -8093,7 +8057,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:30.116662Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:57.103362Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8172,10 +8136,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["fCgufC90RhCelQs6M-z2mA"],
-        "issued_at": "2019-01-08T19:22:30.116680Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Xy-iBs4kQ9aokxP0Js7XWA"],
+        "issued_at": "2019-03-04T20:08:57.103382Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8193,15 +8157,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 899891ba54204b2eb0504bf0e3895ad6
+      - a66cdb641cbf4e59935ee84094701d83
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-31e90622-46f1-41e5-8ec1-af92573003b3
+      - req-b8984f59-a13a-450c-86d7-b3b342dff6c0
       Content-Length:
       - '7265'
       Connection:
@@ -8213,7 +8177,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:30.314451Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:57.308855Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -8292,10 +8256,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4vRk8C20QCm1kkHHad7lXw"],
-        "issued_at": "2019-01-08T19:22:30.314468Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9WhaA8BAQlirMnTvkgt1jg"],
+        "issued_at": "2019-03-04T20:08:57.308874Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -8313,15 +8277,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - '08a5274d070c45e89ec613de8971a202'
+      - 5e39cd62bd4e46b5988a3fb7b76a77dc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bdfd32aa-a0f4-4c00-9663-6d71c8faaa91
+      - req-90f7bf63-a80b-4c9e-8e03-7641d6eb6e9d
       Content-Length:
       - '7278'
       Connection:
@@ -8333,7 +8297,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:30.550488Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:08:59.229355Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -8412,10 +8376,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jev7v_V-TS6uyWZID6EsCg"],
-        "issued_at": "2019-01-08T19:22:30.550513Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-WXnn2kKRPGrkVPTun52Fg"],
+        "issued_at": "2019-03-04T20:08:59.229374Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -8430,7 +8394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 524a55320a0f4f5e956b3920e40b56cc
+      - fdc6c9ac158f4b4c94ee532b3d5397f9
   response:
     status:
       code: 200
@@ -8441,14 +8405,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b9680a4a-aaec-4dc6-a288-12a09129ee1a
+      - req-b4f396eb-c8ea-4985-bfdc-1d01089930e8
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -8463,7 +8427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cfa77d40cd8b4afe8d405d6789835b45
+      - e6b28bfa3fda4983ab4d75b4481ed8ba
   response:
     status:
       code: 200
@@ -8474,14 +8438,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8c3d3cc3-645f-4529-9d9e-5962a54048a1
+      - req-4256e506-50af-40db-ab28-2be78887e47e
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -8496,7 +8460,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8507,9 +8471,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-12587a3f-e22b-4dd2-964f-61b1638e67c4
+      - req-d1c55020-fe07-4c53-83d0-e7edaae62247
       Date:
-      - Tue, 08 Jan 2019 19:22:30 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -8543,7 +8507,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -8558,7 +8522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8569,14 +8533,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f323e18d-fc5c-409b-8401-97a7cd396b39
+      - req-77560f2c-6340-40ff-93fa-927f610a4fc4
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -8591,7 +8555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98e1a5196dda49838f2d3256e7661577
+      - 762c55c49d32497682864db87d446fc4
   response:
     status:
       code: 200
@@ -8602,14 +8566,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-1eaf6c82-fc01-4760-8bf2-3485bf8db065
+      - req-fc77b8e5-ac74-4c27-83f8-e322d8ce31bf
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -8624,7 +8588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5600c489524f4940a3e10f21f198b82d
+      - 264761161b354082801d679fa74d38f4
   response:
     status:
       code: 200
@@ -8635,14 +8599,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-23fc7b47-0cd2-4a76-a033-e54238e9f420
+      - req-1273d11c-b660-422e-bebd-312b1d9c92bc
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:08:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:08:59 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -8657,7 +8621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 899891ba54204b2eb0504bf0e3895ad6
+      - a66cdb641cbf4e59935ee84094701d83
   response:
     status:
       code: 200
@@ -8668,14 +8632,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-8d7bee8b-a13c-4fb5-9721-6ec9b2a60308
+      - req-ac4d1269-5971-433a-8865-1dfa291e1190
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:09:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -8690,7 +8654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '08a5274d070c45e89ec613de8971a202'
+      - 5e39cd62bd4e46b5988a3fb7b76a77dc
   response:
     status:
       code: 200
@@ -8701,14 +8665,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-5c5bd7a3-e80c-4d09-b875-697eb99680ea
+      - req-bafc8d6d-d7e6-4b47-965c-79b703658425
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:09:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -8723,7 +8687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8734,9 +8698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7aa1cd74-8616-4d30-9314-11de2af8d1b7
+      - req-77a08598-64b5-4931-8b3d-4509ce2e9634
       Date:
-      - Tue, 08 Jan 2019 19:22:31 GMT
+      - Mon, 04 Mar 2019 20:09:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8763,7 +8727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -8778,7 +8742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8789,9 +8753,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9a7e76e7-a8f3-49c8-bc76-a79c3660400c
+      - req-215e101b-e474-469d-aabd-cc53ece51b98
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8818,7 +8782,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:00 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -8833,7 +8797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8844,9 +8808,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-1e2d405b-7be4-46be-9ba7-24cd271b5de8
+      - req-4bf4f1fa-4f28-42cf-98f1-b294ae3697db
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -8873,7 +8837,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -8888,7 +8852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8899,9 +8863,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-2c5a88ea-d4af-4db9-930f-0bb200c26129
+      - req-cd6d4fd7-8367-451a-b03d-c575925b9a3a
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8913,7 +8877,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -8928,7 +8892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8939,9 +8903,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-1a55a61a-ceab-41e1-9008-fe3706137d0c
+      - req-44546acf-d794-4024-97f9-bb74ecaa50db
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8953,7 +8917,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -8968,7 +8932,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cb5a724a3394aaab8c91cc135672cb0
+      - 4dfc793ffa2c48fab9f83b118d984958
   response:
     status:
       code: 200
@@ -8979,9 +8943,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-30ea0649-56e6-473d-9a94-5bbf9ebe7a7e
+      - req-37eead1f-6d28-4215-bd55-41371e5f897f
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -8993,7 +8957,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -9008,7 +8972,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9019,22 +8983,159 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-685f7418-559a-4f08-8fa2-0bfed0c29132
+      - req-3c50ae7d-f76e-4025-8999-bc8e24f8767b
       Date:
-      - Tue, 08 Jan 2019 19:22:32 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
-        true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
-        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
-        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
         false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
+        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - bcb2927f818c40f998c2ae75e1a8ae4c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ee641d39-0984-41ef-98d5-8e859dfeb81b
+      Date:
+      - Mon, 04 Mar 2019 20:09:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
+        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
@@ -9107,26 +9208,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
         "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
-        "subnetpool_id": null}]}'
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
@@ -9141,7 +9236,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9152,9 +9247,9 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ef9d27b6-0e53-4667-a99e-8e63e4ec4dd2
+      - req-88151edc-0970-4ee2-9317-ee6129ca6e60
       Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
+      - Mon, 04 Mar 2019 20:09:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
@@ -9245,152 +9340,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
         "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
+        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-26a5dae6-b078-488f-83b3-b383c9b9ff1d
-      Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:01 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9405,7 +9368,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9416,9 +9379,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3d926057-7471-42f2-a045-88bf1317ee20
+      - req-239d5c87-72fe-492a-ae1e-88c3acdc948c
       Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9460,7 +9423,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9475,7 +9438,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9486,9 +9449,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5ca3447d-04ed-4814-b4cb-3de6c5f6a526
+      - req-05a662a5-3835-4db8-88b7-8076005e6793
       Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9530,7 +9493,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -9545,7 +9508,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9556,9 +9519,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8751b7e4-a163-42df-b484-0434bc42ea56
+      - req-7fe6cc0c-b5a9-49e4-8997-54b06db00099
       Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9961,7 +9924,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -9976,7 +9939,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -9987,9 +9950,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-07c4d517-89cd-482a-88e7-a6ce466fce71
+      - req-b0304e0a-3e43-4067-be60-b740e263b1e0
       Date:
-      - Tue, 08 Jan 2019 19:22:33 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10392,7 +10355,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -10407,7 +10370,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10418,9 +10381,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a96586df-5c4c-46e8-8613-44dddaf5329f
+      - req-0a77be61-d578-4f0b-a191-ab67b73f43b6
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -10452,7 +10415,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -10467,7 +10430,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10478,9 +10441,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-826052d9-eec6-452d-b663-f7c9a6c58d5f
+      - req-7c813799-9378-4efc-867d-fab50e5ce793
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -10512,7 +10475,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:02 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -10527,7 +10490,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10538,9 +10501,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-74f8aabc-055a-45a5-b80e-302f1a5717e1
+      - req-9b926e14-3dfb-456b-b089-e045de29346e
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -10575,7 +10538,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -10590,7 +10553,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10601,9 +10564,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-93b68f0e-e4ca-48a6-81ca-a6bc77a33055
+      - req-ece1bf4b-8987-46a8-8b32-07f345841773
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -10646,7 +10609,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -10661,7 +10624,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10672,9 +10635,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-aa8438b4-4c49-4037-9013-da4a92b0536d
+      - req-01971722-1224-494d-a983-8410daab7e7c
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -10717,7 +10680,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -10732,7 +10695,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10743,9 +10706,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-e541d834-229a-4846-9620-67050f582156
+      - req-741106d1-a3e3-46f6-a7cf-c14ae8720e54
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -10852,7 +10815,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -10867,7 +10830,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10878,9 +10841,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-8ed4425e-eefb-4b4c-9fa6-7936332187d7
+      - req-5c4a335f-e973-49d7-9f41-08560610f590
       Date:
-      - Tue, 08 Jan 2019 19:22:34 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -10922,7 +10885,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -10937,7 +10900,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6cd2d062156f465f95082266b0647623
+      - bcb2927f818c40f998c2ae75e1a8ae4c
   response:
     status:
       code: 200
@@ -10948,15 +10911,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-ac618e75-442a-4891-aa94-b2d4b597e80d
+      - req-608385db-e411-467c-9b47-d4c3dcb329d8
       Date:
-      - Tue, 08 Jan 2019 19:22:35 GMT
+      - Mon, 04 Mar 2019 20:09:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10974,15 +10937,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:35 GMT
+      - Mon, 04 Mar 2019 20:09:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3cb458b51ef3484e937eb699b2f18653
+      - a0e3ba560ad54d85b46629d27024e596
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f8141b9d-1fb7-41e5-8984-17fc1d4dc467
+      - req-ee27b5b4-2f96-4759-8ed0-2c64ca2c8b8d
       Content-Length:
       - '7311'
       Connection:
@@ -10994,7 +10957,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:35.745969Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:09:04.377233Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11073,10 +11036,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4ybzc3gITfmjuOSO1DS9-g"],
-        "issued_at": "2019-01-08T19:22:35.746004Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["19yv5U3qRjiNXDYP8RbDbQ"],
+        "issued_at": "2019-03-04T20:09:04.377252Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11094,15 +11057,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:35 GMT
+      - Mon, 04 Mar 2019 20:09:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c957c298-d1c0-48a5-a3cd-10e080d51da3
+      - req-74ea8180-6e9f-4c2a-800a-d5eaf9636638
       Content-Length:
       - '7311'
       Connection:
@@ -11114,7 +11077,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:35.960118Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:09:04.578107Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11193,10 +11156,46 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["oeMz-Y8jTR2y63zI6PSBLg"],
-        "issued_at": "2019-01-08T19:22:35.960139Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VjyPu7fXTB2S-sxFvJk8nA"],
+        "issued_at": "2019-03-04T20:09:04.578135Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 06db22675601463db5a8de55b42e0906
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-f20bc3c0-13d3-4deb-8e77-5212920bcf93
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-f20bc3c0-13d3-4deb-8e77-5212920bcf93
+      Date:
+      - Mon, 04 Mar 2019 20:09:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:09:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11214,15 +11213,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:36 GMT
+      - Mon, 04 Mar 2019 20:09:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 273a97099c314c6f9125fdbff51d19b6
+      - 36ec5951bf414ae18c00cbd64cbda512
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f53854a9-6938-410b-b70b-f704a59a744d
+      - req-ad3396ce-97be-4983-89ca-58010811e70b
       Content-Length:
       - '297'
       Connection:
@@ -11231,12 +11230,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:22:36.143011Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:09:04.875268Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["p1h05cVcR-O0fGZUfqpFtg"],
-        "issued_at": "2019-01-08T19:22:36.143030Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3ypc-vTjR5y9wY82-o7f1g"],
+        "issued_at": "2019-03-04T20:09:04.875285Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:04 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -11251,20 +11250,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 273a97099c314c6f9125fdbff51d19b6
+      - 36ec5951bf414ae18c00cbd64cbda512
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:36 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-850816f3-c80a-473f-808b-a652219f78b5
+      - req-5ba3f964-83d2-4a8a-bbff-32c0f33cd066
       Content-Length:
       - '2475'
       Connection:
@@ -11297,7 +11296,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11315,15 +11314,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:36 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61ae356e-7454-4e2a-ab17-a74f465e1288
+      - req-a897b6a0-0022-4dc5-8145-ad112bba827b
       Content-Length:
       - '7278'
       Connection:
@@ -11335,7 +11334,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:36.504524Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:05.208304Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11414,10 +11413,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KVfJO7uQTf2RX-rUKcK0iA"],
-        "issued_at": "2019-01-08T19:22:36.504548Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HDOg23WFTqy9qb5SirUtBg"],
+        "issued_at": "2019-03-04T20:09:05.208323Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11435,15 +11434,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:36 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7a9bd5b6-c7cf-4095-93e3-5910f5296b40
+      - req-cbba835a-f705-49e6-b026-912573ec797c
       Content-Length:
       - '7278'
       Connection:
@@ -11455,7 +11454,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:36.710229Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:05.409265Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11534,10 +11533,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["X9y44-1rSMWWdOuFzkzu6g"],
-        "issued_at": "2019-01-08T19:22:36.710253Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8m9SoBTxQ26ORPrCYxKmPw"],
+        "issued_at": "2019-03-04T20:09:05.409282Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11555,15 +11554,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:36 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e6da645d-a304-48f0-99f4-61f023435d54
+      - req-317615ad-8eee-4ef6-9ac5-8d1562550c34
       Content-Length:
       - '7264'
       Connection:
@@ -11575,7 +11574,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:36.918550Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:05.612312Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11654,10 +11653,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["NEkRhtbLRAmeoM80MRGSDA"],
-        "issued_at": "2019-01-08T19:22:36.918568Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BOQwx3jnQNaM82Lg_tnDZQ"],
+        "issued_at": "2019-03-04T20:09:05.612331Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11675,15 +11674,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-07d80958-6516-4ade-879c-9d889148ace9
+      - req-324d57ee-c1e8-4e21-be5f-925463628fd7
       Content-Length:
       - '7278'
       Connection:
@@ -11695,7 +11694,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:37.118725Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:05.811911Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -11774,10 +11773,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MyjZJSdXS2yGwCHFiEk6aw"],
-        "issued_at": "2019-01-08T19:22:37.118742Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MfEdIbJrQkazd3pV9bEB-g"],
+        "issued_at": "2019-03-04T20:09:05.811928Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11795,15 +11794,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-dbc6a5f1-0ecc-4798-9ed1-cae39f9e0a2f
+      - req-f9a2ad29-6903-4b2e-9fc3-671794ac003b
       Content-Length:
       - '7265'
       Connection:
@@ -11815,7 +11814,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:37.317535Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:06.015308Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -11894,10 +11893,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3cBF4TGBTUOaDFezx83kvQ"],
-        "issued_at": "2019-01-08T19:22:37.317552Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HjRe_bctROuat4bJPGgSTQ"],
+        "issued_at": "2019-03-04T20:09:06.015326Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -11915,15 +11914,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6564504d-313e-4c85-a3c6-717231dc55ff
+      - req-24acdba6-e348-4bc0-975c-cda70ea7f4f9
       Content-Length:
       - '7278'
       Connection:
@@ -11935,7 +11934,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:37.519325Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:06.235004Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -12014,10 +12013,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["vxWRZDiHQ2m4jwdG4Lx9Hg"],
-        "issued_at": "2019-01-08T19:22:37.519343Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["nVxRoYgqRZm2dZU5vlHXUw"],
+        "issued_at": "2019-03-04T20:09:06.235022Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -12032,27 +12031,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf44db21-57b0-4b3c-a4e9-c5468c5decfd
+      - req-571003aa-5b38-4f59-b39d-d32311fe74b9
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bf44db21-57b0-4b3c-a4e9-c5468c5decfd
+      - req-571003aa-5b38-4f59-b39d-d32311fe74b9
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -12067,27 +12066,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-07796adc-e224-4867-9875-b76d7218cfe0
+      - req-3fd943e6-2db8-4efd-a53e-b9f6a9faf9a5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-07796adc-e224-4867-9875-b76d7218cfe0
+      - req-3fd943e6-2db8-4efd-a53e-b9f6a9faf9a5
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -12102,22 +12101,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e72079c7-280a-4e2d-a6bd-7966f7810228
+      - req-69cff951-231d-4d8e-8efc-4e9e7c4fd444
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-e72079c7-280a-4e2d-a6bd-7966f7810228
+      - req-69cff951-231d-4d8e-8efc-4e9e7c4fd444
       Date:
-      - Tue, 08 Jan 2019 19:22:37 GMT
+      - Mon, 04 Mar 2019 20:09:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -12150,7 +12149,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -12165,22 +12164,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-383d5f32-7e68-4b2c-a529-4cd1663503d0
+      - req-1e60acd3-e6a9-4185-bc89-7a84936ce246
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-383d5f32-7e68-4b2c-a529-4cd1663503d0
+      - req-1e60acd3-e6a9-4185-bc89-7a84936ce246
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -12221,7 +12220,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:06 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -12236,22 +12235,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-418c013c-6426-406c-a784-655ec530a323
+      - req-0912c62b-8b93-4c95-a9af-3fdf7777f6ab
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-418c013c-6426-406c-a784-655ec530a323
+      - req-0912c62b-8b93-4c95-a9af-3fdf7777f6ab
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -12285,7 +12284,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -12300,27 +12299,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3539ffdb-4ebe-44ef-b371-429a5998d04e
+      - req-687e6d0f-27b3-4ed6-ba54-ff690457f100
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3539ffdb-4ebe-44ef-b371-429a5998d04e
+      - req-687e6d0f-27b3-4ed6-ba54-ff690457f100
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -12335,27 +12334,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-26260e53-2ea5-42f7-8ad2-5e429cd585a0
+      - req-30ec2faf-ba76-446e-a081-de2c152bdba5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-26260e53-2ea5-42f7-8ad2-5e429cd585a0
+      - req-30ec2faf-ba76-446e-a081-de2c152bdba5
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -12370,27 +12369,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5194d83f-0bf8-4f1c-b2e0-166dcde190d2
+      - req-e53aed03-0ee6-4666-a4f6-7d75870cd8d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5194d83f-0bf8-4f1c-b2e0-166dcde190d2
+      - req-e53aed03-0ee6-4666-a4f6-7d75870cd8d0
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -12405,27 +12404,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3b4d3429-2a40-4014-9168-b0a5560e7bd1
+      - req-3d2f0a28-a9d6-4582-aaed-8bdaaaeadfc5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3b4d3429-2a40-4014-9168-b0a5560e7bd1
+      - req-3d2f0a28-a9d6-4582-aaed-8bdaaaeadfc5
       Date:
-      - Tue, 08 Jan 2019 19:22:38 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -12440,27 +12439,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9b1c4fb-2f24-4075-bca7-56475058e88d
+      - req-8f361a18-9574-49bf-82e3-fc41da59ea25
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a9b1c4fb-2f24-4075-bca7-56475058e88d
+      - req-8f361a18-9574-49bf-82e3-fc41da59ea25
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -12475,27 +12474,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f19bad4d-b678-403d-b165-c3422b5faf78
+      - req-2e6317a2-70b2-4385-adb5-ea2e42617b0f
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-f19bad4d-b678-403d-b165-c3422b5faf78
+      - req-2e6317a2-70b2-4385-adb5-ea2e42617b0f
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:07 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -12510,27 +12509,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68ec979a-4ba4-4f1d-8f74-9b0af8125310
+      - req-73895b37-0d89-4eba-8b13-8a470117f6af
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-68ec979a-4ba4-4f1d-8f74-9b0af8125310
+      - req-73895b37-0d89-4eba-8b13-8a470117f6af
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -12545,27 +12544,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d6746c49-570d-4176-b18b-2b568ce50389
+      - req-1788bec5-0e81-461d-97d0-c880877d40ed
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d6746c49-570d-4176-b18b-2b568ce50389
+      - req-1788bec5-0e81-461d-97d0-c880877d40ed
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -12580,27 +12579,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3e9f91c9-65ae-4d54-811a-6c75ce5030af
+      - req-36b7ee59-f7fa-478d-b89b-8a2de6f9f9a6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3e9f91c9-65ae-4d54-811a-6c75ce5030af
+      - req-36b7ee59-f7fa-478d-b89b-8a2de6f9f9a6
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -12615,22 +12614,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4cae3554-47ce-47e9-be3a-b2e21df6b5af
+      - req-36fbbb4d-af42-4a4d-b650-58ac45e86bf4
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-4cae3554-47ce-47e9-be3a-b2e21df6b5af
+      - req-36fbbb4d-af42-4a4d-b650-58ac45e86bf4
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12645,7 +12644,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -12660,22 +12659,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9e3f46c6-089b-44df-a9af-a0ca4ec32185
+      - req-39dd15f2-51c2-41df-b2c9-89f09af86045
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-9e3f46c6-089b-44df-a9af-a0ca4ec32185
+      - req-39dd15f2-51c2-41df-b2c9-89f09af86045
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -12690,7 +12689,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -12705,27 +12704,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8af26a53-cf97-43e9-9b53-e8d02842de48
+      - req-9d0a7b22-eede-44de-bb81-3abaaa799350
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-8af26a53-cf97-43e9-9b53-e8d02842de48
+      - req-9d0a7b22-eede-44de-bb81-3abaaa799350
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -12740,27 +12739,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-80761eb2-4416-4e53-b80e-4a78ac3ae44e
+      - req-36285c0b-8b01-4f2b-a68d-eb8437580fc7
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-80761eb2-4416-4e53-b80e-4a78ac3ae44e
+      - req-36285c0b-8b01-4f2b-a68d-eb8437580fc7
       Date:
-      - Tue, 08 Jan 2019 19:22:39 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -12775,27 +12774,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-035bf12e-8301-4972-a40b-14dc33b3126d
+      - req-29986e26-2012-4505-9048-33a100c0ad49
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-035bf12e-8301-4972-a40b-14dc33b3126d
+      - req-29986e26-2012-4505-9048-33a100c0ad49
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -12810,27 +12809,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1490a3a2-c435-441b-8bee-fb7f73c75b5b
+      - req-4203f76a-abf3-44b2-b6c2-bb8458dfddfb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1490a3a2-c435-441b-8bee-fb7f73c75b5b
+      - req-4203f76a-abf3-44b2-b6c2-bb8458dfddfb
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:08 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -12845,27 +12844,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e03e21f6-c63e-4852-aad9-af9c49308452
+      - req-5955a66b-b38f-496c-a5b1-1836aaccd2fb
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e03e21f6-c63e-4852-aad9-af9c49308452
+      - req-5955a66b-b38f-496c-a5b1-1836aaccd2fb
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -12880,27 +12879,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-53624ed0-c205-4f9e-99ae-5dce544f4bb0
+      - req-81b0982e-5abd-4b05-82dd-e0cbe8cb4fb5
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-53624ed0-c205-4f9e-99ae-5dce544f4bb0
+      - req-81b0982e-5abd-4b05-82dd-e0cbe8cb4fb5
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -12915,27 +12914,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e343a5fa-222d-4cf8-811d-58fe345af976
+      - req-384a9e6f-7b22-4448-9ebc-a60ac98c8081
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e343a5fa-222d-4cf8-811d-58fe345af976
+      - req-384a9e6f-7b22-4448-9ebc-a60ac98c8081
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -12950,27 +12949,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e6a317bf-795d-490d-802d-c50689d24027
+      - req-754dad15-b731-4967-a643-ffd432d151fe
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e6a317bf-795d-490d-802d-c50689d24027
+      - req-754dad15-b731-4967-a643-ffd432d151fe
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -12985,27 +12984,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-27d70d30-f801-4edc-a60c-a5a2abe3e517
+      - req-fab3920d-0ee5-4dca-bc59-945eebc06049
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-27d70d30-f801-4edc-a60c-a5a2abe3e517
+      - req-fab3920d-0ee5-4dca-bc59-945eebc06049
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -13020,27 +13019,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cb3b848a-b2f5-44aa-bb43-9acfd2d54863
+      - req-93176506-b01a-41e0-8039-6a544414e738
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cb3b848a-b2f5-44aa-bb43-9acfd2d54863
+      - req-93176506-b01a-41e0-8039-6a544414e738
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -13055,27 +13054,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-089d52ba-6563-4149-9a7f-003b46ab0a7d
+      - req-e7455304-e1fe-42e3-8d70-fb2c0cf992f0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-089d52ba-6563-4149-9a7f-003b46ab0a7d
+      - req-e7455304-e1fe-42e3-8d70-fb2c0cf992f0
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -13090,27 +13089,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0828391e-ece6-4f65-828a-2fe9b172e450
+      - req-0cd27208-257d-4a1b-bdaa-aa78ada6312e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0828391e-ece6-4f65-828a-2fe9b172e450
+      - req-0cd27208-257d-4a1b-bdaa-aa78ada6312e
       Date:
-      - Tue, 08 Jan 2019 19:22:40 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -13125,27 +13124,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a9b8bcc3-1593-4833-b97c-f51b2149bf2c
+      - req-df1358db-7106-4bcc-b07f-33f430bce6e5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a9b8bcc3-1593-4833-b97c-f51b2149bf2c
+      - req-df1358db-7106-4bcc-b07f-33f430bce6e5
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -13160,27 +13159,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dec2ffbf-b66b-4597-ad98-50af075370d4
+      - req-0b7c0882-de34-43a1-ada6-4bf1ddf2b644
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-dec2ffbf-b66b-4597-ad98-50af075370d4
+      - req-0b7c0882-de34-43a1-ada6-4bf1ddf2b644
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:09 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -13195,27 +13194,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c010f670-fb72-489d-83bc-ea63882113a1
+      - req-11f196aa-eae6-4267-a13a-38fc21fec97d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c010f670-fb72-489d-83bc-ea63882113a1
+      - req-11f196aa-eae6-4267-a13a-38fc21fec97d
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -13230,27 +13229,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f141eb95-c2b5-493d-beab-dd000bd27264
+      - req-f37ec062-0450-4d1f-ac09-24d1f7bc4ee1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-f141eb95-c2b5-493d-beab-dd000bd27264
+      - req-f37ec062-0450-4d1f-ac09-24d1f7bc4ee1
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -13265,27 +13264,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-094ac558-938f-4c7c-8646-cde8b6068542
+      - req-fd7ee2f0-e9c6-4412-a2bf-1790caeddf9c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-094ac558-938f-4c7c-8646-cde8b6068542
+      - req-fd7ee2f0-e9c6-4412-a2bf-1790caeddf9c
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -13300,27 +13299,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6948450b-2cc9-42a3-aa8f-535f56981634
+      - req-7760e769-55aa-434c-bb9a-585abb172d56
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6948450b-2cc9-42a3-aa8f-535f56981634
+      - req-7760e769-55aa-434c-bb9a-585abb172d56
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -13335,27 +13334,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e7f8a3f-24e3-437c-af7b-9a4d5e9d7ca8
+      - req-46ac443b-75db-4c8f-b921-f63dfb4894d3
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0e7f8a3f-24e3-437c-af7b-9a4d5e9d7ca8
+      - req-46ac443b-75db-4c8f-b921-f63dfb4894d3
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -13370,27 +13369,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab14f678-2a79-4905-b88e-258b2fc6f259
+      - req-db2516fb-11a8-4e00-bfbf-2ade526120ef
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ab14f678-2a79-4905-b88e-258b2fc6f259
+      - req-db2516fb-11a8-4e00-bfbf-2ade526120ef
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -13405,27 +13404,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a68749c1-56ce-4171-8f92-61abdef54079
+      - req-a69239ef-ad28-4434-a3c8-3226c6e2a5a6
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a68749c1-56ce-4171-8f92-61abdef54079
+      - req-a69239ef-ad28-4434-a3c8-3226c6e2a5a6
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -13440,27 +13439,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab5175fa-eae4-49ce-aa3f-2958c139d888
+      - req-9c44ff16-72df-47d0-8acb-eb133b21b10a
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-ab5175fa-eae4-49ce-aa3f-2958c139d888
+      - req-9c44ff16-72df-47d0-8acb-eb133b21b10a
       Date:
-      - Tue, 08 Jan 2019 19:22:41 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -13475,22 +13474,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-64629cfd-f944-4202-b71c-0582f1c9ccc9
+      - req-a2671d27-331b-4309-a989-d085921d8bca
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-64629cfd-f944-4202-b71c-0582f1c9ccc9
+      - req-a2671d27-331b-4309-a989-d085921d8bca
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13502,7 +13501,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13517,22 +13516,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b4181a4c95a34315a747517460835860
+      - a5f0cfbffcf1489fae533b6d62d7215a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12209fdf-b562-4b1e-85f5-d1552ffa1f33
+      - req-a7a272dc-8215-4550-af3e-96f2f019616d
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-12209fdf-b562-4b1e-85f5-d1552ffa1f33
+      - req-a7a272dc-8215-4550-af3e-96f2f019616d
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13544,7 +13543,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -13559,22 +13558,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bce09da9-a0a6-4ca2-9112-1cc201fc9859
+      - req-a1f53785-aef2-40c7-89a5-94adf205da0f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-bce09da9-a0a6-4ca2-9112-1cc201fc9859
+      - req-a1f53785-aef2-40c7-89a5-94adf205da0f
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13586,7 +13585,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13601,22 +13600,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - df0f2bafc69840c8a97a690f4f1d7509
+      - 8a723a105c954c53830607702a9178b3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4b1d5e25-bdfb-4bf4-a17a-922d542530bd
+      - req-cc8c868e-7551-4abe-919c-808c240fcb75
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-4b1d5e25-bdfb-4bf4-a17a-922d542530bd
+      - req-cc8c868e-7551-4abe-919c-808c240fcb75
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13628,7 +13627,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -13643,22 +13642,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-535d647c-a117-41c4-ab6d-b048d93e47a9
+      - req-549839ef-195a-416e-a551-563c41afb802
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-535d647c-a117-41c4-ab6d-b048d93e47a9
+      - req-549839ef-195a-416e-a551-563c41afb802
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13670,7 +13669,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13685,22 +13684,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db948969f30347ccb1ae21a7c6c59000
+      - 18a53cbf13c5474b9c3e2840f18299c0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-06e5e819-82ab-46b4-86a4-7988e34600c3
+      - req-07bc4b0f-6bff-4ed5-9ede-a94fb6bf8844
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-06e5e819-82ab-46b4-86a4-7988e34600c3
+      - req-07bc4b0f-6bff-4ed5-9ede-a94fb6bf8844
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13712,7 +13711,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -13727,22 +13726,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3202944c-184f-4049-9108-18b519e4bafb
+      - req-790b9da7-2691-4e20-8558-7a8375e8b511
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-3202944c-184f-4049-9108-18b519e4bafb
+      - req-790b9da7-2691-4e20-8558-7a8375e8b511
       Date:
-      - Tue, 08 Jan 2019 19:22:42 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13754,7 +13753,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13769,22 +13768,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bce1a8b0c3942f3abbce3f00b57f0f3
+      - 90a8edf74f7c4d6db9dc0f273b9ce5f9
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9d250504-2c43-4996-bfee-a2d5474d3692
+      - req-d92f3998-c961-438f-888c-663039de5e0c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-9d250504-2c43-4996-bfee-a2d5474d3692
+      - req-d92f3998-c961-438f-888c-663039de5e0c
       Date:
-      - Tue, 08 Jan 2019 19:22:43 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13796,7 +13795,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -13811,22 +13810,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1cd33f0-028d-4390-a4a5-a382e0ff46d5
+      - req-b28bffdc-225a-4ddb-a25d-f4dcf799c842
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e1cd33f0-028d-4390-a4a5-a382e0ff46d5
+      - req-b28bffdc-225a-4ddb-a25d-f4dcf799c842
       Date:
-      - Tue, 08 Jan 2019 19:22:43 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13838,7 +13837,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13853,22 +13852,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c1e36d0b672f44c69fd9fabe3aeae04e
+      - 06db22675601463db5a8de55b42e0906
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e386bfc2-e3f4-4cd3-814f-b1df99b25887
+      - req-ecb053b0-2cc7-44be-8b98-72566bd42701
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e386bfc2-e3f4-4cd3-814f-b1df99b25887
+      - req-ecb053b0-2cc7-44be-8b98-72566bd42701
       Date:
-      - Tue, 08 Jan 2019 19:22:43 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13880,7 +13879,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -13895,22 +13894,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1904aba3-590f-40be-9ef6-51d41bc77c5c
+      - req-980fec68-b208-42ff-84e2-2762478f42dd
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1904aba3-590f-40be-9ef6-51d41bc77c5c
+      - req-980fec68-b208-42ff-84e2-2762478f42dd
       Date:
-      - Tue, 08 Jan 2019 19:22:43 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13922,7 +13921,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -13937,22 +13936,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31f248f776664aa19b86f2e58d9e4e51
+      - 6355c6743ad045adacac92b6f081f004
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fb5c24ac-eb86-4ae1-a363-5ef977f95d77
+      - req-24f1f26e-a4e1-4937-96c8-6691e32c5cac
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-fb5c24ac-eb86-4ae1-a363-5ef977f95d77
+      - req-24f1f26e-a4e1-4937-96c8-6691e32c5cac
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -13964,7 +13963,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:11 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -13979,22 +13978,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f7631231-483e-4d55-8edc-370380cdd22c
+      - req-1abc2a51-3bf9-4386-9c1f-e2b527d078d6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f7631231-483e-4d55-8edc-370380cdd22c
+      - req-1abc2a51-3bf9-4386-9c1f-e2b527d078d6
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -14006,7 +14005,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -14021,22 +14020,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9dd7f18cd96a4270ae395b056fc23395
+      - 29ae4a2d039f436ab32968d8fcb9e745
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e1a36fcf-1e3f-42b9-bc60-3166a4308f58
+      - req-ca862ac4-526a-4479-8cdc-4154bd8e3c6a
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-e1a36fcf-1e3f-42b9-bc60-3166a4308f58
+      - req-ca862ac4-526a-4479-8cdc-4154bd8e3c6a
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -14048,7 +14047,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14066,15 +14065,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2a707fe7d604442acdf5a52161df4b1
+      - 3aefa45d7ba64c438f9aebb4277c4efc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0f276169-f3f1-4609-88a1-eba6f07a66e6
+      - req-7d21a466-4bf4-4c80-87a7-e260e9ccbd13
       Content-Length:
       - '7311'
       Connection:
@@ -14086,7 +14085,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:44.621828Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:09:12.487294Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14165,10 +14164,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4vyewHYdRqu-gkL6UvuGKQ"],
-        "issued_at": "2019-01-08T19:22:44.621848Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bOgTXRXoQmmJ4hHWQtL81g"],
+        "issued_at": "2019-03-04T20:09:12.487314Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14186,15 +14185,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - ca39b9942fa040b18cd49f7af421f282
+      - f8f773a4d6d74b0ba3307a0924fabd57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ba7e78f1-0c87-4d98-9941-14ecac77ce98
+      - req-1e878e97-dd71-4732-a513-634a80c4bb1e
       Content-Length:
       - '7311'
       Connection:
@@ -14206,7 +14205,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:22:44.839219Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:09:12.700362Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14285,10 +14284,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xGOj39RHSSi3g4BAkHno-g"],
-        "issued_at": "2019-01-08T19:22:44.839238Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4KwAfvqrQTGkBwdjWnkvVQ"],
+        "issued_at": "2019-03-04T20:09:12.700385Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14306,15 +14305,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:44 GMT
+      - Mon, 04 Mar 2019 20:09:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 1ec6566559d5491aa6da2890d04d9edb
+      - 8638eafad20e4101b847b886f7a0c4b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9d56fa2d-2649-45b8-a5b4-b382da9ef485
+      - req-6b5f0dd2-ab1f-44df-b341-23c4070fc5da
       Content-Length:
       - '297'
       Connection:
@@ -14323,12 +14322,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:22:45.011671Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:09:12.881283Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["IJXhMfoyTH6XqEXcE1_pmQ"],
-        "issued_at": "2019-01-08T19:22:45.011691Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bqCwXjooQlCEfT_GRtJlqQ"],
+        "issued_at": "2019-03-04T20:09:12.881301Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:12 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -14343,20 +14342,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1ec6566559d5491aa6da2890d04d9edb
+      - 8638eafad20e4101b847b886f7a0c4b6
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:45 GMT
+      - Mon, 04 Mar 2019 20:09:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f98bceca-284d-4f8f-a740-0f4a8d3b4ffa
+      - req-31023d91-4963-4cf7-a8d5-9d760f4d010a
       Content-Length:
       - '2475'
       Connection:
@@ -14389,7 +14388,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14407,15 +14406,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:45 GMT
+      - Mon, 04 Mar 2019 20:09:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 46ffc8931b9d454480d53d4d17e8b597
+      - 06aef413635b49b7953daa4c4cbff3e4
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01c8b41b-fa5a-40d3-a129-edb6d882c246
+      - req-49eb6ee7-762e-43d4-ac45-09cbd8a45fbf
       Content-Length:
       - '7278'
       Connection:
@@ -14427,7 +14426,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:45.355365Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:13.227589Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14506,10 +14505,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kGwyTK6QSPC7LVmupcQgRw"],
-        "issued_at": "2019-01-08T19:22:45.355384Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7ANzElBMQYqYuc0Tq1XBaQ"],
+        "issued_at": "2019-03-04T20:09:13.227607Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14527,15 +14526,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:45 GMT
+      - Mon, 04 Mar 2019 20:09:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 24dfb056f7ad4a93be16207216df4c74
+      - b4f3d44b5cb64777b9e5f907c2a557c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f3910cf7-eae1-4d8e-a6e3-fd430c73a5c0
+      - req-ab352e30-4c29-4d96-adb9-02fe8f2fc6ff
       Content-Length:
       - '7278'
       Connection:
@@ -14547,7 +14546,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:45.565657Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:13.433155Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14626,10 +14625,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["W1ouQQNeTle20ClBNzHBeQ"],
-        "issued_at": "2019-01-08T19:22:45.565675Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lMM295D8Tmuhw8mVt3k-yA"],
+        "issued_at": "2019-03-04T20:09:13.433173Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14647,15 +14646,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:45 GMT
+      - Mon, 04 Mar 2019 20:09:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bd07caa7-34f2-45d4-b04c-7743235540f9
+      - req-115edbcb-4b1a-4e2d-b4bd-0b3c5100b90d
       Content-Length:
       - '7264'
       Connection:
@@ -14667,7 +14666,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:45.777107Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:13.651158Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14746,10 +14745,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8YaqxOxKTqSDHA21QHgDaw"],
-        "issued_at": "2019-01-08T19:22:45.777126Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YzpNxKVCQS6xYDUnI7M1Jg"],
+        "issued_at": "2019-03-04T20:09:13.651177Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14767,15 +14766,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:45 GMT
+      - Mon, 04 Mar 2019 20:09:13 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 7cf3851cf7694ca1ba63253e4931cc9b
+      - efcb1b1123354dcdbd1852cd8c0d4a16
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4757a178-0b2c-4b5f-b117-580bdfe92d69
+      - req-33d74b8c-5793-4325-a1bd-6c3c0c3f354f
       Content-Length:
       - '7278'
       Connection:
@@ -14787,7 +14786,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:45.986242Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:13.867743Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -14866,10 +14865,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["koy4Ds7pR5eG3FNS7jZbVA"],
-        "issued_at": "2019-01-08T19:22:45.986260Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["quDZ6dLfSQ61oLSgtTR38g"],
+        "issued_at": "2019-03-04T20:09:13.867761Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:13 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -14887,15 +14886,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 67314b4e4f6e44c39b830df777602a8d
+      - acfd6fed5bfb447b912f37fd2a233b9c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b47b0df8-5e0d-4dd9-a59c-1962d1c47f6b
+      - req-c04c297b-9a90-4c76-adf5-54f91c2c75da
       Content-Length:
       - '7265'
       Connection:
@@ -14907,7 +14906,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:46.196949Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:14.084068Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -14986,10 +14985,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hif1MmWNSYaHq0thEc8aVw"],
-        "issued_at": "2019-01-08T19:22:46.196969Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kXLqK1__SCi_gauSmqb_vg"],
+        "issued_at": "2019-03-04T20:09:14.084086Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -15007,15 +15006,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 426c7c14285f4bb9b2aa7c5377a5f5d0
+      - 57118e1db7c44c6a977bf6414e81b4bd
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-695ac42a-6ec6-4994-836e-266540647ded
+      - req-bdab7d5d-599b-4b4b-a6d1-41e089ab63ee
       Content-Length:
       - '7278'
       Connection:
@@ -15027,7 +15026,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:22:46.420147Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:09:14.294416Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -15106,10 +15105,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_Ybh5hQKTuysbrbNPmEoeg"],
-        "issued_at": "2019-01-08T19:22:46.420174Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["KjVGaESFTyySMPZ--9u86A"],
+        "issued_at": "2019-03-04T20:09:14.294433Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -15124,7 +15123,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 46ffc8931b9d454480d53d4d17e8b597
+      - 06aef413635b49b7953daa4c4cbff3e4
   response:
     status:
       code: 200
@@ -15137,22 +15136,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975366.55704'
+      - '1551730154.43384'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975366.55704'
+      - '1551730154.43384'
       X-Trans-Id:
-      - txe09c4bc1593741fb95600-005c34f886
+      - tx3a4543859b354f6c91f6f-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -15167,7 +15166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 24dfb056f7ad4a93be16207216df4c74
+      - b4f3d44b5cb64777b9e5f907c2a557c8
   response:
     status:
       code: 200
@@ -15180,22 +15179,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975366.67026'
+      - '1551730154.55140'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975366.67026'
+      - '1551730154.55140'
       X-Trans-Id:
-      - tx9eb3b7d603ff433db104a-005c34f886
+      - tx3aaab12287ed442a86cdb-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -15210,7 +15209,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
   response:
     status:
       code: 200
@@ -15239,15 +15238,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txc9df666647334203abc7d-005c34f886
+      - tx48b797b63899485f9785e-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -15262,7 +15261,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
   response:
     status:
       code: 200
@@ -15291,14 +15290,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx35888f0ee1584f719455c-005c34f886
+      - txd2114713c69747ba8b9fa-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -15313,7 +15312,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7cf3851cf7694ca1ba63253e4931cc9b
+      - efcb1b1123354dcdbd1852cd8c0d4a16
   response:
     status:
       code: 200
@@ -15326,22 +15325,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975366.99684'
+      - '1551730154.86599'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975366.99684'
+      - '1551730154.86599'
       X-Trans-Id:
-      - tx3b1226659a494536bc65b-005c34f886
+      - txe39cdd0b1c68482ea0e54-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:46 GMT
+      - Mon, 04 Mar 2019 20:09:14 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -15356,7 +15355,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ca39b9942fa040b18cd49f7af421f282
+      - f8f773a4d6d74b0ba3307a0924fabd57
   response:
     status:
       code: 200
@@ -15369,22 +15368,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975367.10672'
+      - '1551730155.02269'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975367.10672'
+      - '1551730155.02269'
       X-Trans-Id:
-      - tx2b6c6cc4fc1c40e48b292-005c34f887
+      - txb01da5edd8c54d9e8ecf5-005c7d85ea
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -15399,7 +15398,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 67314b4e4f6e44c39b830df777602a8d
+      - acfd6fed5bfb447b912f37fd2a233b9c
   response:
     status:
       code: 200
@@ -15412,22 +15411,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975367.22195'
+      - '1551730155.18574'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975367.22195'
+      - '1551730155.18574'
       X-Trans-Id:
-      - tx3fc75006b1a34ca88405b-005c34f887
+      - tx2a0ac7459d0446a488784-005c7d85eb
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -15442,7 +15441,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 426c7c14285f4bb9b2aa7c5377a5f5d0
+      - 57118e1db7c44c6a977bf6414e81b4bd
   response:
     status:
       code: 200
@@ -15455,22 +15454,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975367.33267'
+      - '1551730155.32441'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975367.33267'
+      - '1551730155.32441'
       X-Trans-Id:
-      - txa918bdff5e0d4613b8568-005c34f887
+      - tx7d71b95aa126468f9d997-005c7d85eb
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -15485,7 +15484,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
   response:
     status:
       code: 200
@@ -15506,9 +15505,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx088120ab740b4d70b6840-005c34f887
+      - tx03cf5f483d304e4086d3a-005c7d85eb
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -15518,7 +15517,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -15533,7 +15532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
   response:
     status:
       code: 200
@@ -15554,14 +15553,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbc70055b14974762b1fc8-005c34f887
+      - tx71243d9978304754b461e-005c7d85eb
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -15576,7 +15575,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0fed0f8fc5cf4ea992a3104b15df8326
+      - f774726cdbdd4b9e88cd733d24830e91
   response:
     status:
       code: 200
@@ -15597,12 +15596,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx2b240ffffd33436caaf4a-005c34f887
+      - txf1ae35609de548d7a6398-005c7d85eb
       Date:
-      - Tue, 08 Jan 2019 19:22:47 GMT
+      - Mon, 04 Mar 2019 20:09:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:22:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:09:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_legacy_fast_refresh.yml
@@ -17,15 +17,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:41 GMT
+      - Mon, 04 Mar 2019 20:06:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-7cb48dab-efb5-42b4-8bd1-b456b6b9cce9
+      - req-97957c5d-1645-49df-beb8-7da4ab886972
       Content-Length:
       - '7311'
       Connection:
@@ -37,7 +37,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:41.955943Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:10.837158Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -116,10 +116,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4VZIeFV9TDu-c7PTKJFFLA"],
-        "issued_at": "2019-01-08T19:20:41.955962Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HJwWgS3oRVSD_k4mQ_Aj-A"],
+        "issued_at": "2019-03-04T20:06:10.837185Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:10 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -134,7 +134,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
   response:
     status:
       code: 200
@@ -145,7 +145,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:42 GMT
+      - Mon, 04 Mar 2019 20:06:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -154,7 +154,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -172,15 +172,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:42 GMT
+      - Mon, 04 Mar 2019 20:06:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5950ff25b8c24e858ddaf495e488fb3f
+      - 1f87389598544c58a86a0334700954a6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2985ab98-eb5a-4bb7-89a0-2ed21187ffbf
+      - req-2f4276de-bdab-42bc-ac61-5d8560ae9d3b
       Content-Length:
       - '7311'
       Connection:
@@ -192,7 +192,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:42.245649Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:11.135714Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -271,10 +271,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OL4X_aHIQN-b9FGsD900hQ"],
-        "issued_at": "2019-01-08T19:20:42.245667Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4Vbntwb3Rqi9AeyvjpgSCA"],
+        "issued_at": "2019-03-04T20:06:11.135733Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -292,15 +292,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:42 GMT
+      - Mon, 04 Mar 2019 20:06:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cee057e87099455c973142a3ca7d4caa
+      - d24e91b974a5456f8875de8da8c506f2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c3d2f123-1518-49c7-8544-b0b16c2a858c
+      - req-13c4e60c-cae9-4eb3-97b2-aaf41c9ef2a1
       Content-Length:
       - '7311'
       Connection:
@@ -312,7 +312,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:42.446664Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:11.344732Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -391,10 +391,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["h7-gQ8ueTsG_h9skjhwU8g"],
-        "issued_at": "2019-01-08T19:20:42.446683Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["krdaE-SWTr-sFi2BP77hlw"],
+        "issued_at": "2019-03-04T20:06:11.344752Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -412,15 +412,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:42 GMT
+      - Mon, 04 Mar 2019 20:06:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d4e28d54-d83a-466d-85f1-7850b7b13304
+      - req-ebc627dc-51c1-4413-8ff2-fa00101ab87a
       Content-Length:
       - '7311'
       Connection:
@@ -432,7 +432,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:42.667739Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:11.554938Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -511,10 +511,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HVazMASvQYaLbI2OHYNANQ"],
-        "issued_at": "2019-01-08T19:20:42.667758Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["7lguIB8YRmWe9KGo8ZNqHA"],
+        "issued_at": "2019-03-04T20:06:11.554956Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -532,15 +532,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:42 GMT
+      - Mon, 04 Mar 2019 20:06:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b0515394611e43ffbcec63e1814bcf47
+      - c0f38415a07746b49bc3901fddf1bc57
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0a9bec93-0952-468c-bf1e-33904a0689d2
+      - req-bbd8a860-46f7-49ef-a5cf-866c4f7fb1df
       Content-Length:
       - '7311'
       Connection:
@@ -552,7 +552,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:42.878648Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:11.770953Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -631,10 +631,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["_JmjV58eQJ-mj8SExELZAg"],
-        "issued_at": "2019-01-08T19:20:42.878667Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["smXsqb94TUejVgN44mFd-w"],
+        "issued_at": "2019-03-04T20:06:11.770974Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -652,15 +652,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 810c340d99b2421f9751ca8eb1e9b55e
+      - 5564ee0e0f9f4a1fbc352d0e10e992da
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-3c8722ef-0fb5-4c38-acc1-234e36d24a69
+      - req-904d1aef-dbad-4d0e-a1c8-819d93895112
       Content-Length:
       - '7311'
       Connection:
@@ -672,7 +672,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:43.088271Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:12.002161Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -751,10 +751,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["dqLiJrAiTZGPr8CHAtW0Pw"],
-        "issued_at": "2019-01-08T19:20:43.088289Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["njoaveHrSIeK2F7vK7Prqw"],
+        "issued_at": "2019-03-04T20:06:12.002182Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -772,15 +772,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4e8db0ef64004048904443a6495e985e
+      - c09be8067bc940ae8b03399c93a062f1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-72dfe4d6-d374-4a7e-abad-0d0bcea10539
+      - req-30bb1c3b-d78a-46e2-98fd-6221872bb13d
       Content-Length:
       - '7311'
       Connection:
@@ -792,7 +792,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:43.297016Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:12.380695Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -871,10 +871,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Mlq-9fL0QsGhDHouAJLtRQ"],
-        "issued_at": "2019-01-08T19:20:43.297034Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ovHL01LJSdu3wQWCFXrVNA"],
+        "issued_at": "2019-03-04T20:06:12.380713Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -892,15 +892,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 50f3e027d17840fa91cb44e59f235ef5
+      - e9a3fc579e5248c1bdc9e0aff9615145
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0f4cb6a-d50d-488c-8a4c-2f767f980042
+      - req-ee5baea6-863d-44f2-b8ef-8f7950e679c7
       Content-Length:
       - '7311'
       Connection:
@@ -912,7 +912,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:20:43.497154Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:12.584394Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -991,10 +991,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["N8TW-v4DQy6wF4yp9Y9fBQ"],
-        "issued_at": "2019-01-08T19:20:43.497171Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["H54kY8cxQc6AiaUQKxXoWA"],
+        "issued_at": "2019-03-04T20:06:12.584410Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1012,15 +1012,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3373e52ba5894229a77928788b046f4e
+      - 531bfa10f7d14fd292e789d72db35029
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1303caf1-dbc1-41c1-9b88-3fc5ee5efa7c
+      - req-9e390201-fd93-48cb-87db-e22938e7d1c7
       Content-Length:
       - '297'
       Connection:
@@ -1029,12 +1029,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:20:43.670715Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:06:12.762302Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["04NdSdt1TTuDvyjWCU5xlg"],
-        "issued_at": "2019-01-08T19:20:43.670732Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["o0umD_dtSfW3BBQTl5mtUg"],
+        "issued_at": "2019-03-04T20:06:12.762320Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:12 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -1049,20 +1049,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 3373e52ba5894229a77928788b046f4e
+      - 531bfa10f7d14fd292e789d72db35029
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d1973c3b-1e75-4a80-97b7-d46db0899b75
+      - req-732bfb0b-489d-4683-8d7a-444fcb41f9a6
       Content-Length:
       - '2475'
       Connection:
@@ -1095,7 +1095,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:12 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1110,7 +1110,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1123,9 +1123,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-f160594f-2088-4cfb-b1e4-114a419b9b8b
+      - req-b47a4122-822d-489a-afc0-bd5fee010eab
       Date:
-      - Tue, 08 Jan 2019 19:20:43 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/1",
@@ -1139,7 +1139,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1154,7 +1154,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1167,9 +1167,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-73989258-5929-4ced-9b6d-f3997bbedaf1
+      - req-4d694728-4049-4e24-a10e-ad2d01f9d689
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/3",
@@ -1183,7 +1183,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1198,7 +1198,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1211,9 +1211,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-9cc126b1-54b4-48d1-b263-8a164ccf4088
+      - req-609e2cae-941d-4664-b7aa-1a4c07dd44f6
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/5",
@@ -1228,7 +1228,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1243,7 +1243,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1256,9 +1256,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-ffa06649-0c1e-4462-88e8-65bab2a63de3
+      - req-34fe98fb-ce5d-4f3b-a087-a9fd175b75ad
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1268,7 +1268,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/flavors/7/os-flavor-access
@@ -1283,7 +1283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1296,15 +1296,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-14b65d16-68f2-4a15-a603-53b02eb38017
+      - req-a3aa00d9-2d24-4c10-9968-8f5f3feef53c
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone
@@ -1319,7 +1319,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1332,15 +1332,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-6f3ea8d8-817d-4d41-9f2e-6963c6508448
+      - req-d06aef06-d717-41f2-9095-eb61e8d56871
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
@@ -1355,28 +1355,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0515394611e43ffbcec63e1814bcf47
+      - c0f38415a07746b49bc3901fddf1bc57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-249699f3-60b3-49b3-adbf-d5c2c4094f0e
+      - req-17defcf1-9bb9-45aa-98c7-2afcf35d3971
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-249699f3-60b3-49b3-adbf-d5c2c4094f0e
+      - req-17defcf1-9bb9-45aa-98c7-2afcf35d3971
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:13 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-aggregates
@@ -1391,7 +1391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1404,14 +1404,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-0761be67-978e-45d5-a54d-29beb1a9cd91
+      - req-30075bfb-448f-4f29-89c2-e93ceaca0cef
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1429,15 +1429,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 788c9629ffd144cbbe2b9b581e1af5a5
+      - a5f816dab34941b89890e6e5c09767d2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-82ad3e26-25d0-40db-872e-d1ce0c713af3
+      - req-72925b2c-73ca-483a-a9e7-382d8cd477f5
       Content-Length:
       - '7278'
       Connection:
@@ -1449,7 +1449,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:44.893454Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:14.255137Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1528,10 +1528,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["8sT7SyYeTlakk8A11dwdUw"],
-        "issued_at": "2019-01-08T19:20:44.893472Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["r5WkRc9MQ3C5tIrobwQQiA"],
+        "issued_at": "2019-03-04T20:06:14.255169Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1546,7 +1546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788c9629ffd144cbbe2b9b581e1af5a5
+      - a5f816dab34941b89890e6e5c09767d2
   response:
     status:
       code: 200
@@ -1557,7 +1557,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:44 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1566,7 +1566,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1584,15 +1584,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:45 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - eeab29998f384f6db012092f4e9c3ce1
+      - b7b3e0c078844126be245f9f66381cc5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61e69fca-a1b3-41d6-868c-4ab1c8d22590
+      - req-71be51fe-2b82-4196-85f6-ec1e7bdfffab
       Content-Length:
       - '7278'
       Connection:
@@ -1604,7 +1604,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:45.439780Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:14.599937Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1683,10 +1683,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["VNLVqqedT2qRqvxhq8bbcg"],
-        "issued_at": "2019-01-08T19:20:45.439799Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["i3MMNudvSUub0T8aIfeOkQ"],
+        "issued_at": "2019-03-04T20:06:14.599971Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1701,7 +1701,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eeab29998f384f6db012092f4e9c3ce1
+      - b7b3e0c078844126be245f9f66381cc5
   response:
     status:
       code: 200
@@ -1712,7 +1712,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:45 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1721,7 +1721,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1739,15 +1739,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:45 GMT
+      - Mon, 04 Mar 2019 20:06:14 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a4d9809befb547b1ba412d89c6c25557
+      - dd0075e6541f4870932867f68ee0bbb7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-afae92d1-89b1-477c-9a26-29ea6ef9747f
+      - req-fb9da8a8-b2e3-40fd-be52-1e4a58f8a1cd
       Content-Length:
       - '7264'
       Connection:
@@ -1759,7 +1759,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:45.725818Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:14.939667Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -1838,10 +1838,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["9ZheuX_oT7S3ih9JyXHU6g"],
-        "issued_at": "2019-01-08T19:20:45.725836Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["voBTGQNsT5ia2oT3Lx1wgg"],
+        "issued_at": "2019-03-04T20:06:14.939697Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:14 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -1856,7 +1856,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4d9809befb547b1ba412d89c6c25557
+      - dd0075e6541f4870932867f68ee0bbb7
   response:
     status:
       code: 200
@@ -1867,7 +1867,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:45 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1876,7 +1876,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -1894,15 +1894,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:45 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - aa4eccb90f8645029a199016f081600d
+      - ad7c3a6d76da4737b21a26d264586056
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e37fbb34-bb42-43c8-9525-0a142d14cc2d
+      - req-5864a5bc-2bcb-40d0-9eb1-0d0a90fad66f
       Content-Length:
       - '7278'
       Connection:
@@ -1914,7 +1914,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:46.010623Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:15.256229Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -1993,10 +1993,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["D0X_wJR0T1K4jV4njsKxYw"],
-        "issued_at": "2019-01-08T19:20:46.010642Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["hXIKRFBwSTmRgnJG4VqE0A"],
+        "issued_at": "2019-03-04T20:06:15.256252Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2011,7 +2011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa4eccb90f8645029a199016f081600d
+      - ad7c3a6d76da4737b21a26d264586056
   response:
     status:
       code: 200
@@ -2022,7 +2022,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2031,7 +2031,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2049,15 +2049,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b5c54d9ddc7c4aabb5f8e278f93dfc1e
+      - e655bea5c7d949ac992d69a36da05696
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-934227b3-55e1-4c0a-b255-e3052870fa3b
+      - req-700e3b49-95c1-4e5f-8d96-e0d7899ef7b9
       Content-Length:
       - '7265'
       Connection:
@@ -2069,7 +2069,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:46.291031Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:15.560461Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2148,10 +2148,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3gClVXziQPCe1e2OWQ6kQQ"],
-        "issued_at": "2019-01-08T19:20:46.291049Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZxjAhW5uQ2ykJ6oK5lddeQ"],
+        "issued_at": "2019-03-04T20:06:15.560483Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2166,7 +2166,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b5c54d9ddc7c4aabb5f8e278f93dfc1e
+      - e655bea5c7d949ac992d69a36da05696
   response:
     status:
       code: 200
@@ -2177,7 +2177,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2186,7 +2186,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2204,15 +2204,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e0fbbd1071114fc9a7e6d4a9f2b12173
+      - b598531518fa4e318840d370aa8e9889
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d3eea687-3faf-432e-b7a0-346cbcd484a2
+      - req-3e6d2f82-5602-4100-8925-d11ddc780801
       Content-Length:
       - '7278'
       Connection:
@@ -2224,7 +2224,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:46.575093Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:15.867091Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2303,10 +2303,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FnRDqi_9RH6GFUK59p_MTQ"],
-        "issued_at": "2019-01-08T19:20:46.575112Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4ATaN3sNQ0Gfx4xLlOhe2Q"],
+        "issued_at": "2019-03-04T20:06:15.867133Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/
@@ -2321,7 +2321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0fbbd1071114fc9a7e6d4a9f2b12173
+      - b598531518fa4e318840d370aa8e9889
   response:
     status:
       code: 200
@@ -2332,7 +2332,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -2341,7 +2341,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.206:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:15 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -2356,7 +2356,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 788c9629ffd144cbbe2b9b581e1af5a5
+      - a5f816dab34941b89890e6e5c09767d2
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2369,9 +2369,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-a182fe67-5c34-4f7e-a3b5-f5274d0ebb52
+      - req-4287aadb-2ac5-4b1d-825e-4c511b4d6323
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2380,7 +2380,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -2395,7 +2395,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eeab29998f384f6db012092f4e9c3ce1
+      - b7b3e0c078844126be245f9f66381cc5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2408,9 +2408,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8c2817e3-6db9-4342-8d99-bad882c1d707
+      - req-97b15dff-80c6-4add-a353-d125f4f0b477
       Date:
-      - Tue, 08 Jan 2019 19:20:46 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2419,7 +2419,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -2434,7 +2434,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4d9809befb547b1ba412d89c6c25557
+      - dd0075e6541f4870932867f68ee0bbb7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2447,9 +2447,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-f1a31112-343c-4bea-a9be-722b4215385e
+      - req-ef34dcdc-4bc5-43da-b98e-0bc67c24e114
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2458,7 +2458,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -2473,7 +2473,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aa4eccb90f8645029a199016f081600d
+      - ad7c3a6d76da4737b21a26d264586056
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2486,9 +2486,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-75055b87-a162-4639-a4e5-9b93dd341463
+      - req-8a1fe01c-1bc6-4526-b612-3c7ad4f75418
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2497,7 +2497,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -2512,7 +2512,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2525,9 +2525,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-2d63d8bc-6ca6-4d35-864e-6837a2431387
+      - req-c8756ea6-2b8f-4373-b949-8c3da40503da
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2536,7 +2536,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -2551,7 +2551,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b5c54d9ddc7c4aabb5f8e278f93dfc1e
+      - e655bea5c7d949ac992d69a36da05696
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2564,9 +2564,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-93bb151e-e394-411e-872f-6250570ac955
+      - req-3dec8bc8-5fe5-48c8-88ea-a5aa02f9e7e3
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2575,7 +2575,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -2590,7 +2590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e0fbbd1071114fc9a7e6d4a9f2b12173
+      - b598531518fa4e318840d370aa8e9889
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2603,9 +2603,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-dcb1cd65-5b76-488e-99fb-763b23ceb686
+      - req-6b35f16c-d844-4671-aa66-d1c4cb3a2ab9
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -2614,7 +2614,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2632,15 +2632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:17 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bf40424138ad45ef914688cd79bf9b19
+      - f8749fd2c82f43c2a37defd8f43a2c81
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b86bac1-060d-4e14-87fa-24366aa2225c
+      - req-12ee8ef4-d3b8-4a22-8a17-b0b1841e4eaf
       Content-Length:
       - '7278'
       Connection:
@@ -2652,7 +2652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:47.729695Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:17.079365Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2731,10 +2731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["jCGQvDm9Tu2aWQNEGb3bCw"],
-        "issued_at": "2019-01-08T19:20:47.729713Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZtIW1SGDThai-4v-_FAKWg"],
+        "issued_at": "2019-03-04T20:06:17.079393Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2752,15 +2752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:47 GMT
+      - Mon, 04 Mar 2019 20:06:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bab0ae172c02434c8cd6e4c3169f9e01
+      - 378545fdcf2049c986f3290ff21cd1ae
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bb346dd2-caf9-43ff-9cb8-c6d8a52c3dc7
+      - req-8bac08c2-2b49-4d33-b4be-643a4cd4e798
       Content-Length:
       - '7278'
       Connection:
@@ -2772,7 +2772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:47.928356Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:18.353246Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -2851,10 +2851,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gPHAvoEwShqT5okD2t93MA"],
-        "issued_at": "2019-01-08T19:20:47.928373Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["BsiU7kIoTr26296DhC1m_g"],
+        "issued_at": "2019-03-04T20:06:18.353268Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2872,15 +2872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:48 GMT
+      - Mon, 04 Mar 2019 20:06:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b079f99f0a7e47a39abc758967d8ef8c
+      - 309bcce2b0744e8983ea156e6966291d
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0c91238d-0c15-478b-bc5b-02c098f20b70
+      - req-96c18b14-ef34-4473-a2c9-decdccbfbd27
       Content-Length:
       - '7264'
       Connection:
@@ -2892,7 +2892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:48.148465Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:18.568641Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -2971,10 +2971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["f1eYQF6_SQuR-Lvi73WDNg"],
-        "issued_at": "2019-01-08T19:20:48.148483Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["2CrNvQnOSYSKXhsuWxKy5g"],
+        "issued_at": "2019-03-04T20:06:18.568663Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -2992,15 +2992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:48 GMT
+      - Mon, 04 Mar 2019 20:06:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4607c3f413e1425eb0d8f08146d577d4
+      - 1e4bc7caf3d142838823a827ef84bacc
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5fd5192a-81ba-496a-bbde-485ffbb15b03
+      - req-ec599c3e-d32a-4fde-91aa-b5c825f5ad8b
       Content-Length:
       - '7278'
       Connection:
@@ -3012,7 +3012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:48.352869Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:18.782448Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3091,10 +3091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EbkEozTZQa6bnKPPJ4xpfg"],
-        "issued_at": "2019-01-08T19:20:48.352887Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["HFj1uguGT0Cb5ksfWU_s-Q"],
+        "issued_at": "2019-03-04T20:06:18.782473Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3112,15 +3112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:48 GMT
+      - Mon, 04 Mar 2019 20:06:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 70256e77379845f089a7c6f420e81cfd
+      - '0940ba43a571464697ca1387e41a2c7b'
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-514f25ac-62a5-4136-9eb7-0b36717b5f27
+      - req-ba80a4f2-2a60-47eb-970f-59dc875269df
       Content-Length:
       - '7265'
       Connection:
@@ -3132,7 +3132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:48.575750Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:19.033742Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3211,10 +3211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["89Xk1JSLS4--wgadLXt57w"],
-        "issued_at": "2019-01-08T19:20:48.575781Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["K9-Z92_DSY-ve97hKUsmUg"],
+        "issued_at": "2019-03-04T20:06:19.033785Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3232,15 +3232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:48 GMT
+      - Mon, 04 Mar 2019 20:06:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 49c45a71c9724fc5a2f5b8fc68a3c472
+      - 07fe75810be0482880cba5765eab1ed3
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0cf1ee6f-53bd-4933-8cc2-65ac2363ada9
+      - req-8f5dd4bc-efdb-4bfc-9ff2-9f8f608bd3fc
       Content-Length:
       - '7278'
       Connection:
@@ -3252,7 +3252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:48.776311Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:19.257449Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3331,10 +3331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["mYjUyn6fQnitut5XxD7A-g"],
-        "issued_at": "2019-01-08T19:20:48.776329Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["YBy-CNgjRdWPzoN0EpxpYw"],
+        "issued_at": "2019-03-04T20:06:19.257479Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3//os-quota-sets/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -3349,22 +3349,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf40424138ad45ef914688cd79bf9b19
+      - f8749fd2c82f43c2a37defd8f43a2c81
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19444d62-f121-40ac-9ec2-c06641a23c88
+      - req-a69fc4b5-82f8-41d4-a951-e82c83b27264
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-19444d62-f121-40ac-9ec2-c06641a23c88
+      - req-a69fc4b5-82f8-41d4-a951-e82c83b27264
       Date:
-      - Tue, 08 Jan 2019 19:20:49 GMT
+      - Mon, 04 Mar 2019 20:06:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3374,7 +3374,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "0098405163cd4c9dbb42c2cb43eb6fd3"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74//os-quota-sets/28db8f69ba9e4305b7fad82da4c86e74
@@ -3389,22 +3389,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bab0ae172c02434c8cd6e4c3169f9e01
+      - 378545fdcf2049c986f3290ff21cd1ae
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68144279-d600-4432-a115-2a30f9d9cb47
+      - req-58ce203c-7182-44c9-b7dc-df031f71643f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-68144279-d600-4432-a115-2a30f9d9cb47
+      - req-58ce203c-7182-44c9-b7dc-df031f71643f
       Date:
-      - Tue, 08 Jan 2019 19:20:49 GMT
+      - Mon, 04 Mar 2019 20:06:19 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3414,7 +3414,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "28db8f69ba9e4305b7fad82da4c86e74"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:19 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91//os-quota-sets/4637c33fee924ebea81f8d209e452c91
@@ -3429,22 +3429,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b079f99f0a7e47a39abc758967d8ef8c
+      - 309bcce2b0744e8983ea156e6966291d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-feccbeb2-a195-4dca-baa4-a2d248a58b96
+      - req-c68b48b9-3199-471a-bc39-5def41d44f94
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-feccbeb2-a195-4dca-baa4-a2d248a58b96
+      - req-c68b48b9-3199-471a-bc39-5def41d44f94
       Date:
-      - Tue, 08 Jan 2019 19:20:49 GMT
+      - Mon, 04 Mar 2019 20:06:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3454,7 +3454,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "4637c33fee924ebea81f8d209e452c91"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5//os-quota-sets/52c452d7763a4295950527948232a3e5
@@ -3469,22 +3469,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4607c3f413e1425eb0d8f08146d577d4
+      - 1e4bc7caf3d142838823a827ef84bacc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a9eccb1-ef9e-4740-8faf-705a3501c18e
+      - req-01844f22-b55d-4dcd-980a-d3e049a27877
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-6a9eccb1-ef9e-4740-8faf-705a3501c18e
+      - req-01844f22-b55d-4dcd-980a-d3e049a27877
       Date:
-      - Tue, 08 Jan 2019 19:20:49 GMT
+      - Mon, 04 Mar 2019 20:06:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3494,7 +3494,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "52c452d7763a4295950527948232a3e5"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52//os-quota-sets/88ae57d444fd485ab2dfddd5a2615d52
@@ -3509,22 +3509,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b0515394611e43ffbcec63e1814bcf47
+      - c0f38415a07746b49bc3901fddf1bc57
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bb216b4c-9b67-4f5b-bf6e-ba9c06d4d556
+      - req-68fa618d-da02-4679-931d-7287ae8fb15f
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-bb216b4c-9b67-4f5b-bf6e-ba9c06d4d556
+      - req-68fa618d-da02-4679-931d-7287ae8fb15f
       Date:
-      - Tue, 08 Jan 2019 19:20:50 GMT
+      - Mon, 04 Mar 2019 20:06:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3534,7 +3534,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "88ae57d444fd485ab2dfddd5a2615d52"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:20 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23//os-quota-sets/d09cbe26295d47ff848ea73c74264e23
@@ -3549,22 +3549,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 70256e77379845f089a7c6f420e81cfd
+      - '0940ba43a571464697ca1387e41a2c7b'
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99f6704f-5b93-4f91-8446-6e73d8efb71b
+      - req-e86a428e-85ff-4199-9492-50ba0033c8ea
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-99f6704f-5b93-4f91-8446-6e73d8efb71b
+      - req-e86a428e-85ff-4199-9492-50ba0033c8ea
       Date:
-      - Tue, 08 Jan 2019 19:20:50 GMT
+      - Mon, 04 Mar 2019 20:06:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3574,7 +3574,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "d09cbe26295d47ff848ea73c74264e23"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:21 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d//os-quota-sets/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -3589,22 +3589,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 49c45a71c9724fc5a2f5b8fc68a3c472
+      - 07fe75810be0482880cba5765eab1ed3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1f2f88e3-bfd3-4869-b0a7-4e1c7ca93b5f
+      - req-488a8665-c7e1-4718-b23f-4c0a437165a8
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1f2f88e3-bfd3-4869-b0a7-4e1c7ca93b5f
+      - req-488a8665-c7e1-4718-b23f-4c0a437165a8
       Date:
-      - Tue, 08 Jan 2019 19:20:50 GMT
+      - Mon, 04 Mar 2019 20:06:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -3614,7 +3614,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3632,15 +3632,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:50 GMT
+      - Mon, 04 Mar 2019 20:06:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 455f6cc7534746289ea5bf02767b76fe
+      - 96a32936baac4597823bcd19ff4edf5a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-864feb09-b25d-4c9c-97fc-327c6dd0116d
+      - req-b486913b-d7d3-4572-9c3f-44f0063b3cfa
       Content-Length:
       - '7278'
       Connection:
@@ -3652,7 +3652,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:50.781795Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:21.612860Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3731,10 +3731,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["DBi9OjleQT2yQSja25sUXQ"],
-        "issued_at": "2019-01-08T19:20:50.781813Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["pQV8dwy5Rr2MM_nmd7gjCg"],
+        "issued_at": "2019-03-04T20:06:21.612883Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3752,15 +3752,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:50 GMT
+      - Mon, 04 Mar 2019 20:06:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4ca3183e4d61414080d565943b22082e
+      - a0a5c53e9caf49a2b6e5d1ab255f9a93
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4efcb85c-8d09-460b-869a-153fc72c8527
+      - req-74f3158d-728e-4004-be1b-2a9ede2a39e6
       Content-Length:
       - '7278'
       Connection:
@@ -3772,7 +3772,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:50.989474Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:21.829967Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -3851,10 +3851,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["AcfcUEmvSWKU3j7pW1LP_Q"],
-        "issued_at": "2019-01-08T19:20:50.989493Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["474yvShyTZmW4FaKl1_atA"],
+        "issued_at": "2019-03-04T20:06:21.829992Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:21 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3872,15 +3872,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:51 GMT
+      - Mon, 04 Mar 2019 20:06:21 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6a187195503b42198f673f36cad4d5d6
+      - 3e39ecc4e6804432ba0e7c4208b877b1
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d5e9cab5-1886-404b-b6c9-91cdae3cc9a0
+      - req-b6bf5985-f967-444a-8673-ad3cbf149edf
       Content-Length:
       - '7264'
       Connection:
@@ -3892,7 +3892,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:51.197911Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:22.049443Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -3971,10 +3971,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QVVAZnWETAyOVvbOK_YjWw"],
-        "issued_at": "2019-01-08T19:20:51.197952Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["m_hpbvOnQbqFOKUlM5hL7g"],
+        "issued_at": "2019-03-04T20:06:22.049475Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -3992,15 +3992,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:51 GMT
+      - Mon, 04 Mar 2019 20:06:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a128eac80d744c0ab2f97f6d6033b132
+      - b9201f41ed984aa69e82103781c69d70
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9bd278b4-73ba-4656-a0b1-293f0c6cd37b
+      - req-d88c6620-fc8c-4691-b896-b81358816585
       Content-Length:
       - '7278'
       Connection:
@@ -4012,7 +4012,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:51.391478Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:22.262109Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4091,10 +4091,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bY1ehDF0Sw2wSYSQYNe3tA"],
-        "issued_at": "2019-01-08T19:20:51.391496Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zeePDxuUQKCLXdCLSx8gRg"],
+        "issued_at": "2019-03-04T20:06:22.262144Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4112,15 +4112,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:52 GMT
+      - Mon, 04 Mar 2019 20:06:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - fbe1f4e202fe4d16a8b4733a49449eda
+      - 9c8cbb57d8ec43ceb6ae6ecaf9a383c8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-df7916c3-df67-4142-a2db-bf33068e2a43
+      - req-4f7b3579-ccb0-40a8-a141-cd27d8c1be8e
       Content-Length:
       - '7265'
       Connection:
@@ -4132,7 +4132,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:52.600471Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:22.542474Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -4211,10 +4211,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["EvcbiOofT2Gpq_i9av_9OA"],
-        "issued_at": "2019-01-08T19:20:52.600490Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3AbNPAboTwWzsjoDKifpgg"],
+        "issued_at": "2019-03-04T20:06:22.542498Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:22 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4232,15 +4232,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:52 GMT
+      - Mon, 04 Mar 2019 20:06:22 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - cda1aafdb3914b2da503a42d46369bee
+      - 62e9446a2a704995add733c6c02eb639
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1443552f-695d-4b1b-b213-4d50034b57ca
+      - req-a6c37b3f-9dfd-4c8a-b0f2-211d1781bcbf
       Content-Length:
       - '7278'
       Connection:
@@ -4252,7 +4252,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:52.806458Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:22.756981Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4331,10 +4331,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["3ORsM3QmSVSU20sC9PM0sA"],
-        "issued_at": "2019-01-08T19:20:52.806476Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yr68vZcbRjWQ5UWnEBcOpA"],
+        "issued_at": "2019-03-04T20:06:22.757003Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/0098405163cd4c9dbb42c2cb43eb6fd3
@@ -4349,7 +4349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 455f6cc7534746289ea5bf02767b76fe
+      - 96a32936baac4597823bcd19ff4edf5a
   response:
     status:
       code: 200
@@ -4360,16 +4360,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-c9c04606-75b9-4fe3-ae95-ebe93c350207
+      - req-59832d8f-4b0b-43d4-ad03-f9840d2f6964
       Date:
-      - Tue, 08 Jan 2019 19:20:52 GMT
+      - Mon, 04 Mar 2019 20:06:22 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:22 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/28db8f69ba9e4305b7fad82da4c86e74
@@ -4384,7 +4384,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4ca3183e4d61414080d565943b22082e
+      - a0a5c53e9caf49a2b6e5d1ab255f9a93
   response:
     status:
       code: 200
@@ -4395,16 +4395,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-27d9d376-0025-4e38-a38c-f6dc4bdb3e92
+      - req-12589cb0-7f72-48ea-8bce-19bb4bbb5ee8
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/4637c33fee924ebea81f8d209e452c91
@@ -4419,7 +4419,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6a187195503b42198f673f36cad4d5d6
+      - 3e39ecc4e6804432ba0e7c4208b877b1
   response:
     status:
       code: 200
@@ -4430,16 +4430,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d9a4d873-c4bb-4959-aaef-881ac2a9a1df
+      - req-0aed9a7a-0b87-44ec-a5ef-7ca2745b15a5
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/52c452d7763a4295950527948232a3e5
@@ -4454,7 +4454,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a128eac80d744c0ab2f97f6d6033b132
+      - b9201f41ed984aa69e82103781c69d70
   response:
     status:
       code: 200
@@ -4465,16 +4465,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-d3267282-084b-406b-ae76-a1f55a8a49fb
+      - req-eb39715d-b7a8-4829-a803-b540c73e5659
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/88ae57d444fd485ab2dfddd5a2615d52
@@ -4489,7 +4489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5950ff25b8c24e858ddaf495e488fb3f
+      - 1f87389598544c58a86a0334700954a6
   response:
     status:
       code: 200
@@ -4500,16 +4500,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-ea2c1e9d-c680-4715-b2a1-5c49ecacb0a5
+      - req-768f17ea-42f6-49a7-8a78-16095e50bcd1
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/d09cbe26295d47ff848ea73c74264e23
@@ -4524,7 +4524,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fbe1f4e202fe4d16a8b4733a49449eda
+      - 9c8cbb57d8ec43ceb6ae6ecaf9a383c8
   response:
     status:
       code: 200
@@ -4535,16 +4535,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a0ba6ad0-f26c-4b85-a115-aa2059ff44be
+      - req-96c709ed-bed2-4cdc-93d5-e144d6bf86ea
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0//quotas/ef2a3405d1ef4dfd9a3616993ef46a4d
@@ -4559,7 +4559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cda1aafdb3914b2da503a42d46369bee
+      - 62e9446a2a704995add733c6c02eb639
   response:
     status:
       code: 200
@@ -4570,16 +4570,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-43277129-f517-4e07-8a9e-7e551a96958c
+      - req-726d945f-1409-462a-a53f-3232786ed8c1
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000
@@ -4594,7 +4594,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4607,9 +4607,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-4b5ef40d-9aee-4f37-b9d1-3cb061cb8f6f
+      - req-b3869329-5cd2-4356-8e8b-9cbcb79bb550
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4619,7 +4619,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4634,7 +4634,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4647,9 +4647,9 @@ http_interactions:
       Content-Length:
       - '1611'
       X-Compute-Request-Id:
-      - req-3d95cea7-a5e3-44e2-8c06-f65ff5e14e2e
+      - req-c6a666a4-4c19-4a19-aac1-753fdc2942cc
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKQyhM0ECmYmB8mI4vfeTEaY90skgHYgA/5apgT+cHhKzZX59Go+LGfb98dOCYEjnV3XKdO5dy7MrSdI5QSvGJmJIQPsH4WZNpRNuEhHzcHS1fEPe9zMceRlLafkTeUKhUGMIi1gOmBRdyZtz6fJw37AK6ioM4+16IhXjNVLV09jHn2PsUjh2RsGX5TzA3eHivptzINBD8eMBkyQwS2uejY42FlIg9qBpa8KEMgyo4KLvd/99kw9wLg1D9Y5+3OxA/J6hLfjSBv7Vd7Xvwd4ZmDlkU5+yH88b2ZOte8MyfAnlVA4v8bMdSsAf1e5NvUuZsoZC8goZCHjXmTDSI+yen
@@ -4659,7 +4659,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCbO5U18NVrx2B72GteyHeYLFEX4dAdLi7Ey1POIdH41eFZt3pKUm642nP2nSi4Iy3HeUyn7ZrxCu/SNnztO3dVoBKY4DAJ3tr6ZEQL6qHt3FXNnqYM6UIc7X2JOmlSIoyGkY+Nzz5Nph9tT81cH05pyxpzHieUYb7NV9whyubfQ7zH/GmqK/pLa3cvTvGD+Ew4yqY2/UqoDFw+Tbs2RY+zrWMTFLtkBCIRhBKeeSsDzxOxKK6Mvgb4DF4eONC5/SmXglniVxcyOEXj3kmFv3BEVYTQwfREnGGpjyZ774Z/jEW85+6S0XIgbg55FyvbIUDTOmbo2dBE4CbrkaQh8GCn
         Generated-by-Nova", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "c3:5f:7f:38:bb:55:2d:84:c4:22:6c:34:32:6c:ce:a1"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4677,15 +4677,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:53 GMT
+      - Mon, 04 Mar 2019 20:06:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e291c8f4d32c4a268947db9056f7b310
+      - f7d7ac255926427a9820fb9555614d28
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5b5b1e0d-626a-4633-a8e2-dd05d7f28076
+      - req-4e1e145a-84e1-4a6b-9374-a5d4b30bcb7b
       Content-Length:
       - '7278'
       Connection:
@@ -4697,7 +4697,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:53.978158Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:24.059359Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4776,10 +4776,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["w20gr12pQwOfszBqF3ioAg"],
-        "issued_at": "2019-01-08T19:20:53.978178Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["zm33FZWvSbqGfds57KNM6g"],
+        "issued_at": "2019-03-04T20:06:24.059382Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4797,15 +4797,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:54 GMT
+      - Mon, 04 Mar 2019 20:06:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 883655648fee47d5ad7dd46a606e622a
+      - 5f2575f4360346dfae500224dcf6312c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c6eb422c-a565-4f12-8825-734f739b0b07
+      - req-04060018-0212-4c3e-8c3a-c47ae1057f48
       Content-Length:
       - '7278'
       Connection:
@@ -4817,7 +4817,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:54.186673Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:24.270700Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -4896,10 +4896,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["UafnLzqtTKWS56QA6pLXtw"],
-        "issued_at": "2019-01-08T19:20:54.186692Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["kHMUapy2QMaVc-IoAlz5cw"],
+        "issued_at": "2019-03-04T20:06:24.270725Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -4917,15 +4917,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:54 GMT
+      - Mon, 04 Mar 2019 20:06:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-680d0cf2-9cee-4901-b5ca-a60e2c87fa73
+      - req-1570f257-7f5c-4a93-a9ce-b4443ea81fdb
       Content-Length:
       - '7264'
       Connection:
@@ -4937,7 +4937,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:54.395414Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:24.486792Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5016,10 +5016,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["0CB3v_g0Ss6ftMWQD4RmWg"],
-        "issued_at": "2019-01-08T19:20:54.395433Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JU3M8cRgRDGxBD2TI4JXJA"],
+        "issued_at": "2019-03-04T20:06:24.486828Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5037,15 +5037,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:54 GMT
+      - Mon, 04 Mar 2019 20:06:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 98f58048707840efb21e3608aea79928
+      - 0a99cc8f8f9d4a219f393f9748885ef8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b4b0a79b-e2da-4065-9d19-6d4ff9f5f10d
+      - req-058d443f-6805-4e5d-bdd5-f5cd7189d5e6
       Content-Length:
       - '7278'
       Connection:
@@ -5057,7 +5057,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:54.601622Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:24.702742Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5136,10 +5136,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["e0ayhIrsTq-lWeYKTfLAJw"],
-        "issued_at": "2019-01-08T19:20:54.601641Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["inFhfsSFSOqjYtGcaHt1nA"],
+        "issued_at": "2019-03-04T20:06:24.702766Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5157,15 +5157,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:54 GMT
+      - Mon, 04 Mar 2019 20:06:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 05d10cb347214615abff2852b6cab6ae
+      - d0009da3fbf449e0990692ab8e6b9e98
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8ca23fcb-ada5-4aa0-ad09-493445aa10c5
+      - req-de3f9fa7-4f57-454d-b690-c53ec0e839b0
       Content-Length:
       - '7265'
       Connection:
@@ -5177,7 +5177,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:54.807368Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:24.948413Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -5256,10 +5256,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["JFliHQ2ASWi9Wddqj2JbwQ"],
-        "issued_at": "2019-01-08T19:20:54.807386Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["FmLg7g9rTWGDPEmCMV8Mhw"],
+        "issued_at": "2019-03-04T20:06:24.948440Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:24 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -5277,15 +5277,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:20:54 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 9ddd8f138f964160b09d7e0e113e174d
+      - eeac94fa304746ec8f2a1aa568412db2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e72464f3-72c9-432b-a8f0-14548ab7fd54
+      - req-605446c8-c70b-486f-ab9a-20ce24764c7c
       Content-Length:
       - '7278'
       Connection:
@@ -5297,7 +5297,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:20:55.007062Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:25.168013Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -5376,10 +5376,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["xVKTZCdTTqm78v0umlr3mw"],
-        "issued_at": "2019-01-08T19:20:55.007090Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ExIFrkJhTRSX79mMIV9woA"],
+        "issued_at": "2019-03-04T20:06:25.168038Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/0098405163cd4c9dbb42c2cb43eb6fd3/stacks?limit=1000&show_nested=true
@@ -5394,7 +5394,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e291c8f4d32c4a268947db9056f7b310
+      - f7d7ac255926427a9820fb9555614d28
   response:
     status:
       code: 200
@@ -5405,14 +5405,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ce22faee-70c8-431d-9e44-72ee55cb2ed0
+      - req-bb6a2625-d2fd-4ecc-bdfe-3f40fd758b5a
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/28db8f69ba9e4305b7fad82da4c86e74/stacks?limit=1000&show_nested=true
@@ -5427,7 +5427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 883655648fee47d5ad7dd46a606e622a
+      - 5f2575f4360346dfae500224dcf6312c
   response:
     status:
       code: 200
@@ -5438,14 +5438,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-73074c16-5af7-43b3-8510-96f2d3b914b0
+      - req-e35e0018-3b59-4bb8-85ce-52bf8f3bf9ef
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&show_nested=true
@@ -5460,7 +5460,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5471,9 +5471,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-9f861fbb-b430-409d-b59d-a9c307527cb7
+      - req-1e37e2d0-843e-4d94-a07f-9be6aae005e2
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -5507,7 +5507,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks?limit=1000&marker=7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0&show_nested=true
@@ -5522,7 +5522,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5533,14 +5533,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-6531a6df-f4b9-4461-a0be-910a2c70e9a5
+      - req-411017b7-8fc0-45c2-8ef0-7dc1bbae5cfd
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/52c452d7763a4295950527948232a3e5/stacks?limit=1000&show_nested=true
@@ -5555,7 +5555,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 98f58048707840efb21e3608aea79928
+      - 0a99cc8f8f9d4a219f393f9748885ef8
   response:
     status:
       code: 200
@@ -5566,14 +5566,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ba083c34-f450-4a90-86ab-a6694f940a9f
+      - req-1aff457f-9b26-42d8-979d-56fbf97cd355
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/88ae57d444fd485ab2dfddd5a2615d52/stacks?limit=1000&show_nested=true
@@ -5588,7 +5588,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 50f3e027d17840fa91cb44e59f235ef5
+      - e9a3fc579e5248c1bdc9e0aff9615145
   response:
     status:
       code: 200
@@ -5599,14 +5599,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-3d0d06aa-9879-4d5c-96f3-5bb5496172df
+      - req-6cfd2f1a-27ae-4e5c-9ca3-f315b93491d7
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:25 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/d09cbe26295d47ff848ea73c74264e23/stacks?limit=1000&show_nested=true
@@ -5621,7 +5621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 05d10cb347214615abff2852b6cab6ae
+      - d0009da3fbf449e0990692ab8e6b9e98
   response:
     status:
       code: 200
@@ -5632,14 +5632,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-37850029-3e84-478d-8ee4-9e68bed0debb
+      - req-5add455f-b9b8-4005-a0d6-c36ea9f11905
       Date:
-      - Tue, 08 Jan 2019 19:20:55 GMT
+      - Mon, 04 Mar 2019 20:06:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/ef2a3405d1ef4dfd9a3616993ef46a4d/stacks?limit=1000&show_nested=true
@@ -5654,7 +5654,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9ddd8f138f964160b09d7e0e113e174d
+      - eeac94fa304746ec8f2a1aa568412db2
   response:
     status:
       code: 200
@@ -5665,14 +5665,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-b30270ee-a299-43c4-88b7-a173c51ca64d
+      - req-c1dd4b5c-be44-4e04-b5e3-9216da2c3691
       Date:
-      - Tue, 08 Jan 2019 19:20:56 GMT
+      - Mon, 04 Mar 2019 20:06:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44
@@ -5687,7 +5687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5698,9 +5698,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-bdc1a42f-a616-40a0-bac5-1ede032dc1dd
+      - req-0b466ae7-a18e-41f3-8aec-fe24bfbcfbcc
       Date:
-      - Tue, 08 Jan 2019 19:20:56 GMT
+      - Mon, 04 Mar 2019 20:06:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5727,7 +5727,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d
@@ -5742,7 +5742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5753,9 +5753,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-9f6af565-120f-41f9-b9ac-d1f014927c5f
+      - req-a8df648b-7d99-42d4-b73f-d3600de6c901
       Date:
-      - Tue, 08 Jan 2019 19:20:56 GMT
+      - Mon, 04 Mar 2019 20:06:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5782,7 +5782,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:26 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0
@@ -5797,7 +5797,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5808,9 +5808,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-3b1e8a80-99c1-439e-9486-e459d9738643
+      - req-16079b86-4ffa-4c6d-a243-885985a7c371
       Date:
-      - Tue, 08 Jan 2019 19:20:56 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -5837,7 +5837,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/resources
@@ -5852,7 +5852,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5863,9 +5863,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-d399a840-3e06-48d1-b083-e913b994427e
+      - req-01c1ebf3-cd05-4e8d-99cd-6b766a724b80
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -5877,7 +5877,7 @@ http_interactions:
         changed", "physical_resource_id": "40989f26-9c38-4f72-b739-afccb44397cf",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack3/00c5dc04-2c94-48d2-8031-db08934e9a44/template
@@ -5892,7 +5892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5903,9 +5903,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-10e8982b-6ccf-4844-af0a-9e9d4983f3e8
+      - req-19c62b3e-731c-449f-9c53-b77f04f91eb7
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -5961,7 +5961,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/resources
@@ -5976,7 +5976,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -5987,9 +5987,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e0ee76bd-5a5c-46dd-b8af-7bdfef19cb82
+      - req-0a6383c1-be88-4c6e-8aec-a41b0547a42c
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6001,7 +6001,7 @@ http_interactions:
         changed", "physical_resource_id": "ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack2/d6eba2a2-7b0d-4213-afbb-69c8f6dddd8d/template
@@ -6016,7 +6016,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -6027,9 +6027,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-3e8fc50d-b93e-4f2e-aedc-a75cfbf944a7
+      - req-a3da8e62-0315-4c71-a0b5-69107460a2f1
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6085,7 +6085,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/resources
@@ -6100,7 +6100,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -6111,9 +6111,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-4cd64e76-21a0-4121-8ea0-0d20c65efed2
+      - req-d4b559a6-ed78-4cd3-9cb2-604f0fc8543e
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -6125,7 +6125,7 @@ http_interactions:
         changed", "physical_resource_id": "8022b967-813a-4e3b-8ff4-7c036957a8a0",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8004/v1/4637c33fee924ebea81f8d209e452c91/stacks/stack1/7fff4dfd-c9e1-4536-a0b1-8952a6cbb9d0/template
@@ -6140,7 +6140,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2aab2c70a52a4829adef776626295163
+      - 33bd9d533f364ddd8c90cf51056eb731
   response:
     status:
       code: 200
@@ -6151,9 +6151,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-d01ce099-5ade-49f5-aa93-4c52460226d7
+      - req-5ef72889-d619-4d88-83d4-29d0ebced064
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:27 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -6209,7 +6209,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:27 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images?all_tenants=True&limit=1000
@@ -6224,7 +6224,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6235,14 +6235,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-e86e95d0-c030-430a-b88c-c602778c406e
+      - req-24f784bd-0f0f-4883-b899-b1dac94bdcf5
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images
@@ -6257,7 +6257,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6268,9 +6268,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-f22afe40-bd86-42c7-8e09-33e8518a4f42
+      - req-a02b179d-32ba-42c6-8f25-4ab85d3bc43f
       Date:
-      - Tue, 08 Jan 2019 19:20:57 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -6312,7 +6312,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f17ed5a2-4e34-4140-a634-0d56b2e564b5/members
@@ -6327,7 +6327,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6338,14 +6338,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b661d15d-13dd-45ef-bd91-5bc1461bff4e
+      - req-ef37a620-80bf-4ef6-8e2c-622a4ec31f4a
       Date:
-      - Tue, 08 Jan 2019 19:20:58 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/afa19b9e-6375-431a-9ef0-07723a338c64/members
@@ -6360,7 +6360,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6371,14 +6371,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-96e0ed30-ac6c-4fb6-9588-fdbbe8ad8330
+      - req-d27d3afe-c45b-43b5-a134-30bc4af4815b
       Date:
-      - Tue, 08 Jan 2019 19:20:58 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/f5a1950f-a8e8-4485-9e51-a49ee40ae42e/members
@@ -6393,7 +6393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6404,14 +6404,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cd4682d0-cb3a-4edc-a443-34e9b1bf6a35
+      - req-29998af7-64b6-4254-876c-c53e0db9daec
       Date:
-      - Tue, 08 Jan 2019 19:20:58 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9292/v2/images/b672acdb-654b-41d7-963c-44a0349bd285/members
@@ -6426,7 +6426,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc35827ed20e4150a168052b4d78d9f7
+      - af44487248f14927b719f436d5442e47
   response:
     status:
       code: 200
@@ -6437,14 +6437,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-670d47a1-d587-41f6-9c32-e5add66e1bec
+      - req-169ba384-df42-4971-8d35-8b846a093262
       Date:
-      - Tue, 08 Jan 2019 19:20:58 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000
@@ -6459,7 +6459,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6472,9 +6472,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-8ca42917-e9f4-459b-b04f-005c9839240e
+      - req-877537e5-4b61-4756-8df3-7f7dc85a4b45
       Date:
-      - Tue, 08 Jan 2019 19:20:58 GMT
+      - Mon, 04 Mar 2019 20:06:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813",
@@ -6520,7 +6520,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:28 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=43f23d3a-fe8d-4bbb-9d23-fe1c437c7813
@@ -6535,7 +6535,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6548,9 +6548,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-71adba0f-68e2-4b34-8c45-e3dc3b8b24b6
+      - req-29d9a297-ed44-4f33-970e-f98e166b53d9
       Date:
-      - Tue, 08 Jan 2019 19:20:59 GMT
+      - Mon, 04 Mar 2019 20:06:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f",
@@ -6596,7 +6596,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=5d121f19-3e04-4743-8ed7-c5dfaa6ef71f
@@ -6611,7 +6611,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6624,9 +6624,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-13a5c96b-abb0-4050-b648-d9f22f7093a3
+      - req-927a7a1a-cc88-4a3f-bea1-6851092d0b55
       Date:
-      - Tue, 08 Jan 2019 19:20:59 GMT
+      - Mon, 04 Mar 2019 20:06:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91",
@@ -6674,7 +6674,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:29 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=7edb7855-d974-4e45-8ad2-88491541ab91
@@ -6689,7 +6689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6702,9 +6702,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-7f442cd7-dfa6-4049-ac8a-bac6debfcab8
+      - req-63b0d284-34a5-40a8-8407-ba7e75035e12
       Date:
-      - Tue, 08 Jan 2019 19:20:59 GMT
+      - Mon, 04 Mar 2019 20:06:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02",
@@ -6746,7 +6746,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/servers/detail?all_tenants=True&limit=1000&marker=ad4f7eb0-9122-41a6-a0f7-55c1d4ca5e02
@@ -6761,7 +6761,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6774,9 +6774,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-e8dbada5-6a61-487c-b46a-d3f1a37194c1
+      - req-b08b7983-b335-49a2-a294-087e2710e7c9
       Date:
-      - Tue, 08 Jan 2019 19:20:59 GMT
+      - Mon, 04 Mar 2019 20:06:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2017-05-22T16:01:49Z",
@@ -6799,7 +6799,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6814,7 +6814,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6827,14 +6827,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-60656dbd-e222-4478-85b7-07b41d7c63eb
+      - req-b6966499-efbe-4e0d-9fa1-29493a859347
       Date:
-      - Tue, 08 Jan 2019 19:20:59 GMT
+      - Mon, 04 Mar 2019 20:06:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:20:59 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:30 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6849,7 +6849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6862,14 +6862,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-974fec5d-b6e3-4edd-b317-4f906d4a6749
+      - req-908d36dd-c060-48f6-a27d-3cb004d0cb70
       Date:
-      - Tue, 08 Jan 2019 19:21:00 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6884,7 +6884,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6897,14 +6897,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-71a5220b-fed5-438c-a0eb-00452641f869
+      - req-e2e17c79-a057-497d-8f43-2d862f67b334
       Date:
-      - Tue, 08 Jan 2019 19:21:00 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6919,7 +6919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6932,14 +6932,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-b70bbce4-586d-4de5-861e-e9d602cbbc52
+      - req-690ecbab-fe39-48ca-8a87-9ef9867486d7
       Date:
-      - Tue, 08 Jan 2019 19:21:00 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6954,7 +6954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -6967,14 +6967,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-c3f27d8b-c504-4476-8243-12eea4f64b05
+      - req-2fae80fb-0da6-4521-bd63-25d54bc10122
       Date:
-      - Tue, 08 Jan 2019 19:21:00 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -6989,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7002,14 +7002,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-bee58f9a-6491-41f5-a28f-73628678b319
+      - req-236b4f47-ddcf-4583-ade5-273ba5fb8787
       Date:
-      - Tue, 08 Jan 2019 19:21:00 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:00 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7024,7 +7024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7037,14 +7037,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6dd725e3-34ba-4354-be1e-cbf69db0c925
+      - req-6a1750f4-18c0-4720-8829-2bc14f442108
       Date:
-      - Tue, 08 Jan 2019 19:21:01 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7059,7 +7059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7072,14 +7072,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-109e5c6e-249e-4cf9-886a-a0ea1b3a3d14
+      - req-e0b68b9a-d028-46b7-8a72-227d3a417675
       Date:
-      - Tue, 08 Jan 2019 19:21:01 GMT
+      - Mon, 04 Mar 2019 20:06:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:31 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-floating-ips
@@ -7094,7 +7094,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7107,14 +7107,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-24dffd3f-fa7f-44fa-9665-48ba1a64c2c5
+      - req-51c7abd5-cd89-4b0e-9639-898ba16dabbc
       Date:
-      - Tue, 08 Jan 2019 19:21:01 GMT
+      - Mon, 04 Mar 2019 20:06:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000
@@ -7129,7 +7129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7142,26 +7142,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-172d5fe3-7966-4b39-b621-d1440f1d05e8
+      - req-e221c7e1-30fd-4611-88d1-c98d04bbdf71
       Date:
-      - Tue, 08 Jan 2019 19:21:01 GMT
+      - Mon, 04 Mar 2019 20:06:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:21:00.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:25.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:20:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:26.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:20:57.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:06:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:20:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:28.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:20:54.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:26.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:32 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8774/v2/88ae57d444fd485ab2dfddd5a2615d52/os-services?all_tenants=True&limit=1000&marker=6
@@ -7176,7 +7176,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 810de7a7a6204b90893a2b6c56fa0e47
+      - 9ab14dab659a408aa5fd39283ccc948d
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -7189,26 +7189,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-bf28f82e-72e0-4d0c-bb0a-2db70e0cc774
+      - req-f823584e-48c8-4d8b-b658-0402699a9741
       Date:
-      - Tue, 08 Jan 2019 19:21:01 GMT
+      - Mon, 04 Mar 2019 20:06:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:21:00.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:06:25.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:20:54.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:06:26.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:20:57.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:06:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 5, "updated_at":
-        "2019-01-08T19:20:59.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:06:28.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-01-08T19:20:54.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 6, "updated_at": "2019-03-04T20:06:26.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7226,15 +7226,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:02 GMT
+      - Mon, 04 Mar 2019 20:06:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e833b8503c044bc3bdc02eab279a982d
+      - b9245608c38843e28ba90e06954042b6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47be6a85-88b7-4108-b68a-54ded1d6e5b1
+      - req-7aa8e97d-52dd-403e-b5c4-5a83d66c306a
       Content-Length:
       - '7311'
       Connection:
@@ -7246,7 +7246,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:02.919169Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:33.607375Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7325,10 +7325,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["4wRxZobcRWqN1x9Kntsb0w"],
-        "issued_at": "2019-01-08T19:21:02.919187Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gknFxJvST2uBHXxGNMpb_Q"],
+        "issued_at": "2019-03-04T20:06:33.607394Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -7346,15 +7346,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1c3f53af-9710-43b6-84d3-9eee680c9d08
+      - req-169491d9-c66f-44f0-8f02-23a767aa8787
       Content-Length:
       - '7311'
       Connection:
@@ -7366,7 +7366,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:03.121809Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:38.945653Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -7445,10 +7445,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lD650fg7S7q157niwKwfTQ"],
-        "issued_at": "2019-01-08T19:21:03.121826Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Z8sgPLz0QTG6mFYIr9Mcew"],
+        "issued_at": "2019-03-04T20:06:38.945675Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:38 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -7463,7 +7463,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7474,9 +7474,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-136c4054-17b8-4f51-b3a7-84c04231ca34
+      - req-16e974f3-fae9-42ee-8d92-6df01124578a
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7",
@@ -7511,7 +7511,7 @@ http_interactions:
         null, "port_range_min": null, "id": "7e354503-9d45-4cc4-a742-4ff9501ba396",
         "security_group_id": "2e57d382-aeb2-4107-85cd-9dbde325f8f7"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=2e57d382-aeb2-4107-85cd-9dbde325f8f7
@@ -7526,7 +7526,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7537,9 +7537,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-f50353b9-7aad-4290-81ff-4504801724a9
+      - req-232c1478-a565-4cfb-9e3d-97c0422c2f9a
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d",
@@ -7582,7 +7582,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "f87c3733-0682-46d9-8df1-05f1207541d1",
         "security_group_id": "42bcab35-fe98-49f3-ba0e-705a2737b81d"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=42bcab35-fe98-49f3-ba0e-705a2737b81d
@@ -7597,7 +7597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7608,9 +7608,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-178e2d49-88f0-4dd6-b372-7a91de577f92
+      - req-93250efa-d8e5-402f-a723-6edea87a23c6
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80",
@@ -7653,7 +7653,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "d0ee1562-3ff7-4ad5-b29f-8dd350ed221f",
         "security_group_id": "7250f04f-facd-4731-b072-f346b1cc7a80"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=7250f04f-facd-4731-b072-f346b1cc7a80
@@ -7668,7 +7668,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7679,9 +7679,9 @@ http_interactions:
       Content-Length:
       - '8771'
       X-Openstack-Request-Id:
-      - req-178dbf34-34c1-4691-a773-6e009caee1f6
+      - req-8a157b98-966a-4a4b-800b-0cfa443c8c07
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d",
@@ -7788,7 +7788,7 @@ http_interactions:
         "port_range_max": 65535, "port_range_min": 1, "id": "e483857b-5eb5-4cb0-94d6-b431a2f0cb10",
         "security_group_id": "8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=8e23a8a5-f66a-4fdd-9c9a-0bb8ddf8266d
@@ -7803,7 +7803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7814,9 +7814,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-0eeaa47d-6fd8-480b-9011-2bd055aef05c
+      - req-42bff890-f8b7-441e-93e7-be7020fd8ad4
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563",
@@ -7858,7 +7858,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "e1aa03c0-0758-42ca-b030-a3d62800e578",
         "security_group_id": "bab65d2f-4717-47eb-bfb2-95100b254563"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=bab65d2f-4717-47eb-bfb2-95100b254563
@@ -7873,7 +7873,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7884,15 +7884,15 @@ http_interactions:
       Content-Length:
       - '173'
       X-Openstack-Request-Id:
-      - req-9e5fceed-41b9-455c-bc5d-fcff3cc00074
+      - req-e8f98ad1-95aa-48fa-a5fc-f29c82bff637
       Date:
-      - Tue, 08 Jan 2019 19:21:03 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.206:9696/v2.0/security-groups?all_tenants=True&limit=1000&page_reverse=True",
         "rel": "previous"}], "security_groups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/networks
@@ -7907,7 +7907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -7918,27 +7918,12 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-fd301383-43b6-4ee5-b27d-c8db78cea624
+      - req-e1a47f52-12a9-48b7-92ba-67808516ea62
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["978d38ec-4845-45ce-b3e3-89e7c9d9109b",
-        "9801267c-cd57-437a-a852-b46640cb4332"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
-        36}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
-        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
-        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
-        31}, {"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["53450d1a-8ecc-43aa-a641-95db25b6be2e"],
         "name": "EmsRefreshSpec-NetworkPublic_40", "provider:physical_network": "public_net_4",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
@@ -7978,19 +7963,34 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "c66145df-4d9d-4898-9e35-12a102b66346", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
+        null}, {"status": "ACTIVE", "subnets": ["9801267c-cd57-437a-a852-b46640cb4332",
+        "978d38ec-4845-45ce-b3e3-89e7c9d9109b"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "provider:segmentation_id":
+        36}, {"status": "ACTIVE", "subnets": ["76d851f4-9cd9-49ca-93ac-bcc7b3c8153a"],
         "name": "EmsRefreshSpec-NetworkPublic_20", "provider:physical_network": "public_net_2",
         "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "24c83610-eab6-4f68-99dd-ab22a638b4a0"], "name": "EmsRefreshSpec-NetworkPrivate",
+        null}, {"status": "ACTIVE", "subnets": ["e96c89d2-810a-4cdb-a19b-93072db5dd20"],
+        "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571", "provider:segmentation_id":
+        99}, {"status": "ACTIVE", "subnets": ["e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "provider:segmentation_id":
+        31}, {"status": "ACTIVE", "subnets": ["24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "f4c17602-9618-4604-b3c9-9e4801d094d3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "provider:segmentation_id":
         11}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:39 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -8005,7 +8005,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8016,12 +8016,36 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9448b3fd-91c9-48f3-94ae-4152a4eff494
+      - req-996625b8-26e9-4377-8349-a7f170ca2d03
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
+        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
         true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
@@ -8085,176 +8109,20 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
         "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}]}'
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
-- request:
-    method: get
-    uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=24c83610-eab6-4f68-99dd-ab22a638b4a0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d5061255-66a3-4bbd-9f4a-bbcb517a210d
-      Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "f477c0cd-eba7-4f8d-a2cc-b05ece115c43", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp": false, "network_id": "17c4c2db-a873-4bdb-9dda-d685e6aee52e",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2",
-        "end": "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "bf6ec7ab-27fb-4d02-9c78-b4169fc3dd0b",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "47adfcbd-021e-45bb-9d19-7f322d741c49", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "75e7a9c8-eeaf-4cd0-80da-05165f897e69",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "a6dc66a9-aac3-4fad-97a6-896dd23fbb10",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
-        true, "network_id": "499019e1-5b2b-4be9-9134-ccc76e20d5be", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
-        "id": "64f64a1d-46bf-4862-a654-b004310cbd7f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "abe64b4f-d6c1-4ab3-bffe-0fbfd1c53571",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.8",
-        "end": "192.168.3.10"}, {"start": "192.168.3.2", "end": "192.168.3.6"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "e96c89d2-810a-4cdb-a19b-93072db5dd20", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "f4823e3f-2c96-44e8-9366-915319145d8a",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
-        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "9bb84a96-3a02-45be-9b16-b0db19c167db",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "f65461d7-91ff-4ebd-af92-3b29fac3bc0e", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "53450d1a-8ecc-43aa-a641-95db25b6be2e",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "9801267c-cd57-437a-a852-b46640cb4332", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.31.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.31.2",
-        "end": "192.168.31.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.31.0/24", "id": "3be7c490-3820-43ad-8bc4-00d0367b8d21",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "48202e65-eda1-4f2a-94ea-cdcae33f0dd0", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "e3ca4b9b-4c37-4fec-a844-b2ec6e141e3d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "3ef7b2a8-00d9-4e03-86e8-89a64e981345", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=f4c17602-9618-4604-b3c9-9e4801d094d3
@@ -8269,7 +8137,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8280,29 +8148,12 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-87a87d49-c538-4ac8-99a7-72f1dd5cde3c
+      - req-83538f20-ff7c-4979-8e03-0e10e76f78f4
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
-        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
-        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
-        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "c66145df-4d9d-4898-9e35-12a102b66346", "tenant_id":
         "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
@@ -8373,20 +8224,37 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "c53efdb0-e706-4c94-b0e5-a9a2eb84b459", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c",
-        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "f4c17602-9618-4604-b3c9-9e4801d094d3",
-        "subnetpool_id": null}]}'
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "483c08c7-96b0-4e08-9db7-96d5650974ac", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "978d38ec-4845-45ce-b3e3-89e7c9d9109b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "91eed80f-14a3-41a1-8acb-558dd451ecec",
+        "tenant_id": "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "c2ab9441-dd1c-4acc-a3a6-753f1a582291",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp":
+        false, "network_id": "0ce7b9aa-32ad-44c6-bad1-6db12eb5ac98", "tenant_id":
+        "4637c33fee924ebea81f8d209e452c91", "dns_nameservers": [], "gateway_ip": "172.16.19.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21", "end":
+        "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "76d851f4-9cd9-49ca-93ac-bcc7b3c8153a",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.0.8", "end": "192.168.0.8"},
+        {"start": "192.168.0.3", "end": "192.168.0.5"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "24c83610-eab6-4f68-99dd-ab22a638b4a0",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "75b79bcf-d96a-4ab9-b1f1-3a5c21e6289c", "tenant_id": "4637c33fee924ebea81f8d209e452c91",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "f4c17602-9618-4604-b3c9-9e4801d094d3", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -8401,7 +8269,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8412,9 +8280,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-e9fcb8e4-b258-42d1-ad18-cc546424aac9
+      - req-e274f765-d946-46be-a1a4-3b5e8a2afcec
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8446,7 +8314,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/routers?all_tenants=True&limit=1000&marker=e49f1a18-9fd8-4130-9e9f-f13b5190f9fd
@@ -8461,7 +8329,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8472,9 +8340,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-16cb307c-cc70-4c0f-a98d-f499615a3a4e
+      - req-40a9aab2-2e01-4b74-97ce-c1e395b466d1
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -8506,7 +8374,7 @@ http_interactions:
         true, "tenant_id": "4637c33fee924ebea81f8d209e452c91", "distributed": false,
         "routes": [], "ha": false, "id": "e49f1a18-9fd8-4130-9e9f-f13b5190f9fd"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -8521,7 +8389,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8532,9 +8400,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-9cb46758-3a12-4c75-b36f-a249f0dc1433
+      - req-67cad55b-1ae3-4012-bc6a-de911995247d
       Date:
-      - Tue, 08 Jan 2019 19:21:04 GMT
+      - Mon, 04 Mar 2019 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -8937,7 +8805,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/ports?all_tenants=True&limit=1000&marker=fb9152f8-5f19-4171-9b8e-f1e594c24d64
@@ -8952,7 +8820,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -8963,9 +8831,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-85c41631-99ad-461f-aa58-9d6637bf8e1d
+      - req-2ed88434-5473-460f-a2a6-81f624670cfc
       Date:
-      - Tue, 08 Jan 2019 19:21:05 GMT
+      - Mon, 04 Mar 2019 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -9368,7 +9236,7 @@ http_interactions:
         "dns_name": "", "binding:vif_details": {}, "binding:vnic_type": "normal",
         "binding:vif_type": "unbound", "tenant_id": "", "mac_address": "fa:16:3e:02:b7:58"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:40 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -9383,7 +9251,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -9394,9 +9262,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1f69f772-65ce-445b-8e7b-79993b37e4c3
+      - req-add655db-41d4-460e-b8db-5c1db13a5028
       Date:
-      - Tue, 08 Jan 2019 19:21:05 GMT
+      - Mon, 04 Mar 2019 20:06:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9438,7 +9306,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:41 GMT
 - request:
     method: get
     uri: http://10.8.99.206:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=e5a4a7fd-b2c7-4a38-b725-a666d4f90f60
@@ -9453,7 +9321,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 579e8aa12abc4f82b8b7b986454428d2
+      - 8b779da2524840c9962ba2a6a220d960
   response:
     status:
       code: 200
@@ -9464,9 +9332,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-02244c7f-75dc-4562-a3c2-93f28eeff5b4
+      - req-321c873a-4b44-4e2b-9f86-1359a3669a59
       Date:
-      - Tue, 08 Jan 2019 19:21:05 GMT
+      - Mon, 04 Mar 2019 20:06:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "c66145df-4d9d-4898-9e35-12a102b66346",
@@ -9508,7 +9376,7 @@ http_interactions:
         "tenant_id": "4637c33fee924ebea81f8d209e452c91", "status": "DOWN", "port_id":
         null, "id": "e5a4a7fd-b2c7-4a38-b725-a666d4f90f60"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9526,15 +9394,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:06 GMT
+      - Mon, 04 Mar 2019 20:06:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 3c6ce0a8c0a84c518446683f0da969d9
+      - 57bf9589f75641b1b0c78ee53a35ab21
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5c871e8c-a7e8-4334-89d6-2e60fa3baf98
+      - req-bea3f328-e217-47d7-ad97-759169d9c942
       Content-Length:
       - '7311'
       Connection:
@@ -9546,7 +9414,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:06.405851Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:43.056861Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9625,10 +9493,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wbKzz_AkQ_agucY0ehmwZw"],
-        "issued_at": "2019-01-08T19:21:06.405869Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["OxzS3YI5TXCGBwwsuNoeXw"],
+        "issued_at": "2019-03-04T20:06:43.056888Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9646,15 +9514,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:06 GMT
+      - Mon, 04 Mar 2019 20:06:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b183f538-4ac5-4658-ba52-c40f998d0ade
+      - req-ed486a95-6368-4f09-85df-28b793427d07
       Content-Length:
       - '7311'
       Connection:
@@ -9666,7 +9534,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:06.610532Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:43.264705Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -9745,10 +9613,46 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-syF_XPKQ7-qxU9_tu0tmQ"],
-        "issued_at": "2019-01-08T19:21:06.610550Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["j90KG4HrTOCvF1cG_lRCcg"],
+        "issued_at": "2019-03-04T20:06:43.264723Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
+- request:
+    method: get
+    uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 8ea4a32b1a344881b1fe181e70bb158a
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-0ef2f24f-9d03-4995-9730-b3b1124e1ee5
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-0ef2f24f-9d03-4995-9730-b3b1124e1ee5
+      Date:
+      - Mon, 04 Mar 2019 20:06:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9766,15 +9670,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:06 GMT
+      - Mon, 04 Mar 2019 20:06:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 4efaae13f8394c29877d25c0145b7298
+      - 8a4d300fcb8c4e00823a36da644e7c51
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-50d90a82-9d83-4068-b7c7-e2ee81961ecc
+      - req-8925e4b1-37ee-42d6-8be5-39330f97b9be
       Content-Length:
       - '297'
       Connection:
@@ -9783,12 +9687,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:21:06.785606Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:06:43.565997Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rtSi7FaXTKa-urxOe_lVfw"],
-        "issued_at": "2019-01-08T19:21:06.785623Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["CJg_EK0LRymNaS6bIyo9oA"],
+        "issued_at": "2019-03-04T20:06:43.566019Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -9803,20 +9707,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4efaae13f8394c29877d25c0145b7298
+      - 8a4d300fcb8c4e00823a36da644e7c51
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:06 GMT
+      - Mon, 04 Mar 2019 20:06:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f076dcdf-386a-4897-8c84-5ec03e927999
+      - req-c2df5030-80a0-457f-b370-5926d1c1c644
       Content-Length:
       - '2475'
       Connection:
@@ -9849,7 +9753,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9867,15 +9771,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:07 GMT
+      - Mon, 04 Mar 2019 20:06:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4e192846-5eae-47ef-8fc1-dbc97303c97d
+      - req-19d71ec2-8331-4f0d-99d3-0762630839fa
       Content-Length:
       - '7278'
       Connection:
@@ -9887,7 +9791,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:07.130594Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:43.925131Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -9966,10 +9870,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Qk-PgbgASnqvGOMC0KubsA"],
-        "issued_at": "2019-01-08T19:21:07.130612Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["bQzsidjfRc-yRf8zX_swOw"],
+        "issued_at": "2019-03-04T20:06:43.925158Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -9987,15 +9891,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:07 GMT
+      - Mon, 04 Mar 2019 20:06:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8e800e25-562e-4e1c-8aa5-b720b724b017
+      - req-adbdbd7c-4e7a-49fc-bc7b-ab6445e835f7
       Content-Length:
       - '7278'
       Connection:
@@ -10007,7 +9911,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:07.332615Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:44.143778Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10086,10 +9990,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PorL_VvdS9SnvF8L7Q5mCg"],
-        "issued_at": "2019-01-08T19:21:07.332633Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Vcc4tL7yScqT0Ly1f9O3vg"],
+        "issued_at": "2019-03-04T20:06:44.143813Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10107,15 +10011,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:07 GMT
+      - Mon, 04 Mar 2019 20:06:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0bfc4c06-89fa-49f9-9832-b86b9817543a
+      - req-14bc124d-df68-4329-a819-d12b5010cb3c
       Content-Length:
       - '7264'
       Connection:
@@ -10127,7 +10031,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:07.540991Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:44.355444Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10206,10 +10110,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QKVQDzOkSfqr8h8-Yey3tg"],
-        "issued_at": "2019-01-08T19:21:07.541010Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QFozCzYAQCeXLQ2xj749pw"],
+        "issued_at": "2019-03-04T20:06:44.355467Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10227,15 +10131,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:07 GMT
+      - Mon, 04 Mar 2019 20:06:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-325f0350-25e2-40d4-abab-6a37235c6e14
+      - req-fca944fc-87de-412d-8c4a-e00ee594582c
       Content-Length:
       - '7278'
       Connection:
@@ -10247,7 +10151,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:07.743528Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:44.568656Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10326,10 +10230,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["v6a07NzCQPi_nZAW-6i7tw"],
-        "issued_at": "2019-01-08T19:21:07.743547Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["rCPkAYJ_RGqJ8dcPUmhoUg"],
+        "issued_at": "2019-03-04T20:06:44.568682Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10347,15 +10251,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:13 GMT
+      - Mon, 04 Mar 2019 20:06:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-94c434ac-95bf-4083-aee3-54de37c5573a
+      - req-84f7ea75-197b-4eab-8170-8c2cccfe6ff2
       Content-Length:
       - '7265'
       Connection:
@@ -10367,7 +10271,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:13.140523Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:44.782042Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -10446,10 +10350,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["QmQTSL9aTCul5P7GK2Wqkg"],
-        "issued_at": "2019-01-08T19:21:13.140543Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ql7WPGoWTWmdy1fZnIDq3A"],
+        "issued_at": "2019-03-04T20:06:44.782065Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -10467,15 +10371,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:13 GMT
+      - Mon, 04 Mar 2019 20:06:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ef964645-5cbd-45e6-9a09-e62a758814f1
+      - req-11ae41b1-3f54-43e3-8ff3-3a0fecad4e90
       Content-Length:
       - '7278'
       Connection:
@@ -10487,7 +10391,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:13.407959Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:45.007195Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -10566,10 +10470,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["MTC-RXXpTeypf9c5zq8Mpg"],
-        "issued_at": "2019-01-08T19:21:13.407979Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["O5pFviSmQoe_frrm8gYhxQ"],
+        "issued_at": "2019-03-04T20:06:45.007227Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/volumes/detail?limit=1000
@@ -10584,27 +10488,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8306f1ea-e827-4394-b384-506b924b344f
+      - req-6f572a3a-6da4-411e-9fa9-36832a42be58
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8306f1ea-e827-4394-b384-506b924b344f
+      - req-6f572a3a-6da4-411e-9fa9-36832a42be58
       Date:
-      - Tue, 08 Jan 2019 19:21:13 GMT
+      - Mon, 04 Mar 2019 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/volumes/detail?limit=1000
@@ -10619,27 +10523,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5a32c84-baa3-4bf7-88fc-1b6afe9bb11a
+      - req-edf13f1f-a964-46f5-ae59-88bce255f61b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-e5a32c84-baa3-4bf7-88fc-1b6afe9bb11a
+      - req-edf13f1f-a964-46f5-ae59-88bce255f61b
       Date:
-      - Tue, 08 Jan 2019 19:21:13 GMT
+      - Mon, 04 Mar 2019 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000
@@ -10654,22 +10558,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bed17c25-550c-435e-b06a-43bf4140d52a
+      - req-373452f4-31ce-4d5f-938c-34b84109987b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-bed17c25-550c-435e-b06a-43bf4140d52a
+      - req-373452f4-31ce-4d5f-938c-34b84109987b
       Date:
-      - Tue, 08 Jan 2019 19:21:13 GMT
+      - Mon, 04 Mar 2019 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a",
@@ -10702,7 +10606,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-08-19T08:37:45.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=f46458aa-309d-4f47-b996-a39db065030a
@@ -10717,22 +10621,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f8c60908-c379-4f1c-bfea-8558e17446be
+      - req-66e62218-2cd4-4fcd-80e1-52fa49b5d318
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-f8c60908-c379-4f1c-bfea-8558e17446be
+      - req-66e62218-2cd4-4fcd-80e1-52fa49b5d318
       Date:
-      - Tue, 08 Jan 2019 19:21:14 GMT
+      - Mon, 04 Mar 2019 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7",
@@ -10773,7 +10677,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-08-19T08:37:33.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=476a0c89-4322-42aa-b7ce-3ac21be55af7
@@ -10788,22 +10692,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d54f1759-bdcb-4afb-90c9-c1f910a34e47
+      - req-7b10a1c9-32ad-4d8e-8ee1-c76c104c610f
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-d54f1759-bdcb-4afb-90c9-c1f910a34e47
+      - req-7b10a1c9-32ad-4d8e-8ee1-c76c104c610f
       Date:
-      - Tue, 08 Jan 2019 19:21:14 GMT
+      - Mon, 04 Mar 2019 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5",
@@ -10837,7 +10741,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-08-19T08:37:05.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:45 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/volumes/detail?limit=1000&marker=8791e24f-874d-4f1e-99ec-75fdb9d48ca5
@@ -10852,27 +10756,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-de020e24-d3a3-4d1f-a496-7c30cff641db
+      - req-59379806-3eb2-4998-94fc-c23a705fba55
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-de020e24-d3a3-4d1f-a496-7c30cff641db
+      - req-59379806-3eb2-4998-94fc-c23a705fba55
       Date:
-      - Tue, 08 Jan 2019 19:21:15 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/volumes/detail?limit=1000
@@ -10887,27 +10791,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7b0dd094-514c-45fb-bcbf-6bafcec398e4
+      - req-e94bcbe6-fefb-414b-ba4c-327322eab760
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7b0dd094-514c-45fb-bcbf-6bafcec398e4
+      - req-e94bcbe6-fefb-414b-ba4c-327322eab760
       Date:
-      - Tue, 08 Jan 2019 19:21:15 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/volumes/detail?limit=1000
@@ -10922,27 +10826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-51f1adb4-2c2e-4a40-9d7f-f0d8109ea45a
+      - req-62a1de53-d89b-4e89-9ca4-92bfa4010011
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-51f1adb4-2c2e-4a40-9d7f-f0d8109ea45a
+      - req-62a1de53-d89b-4e89-9ca4-92bfa4010011
       Date:
-      - Tue, 08 Jan 2019 19:21:15 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/volumes/detail?limit=1000
@@ -10957,27 +10861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91e909c4-9daa-4f10-aa6e-95e19f37953d
+      - req-b30ddc6a-9828-471f-971b-bd617006811d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91e909c4-9daa-4f10-aa6e-95e19f37953d
+      - req-b30ddc6a-9828-471f-971b-bd617006811d
       Date:
-      - Tue, 08 Jan 2019 19:21:15 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/volumes/detail?limit=1000
@@ -10992,27 +10896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8a9fb767-9508-4c63-b8b9-866e269d67aa
+      - req-ae26ba4e-7993-4f03-9bb1-cc9f34502bc2
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8a9fb767-9508-4c63-b8b9-866e269d67aa
+      - req-ae26ba4e-7993-4f03-9bb1-cc9f34502bc2
       Date:
-      - Tue, 08 Jan 2019 19:21:15 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail
@@ -11027,27 +10931,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a442041c-81d0-4382-b23d-79005c5863e5
+      - req-09068d27-add7-4245-b4ab-d143e5c47c31
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-a442041c-81d0-4382-b23d-79005c5863e5
+      - req-09068d27-add7-4245-b4ab-d143e5c47c31
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/snapshots/detail?limit=1000
@@ -11062,27 +10966,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5b055136-ba61-4c81-aadc-309a62173eb0
+      - req-a9992378-b908-48f0-a700-e0948a411020
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-5b055136-ba61-4c81-aadc-309a62173eb0
+      - req-a9992378-b908-48f0-a700-e0948a411020
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:46 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail
@@ -11097,27 +11001,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2313344e-5b03-486c-b02e-0bdaecc13823
+      - req-ddce2888-1da3-437b-b334-48ed59556dec
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-2313344e-5b03-486c-b02e-0bdaecc13823
+      - req-ddce2888-1da3-437b-b334-48ed59556dec
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/snapshots/detail?limit=1000
@@ -11132,27 +11036,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-956a02f4-ca01-4ea1-86cd-d794fd7a692c
+      - req-1c0b11f0-c889-4ea6-bcf4-93e3310152b2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-956a02f4-ca01-4ea1-86cd-d794fd7a692c
+      - req-1c0b11f0-c889-4ea6-bcf4-93e3310152b2
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail
@@ -11167,22 +11071,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e7fc817c-21bb-4fb1-914d-0b687174fa0d
+      - req-b92f569c-c0cc-4008-927e-4b9c953f62b6
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-e7fc817c-21bb-4fb1-914d-0b687174fa0d
+      - req-b92f569c-c0cc-4008-927e-4b9c953f62b6
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11197,7 +11101,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000
@@ -11212,22 +11116,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4006c529-eac0-4762-ad47-aabcb450ffd5
+      - req-52bd7737-90e5-46a2-87d1-baa6665e56c5
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-4006c529-eac0-4762-ad47-aabcb450ffd5
+      - req-52bd7737-90e5-46a2-87d1-baa6665e56c5
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/snapshots/detail?limit=1000&marker=c44d3eb3-31fe-46ed-bfae-707920be171d",
@@ -11242,7 +11146,7 @@ http_interactions:
         "created_at": "2016-08-19T08:37:24.000000", "size": 1, "id": "c44d3eb3-31fe-46ed-bfae-707920be171d",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail
@@ -11257,27 +11161,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-85983851-1d0d-40fc-8587-a9b953c0455c
+      - req-856ec097-b046-45c9-913d-30007a8967b8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-85983851-1d0d-40fc-8587-a9b953c0455c
+      - req-856ec097-b046-45c9-913d-30007a8967b8
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/snapshots/detail?limit=1000
@@ -11292,27 +11196,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-30cd0474-5b99-4b24-aab3-ed8bd7d0a306
+      - req-5f41d3e4-9913-4abf-b46a-0da84fdb9e27
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-30cd0474-5b99-4b24-aab3-ed8bd7d0a306
+      - req-5f41d3e4-9913-4abf-b46a-0da84fdb9e27
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail
@@ -11327,27 +11231,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-81cd732d-f378-475e-8cd5-003e33d994c7
+      - req-5fc720c0-12d9-465d-bfb7-3e646a9b7dea
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-81cd732d-f378-475e-8cd5-003e33d994c7
+      - req-5fc720c0-12d9-465d-bfb7-3e646a9b7dea
       Date:
-      - Tue, 08 Jan 2019 19:21:16 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/snapshots/detail?limit=1000
@@ -11362,27 +11266,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1e907bae-0d8d-4dea-9072-7471db6bff05
+      - req-2eec0eaa-363f-47dc-9c6e-5771a339a837
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-1e907bae-0d8d-4dea-9072-7471db6bff05
+      - req-2eec0eaa-363f-47dc-9c6e-5771a339a837
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:47 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail
@@ -11397,27 +11301,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3fb44729-57cf-4c68-bfd5-fff5e7ada6a7
+      - req-f7699f59-c178-4196-b795-06becc320c1a
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-3fb44729-57cf-4c68-bfd5-fff5e7ada6a7
+      - req-f7699f59-c178-4196-b795-06becc320c1a
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/snapshots/detail?limit=1000
@@ -11432,27 +11336,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-781df2ae-eacb-44d8-9789-42d048f2c5a2
+      - req-291bba2d-039e-41e9-abb0-c8d88e2424e8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-781df2ae-eacb-44d8-9789-42d048f2c5a2
+      - req-291bba2d-039e-41e9-abb0-c8d88e2424e8
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail
@@ -11467,27 +11371,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e99d248e-3897-43a3-9588-c4a0ffea6624
+      - req-e9488ad0-a946-4b01-ad1f-4945759914b6
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e99d248e-3897-43a3-9588-c4a0ffea6624
+      - req-e9488ad0-a946-4b01-ad1f-4945759914b6
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/snapshots/detail?limit=1000
@@ -11502,27 +11406,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-579da899-7b17-49d6-b114-61c6ce9d3c55
+      - req-724bfaf2-d593-4e1e-89e8-c91e2f68e00c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-579da899-7b17-49d6-b114-61c6ce9d3c55
+      - req-724bfaf2-d593-4e1e-89e8-c91e2f68e00c
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail
@@ -11537,27 +11441,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3bbfd9b2-d72f-48d1-9749-67259a813b45
+      - req-dde43119-4bd4-47f6-b652-02758c2fec54
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3bbfd9b2-d72f-48d1-9749-67259a813b45
+      - req-dde43119-4bd4-47f6-b652-02758c2fec54
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/backups/detail?limit=1000
@@ -11572,27 +11476,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c7a633fc-a73f-4289-8505-5af77387e76f
+      - req-4d4fe2df-3ee7-449e-aa96-d069c1deab04
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c7a633fc-a73f-4289-8505-5af77387e76f
+      - req-4d4fe2df-3ee7-449e-aa96-d069c1deab04
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail
@@ -11607,27 +11511,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5f7c4ce4-b48b-4abd-ab8c-e77752e38938
+      - req-db6816be-a895-4c6d-a006-b38dbeceee55
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5f7c4ce4-b48b-4abd-ab8c-e77752e38938
+      - req-db6816be-a895-4c6d-a006-b38dbeceee55
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/backups/detail?limit=1000
@@ -11642,27 +11546,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2725c258-43cb-491a-a694-ad6f768144d8
+      - req-fd19d733-4bf7-4229-834a-7a59eeca5882
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2725c258-43cb-491a-a694-ad6f768144d8
+      - req-fd19d733-4bf7-4229-834a-7a59eeca5882
       Date:
-      - Tue, 08 Jan 2019 19:21:18 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail
@@ -11677,27 +11581,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6fb1433b-0abd-478d-94bf-0c8e208e0115
+      - req-2caa9f9d-1c4f-445f-be15-7c696170cde4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6fb1433b-0abd-478d-94bf-0c8e208e0115
+      - req-2caa9f9d-1c4f-445f-be15-7c696170cde4
       Date:
-      - Tue, 08 Jan 2019 19:21:19 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/backups/detail?limit=1000
@@ -11712,27 +11616,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3655a514-156d-4df6-9a90-129a46b3be2d
+      - req-7a225156-0b46-4e49-b5ab-c8044b773011
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3655a514-156d-4df6-9a90-129a46b3be2d
+      - req-7a225156-0b46-4e49-b5ab-c8044b773011
       Date:
-      - Tue, 08 Jan 2019 19:21:21 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:48 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail
@@ -11747,27 +11651,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91a02e30-1b8c-4fec-ab7c-bfec10a7045d
+      - req-3d3dad1b-b3a6-49a0-9de4-e59e2ef5797e
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91a02e30-1b8c-4fec-ab7c-bfec10a7045d
+      - req-3d3dad1b-b3a6-49a0-9de4-e59e2ef5797e
       Date:
-      - Tue, 08 Jan 2019 19:21:21 GMT
+      - Mon, 04 Mar 2019 20:06:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/backups/detail?limit=1000
@@ -11782,27 +11686,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6d4fc5a6-a793-4125-bc28-8bdaacf57461
+      - req-c102f70c-0e69-4a3c-a71d-72c9eb70c0b0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6d4fc5a6-a793-4125-bc28-8bdaacf57461
+      - req-c102f70c-0e69-4a3c-a71d-72c9eb70c0b0
       Date:
-      - Tue, 08 Jan 2019 19:21:21 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail
@@ -11817,27 +11721,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91351975-d08b-4f67-b364-3911195241cb
+      - req-5bef2350-64ee-4a30-abca-0a4706eb7a23
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-91351975-d08b-4f67-b364-3911195241cb
+      - req-5bef2350-64ee-4a30-abca-0a4706eb7a23
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/backups/detail?limit=1000
@@ -11852,27 +11756,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5a83ee8c-3a2e-4fbb-a55f-3b3f195a4df6
+      - req-fe92d41f-b4e9-4e75-9498-ac449666412d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5a83ee8c-3a2e-4fbb-a55f-3b3f195a4df6
+      - req-fe92d41f-b4e9-4e75-9498-ac449666412d
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail
@@ -11887,27 +11791,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9438e528-753c-4153-890e-0e0404ce5a93
+      - req-d3484c64-0b27-47a1-9361-d1f2611ee5f8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9438e528-753c-4153-890e-0e0404ce5a93
+      - req-d3484c64-0b27-47a1-9361-d1f2611ee5f8
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/backups/detail?limit=1000
@@ -11922,27 +11826,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1280cf6e-3f87-49df-b055-b3b5f3f42380
+      - req-7c286950-1dd5-42c7-a2ea-ce24194b84f1
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-1280cf6e-3f87-49df-b055-b3b5f3f42380
+      - req-7c286950-1dd5-42c7-a2ea-ce24194b84f1
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail
@@ -11957,27 +11861,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-cad96b08-3ce2-40ec-95b1-c1e80e00735e
+      - req-4f4b53d4-3a22-4944-a5c1-db38572da0ea
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-cad96b08-3ce2-40ec-95b1-c1e80e00735e
+      - req-4f4b53d4-3a22-4944-a5c1-db38572da0ea
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/backups/detail?limit=1000
@@ -11992,27 +11896,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fd8d19b7-9fa8-4b5d-afc9-5d2c94885852
+      - req-29e33b5d-7ea7-422b-826c-5dd04fc5d4aa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-fd8d19b7-9fa8-4b5d-afc9-5d2c94885852
+      - req-29e33b5d-7ea7-422b-826c-5dd04fc5d4aa
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000
@@ -12027,22 +11931,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8f13c594-180b-4886-a2a7-5415a939ae95
+      - req-57fac137-4994-41e3-8d07-3b659022ac97
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-8f13c594-180b-4886-a2a7-5415a939ae95
+      - req-57fac137-4994-41e3-8d07-3b659022ac97
       Date:
-      - Tue, 08 Jan 2019 19:21:22 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12054,7 +11958,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/0098405163cd4c9dbb42c2cb43eb6fd3/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12069,22 +11973,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5734ba4824eb4169bef611185da9eaac
+      - 93ae16d6c8fa473a8b0a9c2ac36fc861
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f9eb2181-4986-4dcd-b270-71a62f218032
+      - req-19639188-9154-417e-a1c8-5d169530b3aa
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f9eb2181-4986-4dcd-b270-71a62f218032
+      - req-19639188-9154-417e-a1c8-5d169530b3aa
       Date:
-      - Tue, 08 Jan 2019 19:21:23 GMT
+      - Mon, 04 Mar 2019 20:06:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12096,7 +12000,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:49 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000
@@ -12111,22 +12015,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1dfa1b32-af4f-4306-b5ef-9bd5823c6d7b
+      - req-0c0961f1-8382-4a27-b410-57e73d7b3184
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-1dfa1b32-af4f-4306-b5ef-9bd5823c6d7b
+      - req-0c0961f1-8382-4a27-b410-57e73d7b3184
       Date:
-      - Tue, 08 Jan 2019 19:21:23 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12138,7 +12042,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/28db8f69ba9e4305b7fad82da4c86e74/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12153,22 +12057,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 07a4890a61c34d6f9f99c88a35eda393
+      - 82468f17bb3748dd897c4f31479e3ee0
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c73e2fbd-0c74-4bd1-8a15-32d2f42bad80
+      - req-316aecca-8d7b-4a86-9e46-3769798093a6
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c73e2fbd-0c74-4bd1-8a15-32d2f42bad80
+      - req-316aecca-8d7b-4a86-9e46-3769798093a6
       Date:
-      - Tue, 08 Jan 2019 19:21:28 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12180,7 +12084,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000
@@ -12195,22 +12099,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f42feb60-17a1-4a37-8532-de342b8d8004
+      - req-19c82d44-716a-4a10-a3dd-4bd78152d4d1
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f42feb60-17a1-4a37-8532-de342b8d8004
+      - req-19c82d44-716a-4a10-a3dd-4bd78152d4d1
       Date:
-      - Tue, 08 Jan 2019 19:21:28 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12222,7 +12126,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/4637c33fee924ebea81f8d209e452c91/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12237,22 +12141,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f68e9cd204334831a40303c13b8b2188
+      - da010094a82d49f8be5c2dfe831e51e2
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-214acb97-73e9-4621-9a50-3092e6047618
+      - req-b91a98b0-d969-4fb7-bc49-21327e7db735
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-214acb97-73e9-4621-9a50-3092e6047618
+      - req-b91a98b0-d969-4fb7-bc49-21327e7db735
       Date:
-      - Tue, 08 Jan 2019 19:21:28 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12264,7 +12168,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000
@@ -12279,22 +12183,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-705bb6e2-042b-4a6a-935d-af2422f282d0
+      - req-97c53e14-a6d3-4eb9-8ae6-fe22e94e832f
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-705bb6e2-042b-4a6a-935d-af2422f282d0
+      - req-97c53e14-a6d3-4eb9-8ae6-fe22e94e832f
       Date:
-      - Tue, 08 Jan 2019 19:21:28 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12306,7 +12210,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/52c452d7763a4295950527948232a3e5/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12321,22 +12225,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bda153bb563c444081c4a1f7a90e0cbe
+      - c6b99cae42f745bfb75e876391c499ef
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b88b9850-e36b-482d-8c8d-c7cfe6be042f
+      - req-b8e3f618-2ad0-4f61-83f5-a891492f4890
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b88b9850-e36b-482d-8c8d-c7cfe6be042f
+      - req-b8e3f618-2ad0-4f61-83f5-a891492f4890
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12348,7 +12252,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000
@@ -12363,22 +12267,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-72e1da53-a962-426d-b240-1a97e689cbc6
+      - req-a8cdefdd-20b9-464b-a6a7-eb770efd7871
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-72e1da53-a962-426d-b240-1a97e689cbc6
+      - req-a8cdefdd-20b9-464b-a6a7-eb770efd7871
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12390,7 +12294,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/88ae57d444fd485ab2dfddd5a2615d52/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12405,22 +12309,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f2d8fbcad0514521bc47fbdca80fa86c
+      - 8ea4a32b1a344881b1fe181e70bb158a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0fc02e25-f13e-4693-9f2e-1c7c9914c9e1
+      - req-fc360ebf-a2b3-4b15-a74a-d106174b9030
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0fc02e25-f13e-4693-9f2e-1c7c9914c9e1
+      - req-fc360ebf-a2b3-4b15-a74a-d106174b9030
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12432,7 +12336,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000
@@ -12447,22 +12351,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b49a5607-c73f-44de-a85d-9260c8101972
+      - req-23dcc480-b363-4f6f-9818-86aa2be9e9b2
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-b49a5607-c73f-44de-a85d-9260c8101972
+      - req-23dcc480-b363-4f6f-9818-86aa2be9e9b2
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12474,7 +12378,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/d09cbe26295d47ff848ea73c74264e23/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12489,22 +12393,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c89b8baa41442f982413f878cceed5c
+      - fdfc20a25cb64d688ed14dcb3d21f5a8
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-59a517fa-d0c3-4ee9-a143-26b4da6e1cd8
+      - req-137b6ebb-a105-4b8f-aae1-60164d600149
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-59a517fa-d0c3-4ee9-a143-26b4da6e1cd8
+      - req-137b6ebb-a105-4b8f-aae1-60164d600149
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12516,7 +12420,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:50 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000
@@ -12531,22 +12435,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c8a4cd46-3e23-44e7-9049-b25980516d8e
+      - req-bc428e7a-ba7e-436f-a46d-fcc9a6f78369
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-c8a4cd46-3e23-44e7-9049-b25980516d8e
+      - req-bc428e7a-ba7e-436f-a46d-fcc9a6f78369
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12558,7 +12462,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:51 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8776/v2/ef2a3405d1ef4dfd9a3616993ef46a4d/types?limit=1000&marker=b953db40-aeea-4a55-9bd9-c08dcafd6f7e
@@ -12573,22 +12477,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 920c11c7ec4a4fd9b36ac829f879c0e3
+      - 810a451f44a243ad90628b0900330495
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a5b1cf47-5190-455e-a794-016329de7461
+      - req-e55e8300-a8c5-430e-b7e8-b12b84344ff0
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-a5b1cf47-5190-455e-a794-016329de7461
+      - req-e55e8300-a8c5-430e-b7e8-b12b84344ff0
       Date:
-      - Tue, 08 Jan 2019 19:21:33 GMT
+      - Mon, 04 Mar 2019 20:06:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -12600,7 +12504,7 @@ http_interactions:
         true, "is_public": true, "id": "b953db40-aeea-4a55-9bd9-c08dcafd6f7e", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12618,15 +12522,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:35 GMT
+      - Mon, 04 Mar 2019 20:06:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 0ae7df7f51fc45ef81fac1e4f7b680a6
+      - 5e11607947c04e709046daf9cb6d4b0c
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-43b78883-1110-43e8-8ef7-b550dcbf1e5f
+      - req-5f3ef063-490d-440f-be96-c0561baa946a
       Content-Length:
       - '7311'
       Connection:
@@ -12638,7 +12542,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:35.691493Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:51.497582Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12717,10 +12621,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["lrl4PlBTSWSyJ5bRSmyp3g"],
-        "issued_at": "2019-01-08T19:21:35.691517Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["WdfcgDJlRXmmb8ke6T_0Ag"],
+        "issued_at": "2019-03-04T20:06:51.497605Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12738,15 +12642,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:35 GMT
+      - Mon, 04 Mar 2019 20:06:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - c546095dd01f4ef7b2e57e0e8569fc80
+      - ea83d34b11b842af95a90d97519d3401
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f851f05e-6ac5-47eb-be58-9185ff5ede84
+      - req-477cebda-3b94-459a-92fa-49a64d8ad625
       Content-Length:
       - '7311'
       Connection:
@@ -12758,7 +12662,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "9fe2ff9ee4384b1894a90878d3e92bab",
         "name": "_member_"}, {"id": "e6ea2d27f090432bb811e47290dce55b", "name": "heat_stack_owner"},
         {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name": "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81",
-        "name": "SwiftOperator"}], "expires_at": "2019-01-08T20:21:35.919143Z", "project":
+        "name": "SwiftOperator"}], "expires_at": "2019-03-04T21:06:51.727358Z", "project":
         {"domain": {"id": "default", "name": "Default"}, "id": "88ae57d444fd485ab2dfddd5a2615d52",
         "name": "admin"}, "catalog": [{"endpoints": [{"region_id": "RegionOne", "url":
         "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -12837,10 +12741,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ctBn1e0zS4q2lF26yd6_QA"],
-        "issued_at": "2019-01-08T19:21:35.919161Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Yd29THB6RyabStAmIR9aQg"],
+        "issued_at": "2019-03-04T20:06:51.727381Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12858,15 +12762,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:36 GMT
+      - Mon, 04 Mar 2019 20:06:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 96b6ea846cd54d60a9b44d180bde51b2
+      - 32fdf17d168848ea9f7c415efa9e6096
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b976ccee-17e4-46ee-a6de-584ba1266a89
+      - req-f2a62509-f7cc-43d5-ba89-c0829f2f2680
       Content-Length:
       - '297'
       Connection:
@@ -12875,12 +12779,12 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"token": {"methods": ["password"], "expires_at": "2019-01-08T20:21:36.471351Z",
+      string: '{"token": {"methods": ["password"], "expires_at": "2019-03-04T21:06:51.906865Z",
         "extras": {}, "user": {"domain": {"id": "default", "name": "Default"}, "id":
-        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["1GmkP-Z1TUmsb1eZhYw3XA"],
-        "issued_at": "2019-01-08T19:21:36.471371Z"}}'
+        "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Ge260vGzS72SpLuiL-CI1g"],
+        "issued_at": "2019-03-04T20:06:51.906891Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:51 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v3/users/0e379b058aea4a7ba72d13cddf21c240/projects?domain_id=default
@@ -12895,20 +12799,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96b6ea846cd54d60a9b44d180bde51b2
+      - 32fdf17d168848ea9f7c415efa9e6096
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:36 GMT
+      - Mon, 04 Mar 2019 20:06:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cec1877a-7387-40b8-83c8-eb9a4c6a9f2b
+      - req-081de99c-d943-487c-a889-edf85f10fdf7
       Content-Length:
       - '2475'
       Connection:
@@ -12941,7 +12845,7 @@ http_interactions:
         "enabled": true, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "parent_id": "52c452d7763a4295950527948232a3e5",
         "domain_id": "default", "name": "EmsRefreshSpec-Project-parent-test-2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -12959,15 +12863,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:36 GMT
+      - Mon, 04 Mar 2019 20:06:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - a9440491b0df4484bbd527fa5e238940
+      - 8d934ab81d1f48a3902e4dc7d4ac0bf5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1dd50025-3e59-4248-ba28-89fbd6e67e0b
+      - req-4153e540-efe5-45b2-83e2-8a99ba0789ee
       Content-Length:
       - '7278'
       Connection:
@@ -12979,7 +12883,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:36.830365Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:52.259000Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "0098405163cd4c9dbb42c2cb43eb6fd3", "name":
         "EmsRefreshSpec-Project-parent-test-3"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13058,10 +12962,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["tApwtZwxQqmY_grDJ5Bpxg"],
-        "issued_at": "2019-01-08T19:21:36.830383Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["XTSMQzjASXeAGWU3spFROg"],
+        "issued_at": "2019-03-04T20:06:52.259020Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13079,15 +12983,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:36 GMT
+      - Mon, 04 Mar 2019 20:06:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - d7fd4779df4749a587d6caeea2ca9058
+      - 4f348c46d7744631b771cb393c659bb9
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-2dc47aa0-fda1-4733-8b18-64db4e5f5dd2
+      - req-7e631988-a17b-47fc-af5d-f87d5c85622c
       Content-Length:
       - '7278'
       Connection:
@@ -13099,7 +13003,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:37.037719Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:52.478569Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "28db8f69ba9e4305b7fad82da4c86e74", "name":
         "EmsRefreshSpec-Project-No-Admin-Role"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13178,10 +13082,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["gzQRPQAVS922SeFNg86DXw"],
-        "issued_at": "2019-01-08T19:21:37.037737Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-9TnKTllRDmyPoktE7mQtA"],
+        "issued_at": "2019-03-04T20:06:52.478597Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13199,15 +13103,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:37 GMT
+      - Mon, 04 Mar 2019 20:06:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-33bfb36f-1bff-4a58-abe8-7c4b93bf31b8
+      - req-a211dd34-36f2-40c5-983c-d941ee19923a
       Content-Length:
       - '7264'
       Connection:
@@ -13219,7 +13123,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:37.248647Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:52.742149Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "4637c33fee924ebea81f8d209e452c91", "name":
         "EmsRefreshSpec-Project"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13298,10 +13202,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["Y55Huz8GTRqHLN72EZXyCw"],
-        "issued_at": "2019-01-08T19:21:37.248666Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["PV8sCex0TGGPz-BZgI4rIw"],
+        "issued_at": "2019-03-04T20:06:52.742176Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:52 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13319,15 +13223,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:37 GMT
+      - Mon, 04 Mar 2019 20:06:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 60e3d65548794a2287085a7c39b193d1
+      - 9b15528591ae4e9d9b8d5b163a1d73b5
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9af7069d-0aa7-464c-9a7b-485fddc2581d
+      - req-1b8e0fb2-a927-4a2e-a34d-c37e3f8109b6
       Content-Length:
       - '7278'
       Connection:
@@ -13339,7 +13243,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:37.512826Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:52.984066Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "52c452d7763a4295950527948232a3e5", "name":
         "EmsRefreshSpec-Project-parent-test-1"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13418,10 +13322,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["wxcT833_QgWwUY3Qo3O3TQ"],
-        "issued_at": "2019-01-08T19:21:37.512844Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-NCcor2qSBuqhdRkJYXUcA"],
+        "issued_at": "2019-03-04T20:06:52.984099Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13439,15 +13343,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:37 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - b9e9c771aa6c41c4aa63d3ff2e6d8574
+      - be360fba070b4b318384157046ca8ed7
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d2f16b2f-ebfe-4331-8c50-9a8854b78c76
+      - req-e7e921db-acc8-495c-af7b-3f28beb98243
       Content-Length:
       - '7265'
       Connection:
@@ -13459,7 +13363,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:37.720089Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:53.207690Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "d09cbe26295d47ff848ea73c74264e23", "name":
         "EmsRefreshSpec-Project2"}, "catalog": [{"endpoints": [{"region_id": "RegionOne",
         "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface": "public",
@@ -13538,10 +13442,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["ZG7fZ5RMSsuW2Z8iWQdPwg"],
-        "issued_at": "2019-01-08T19:21:37.720108Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["-df9N-TXQe68io9pyfx8Fw"],
+        "issued_at": "2019-03-04T20:06:53.207712Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v3/auth/tokens
@@ -13559,15 +13463,15 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:21:37 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       X-Subject-Token:
-      - 6c7f0bf804b2492cae72aca134a22bc1
+      - cea1c52b35d240afb087630c6fd11678
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-58fc2eb5-95d5-4ccc-9ea7-3bd419954d28
+      - req-f6fd9fbb-415d-44dd-a27f-ea4a5b979ecd
       Content-Length:
       - '7278'
       Connection:
@@ -13579,7 +13483,7 @@ http_interactions:
       string: '{"token": {"methods": ["password"], "roles": [{"id": "e6ea2d27f090432bb811e47290dce55b",
         "name": "heat_stack_owner"}, {"id": "e6055e3c27bb4e8ba987a6cd2da07872", "name":
         "admin"}, {"id": "79d1f8734bd847a1a6cda6e90acb9f81", "name": "SwiftOperator"}],
-        "expires_at": "2019-01-08T20:21:37.931840Z", "project": {"domain": {"id":
+        "expires_at": "2019-03-04T21:06:53.424150Z", "project": {"domain": {"id":
         "default", "name": "Default"}, "id": "ef2a3405d1ef4dfd9a3616993ef46a4d", "name":
         "EmsRefreshSpec-Project-parent-test-2"}, "catalog": [{"endpoints": [{"region_id":
         "RegionOne", "url": "http://10.8.99.206:5000/v3", "region": "RegionOne", "interface":
@@ -13658,10 +13562,10 @@ http_interactions:
         "region": "RegionOne", "interface": "public", "id": "d2d9ccf91f1a4f9cb206099a2e8cdee6"}],
         "type": "orchestration", "id": "dbbc6a6e97b74747a68cbfd88d06f797", "name":
         "heat"}], "extras": {}, "user": {"domain": {"id": "default", "name": "Default"},
-        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["sVnYSxROSxG_eP7BtNXurQ"],
-        "issued_at": "2019-01-08T19:21:37.931860Z"}}'
+        "id": "0e379b058aea4a7ba72d13cddf21c240", "name": "admin"}, "audit_ids": ["P7SAEedGQLqs_zg114gDLg"],
+        "issued_at": "2019-03-04T20:06:53.424172Z"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_0098405163cd4c9dbb42c2cb43eb6fd3/?format=json&limit=1000
@@ -13676,7 +13580,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9440491b0df4484bbd527fa5e238940
+      - 8d934ab81d1f48a3902e4dc7d4ac0bf5
   response:
     status:
       code: 200
@@ -13689,22 +13593,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.09389'
+      - '1551730013.55973'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.09389'
+      - '1551730013.55973'
       X-Trans-Id:
-      - txeaa7a81da9ec422c85857-005c34f842
+      - tx9482c2483bf943d99400b-005c7d855d
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_28db8f69ba9e4305b7fad82da4c86e74/?format=json&limit=1000
@@ -13719,7 +13623,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d7fd4779df4749a587d6caeea2ca9058
+      - 4f348c46d7744631b771cb393c659bb9
   response:
     status:
       code: 200
@@ -13732,22 +13636,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.23578'
+      - '1551730013.67695'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.23578'
+      - '1551730013.67695'
       X-Trans-Id:
-      - tx5b08d9cb272b424697a02-005c34f842
+      - tx9796a5f65d36405f8dd91-005c7d855d
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000
@@ -13762,7 +13666,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
   response:
     status:
       code: 200
@@ -13791,15 +13695,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txf1cee97be3bf4100b121e-005c34f842
+      - txf0544547308d45bab70bb-005c7d855d
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/?format=json&limit=1000&marker=dir_3
@@ -13814,7 +13718,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
   response:
     status:
       code: 200
@@ -13843,14 +13747,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx4818356324c64438ae545-005c34f842
+      - txe74db35f4bff4fca978e9-005c7d855d
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:53 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_52c452d7763a4295950527948232a3e5/?format=json&limit=1000
@@ -13865,7 +13769,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 60e3d65548794a2287085a7c39b193d1
+      - 9b15528591ae4e9d9b8d5b163a1d73b5
   response:
     status:
       code: 200
@@ -13878,22 +13782,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.57219'
+      - '1551730014.01684'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.57219'
+      - '1551730014.01684'
       X-Trans-Id:
-      - tx5d125887359f4f978eb75-005c34f842
+      - txaf4a9ade4329460086c9f-005c7d855d
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_88ae57d444fd485ab2dfddd5a2615d52/?format=json&limit=1000
@@ -13908,7 +13812,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c546095dd01f4ef7b2e57e0e8569fc80
+      - ea83d34b11b842af95a90d97519d3401
   response:
     status:
       code: 200
@@ -13921,22 +13825,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.69448'
+      - '1551730014.13758'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.69448'
+      - '1551730014.13758'
       X-Trans-Id:
-      - txc9b834a9ce8446ca9c049-005c34f842
+      - txa0917e6635d44d58aa152-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_d09cbe26295d47ff848ea73c74264e23/?format=json&limit=1000
@@ -13951,7 +13855,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b9e9c771aa6c41c4aa63d3ff2e6d8574
+      - be360fba070b4b318384157046ca8ed7
   response:
     status:
       code: 200
@@ -13964,22 +13868,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.81466'
+      - '1551730014.25833'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.81466'
+      - '1551730014.25833'
       X-Trans-Id:
-      - txa23407e3cc794efabc70e-005c34f842
+      - txb0300974060949208157e-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_ef2a3405d1ef4dfd9a3616993ef46a4d/?format=json&limit=1000
@@ -13994,7 +13898,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c7f0bf804b2492cae72aca134a22bc1
+      - cea1c52b35d240afb087630c6fd11678
   response:
     status:
       code: 200
@@ -14007,22 +13911,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975298.94101'
+      - '1551730014.37656'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975298.94101'
+      - '1551730014.37656'
       X-Trans-Id:
-      - tx8dc756f47483408bb25f9-005c34f842
+      - tx63c6ca13442245369e6a7-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:38 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_1?format=json
@@ -14037,7 +13941,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
   response:
     status:
       code: 200
@@ -14058,9 +13962,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txb79d4a3462784c44a1f07-005c34f843
+      - tx6bc0066ac7304086bd66e-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:39 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-08-19T08:37:59.564460",
@@ -14070,7 +13974,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-08-19T08:38:00.995870",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_2?format=json
@@ -14085,7 +13989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
   response:
     status:
       code: 200
@@ -14106,14 +14010,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txc66017acb3e44f9394404-005c34f843
+      - tx0a2b3ea2084e42a694713-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:39 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 - request:
     method: get
     uri: http://10.8.99.206:8080/v1/AUTH_4637c33fee924ebea81f8d209e452c91/dir_3?format=json
@@ -14128,7 +14032,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e7efc4e0482140beb10dc2a88c9edd01
+      - c1b1bfddc0ee4700bcf0fe772bc616f6
   response:
     status:
       code: 200
@@ -14149,12 +14053,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx33b7dd1294c44975b13d6-005c34f844
+      - tx1d42e8730870451891ba7-005c7d855e
       Date:
-      - Tue, 08 Jan 2019 19:21:40 GMT
+      - Mon, 04 Mar 2019 20:06:54 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:21:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_legacy_fast_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:08 GMT
+      - Mon, 04 Mar 2019 20:01:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2aa036db-45e1-41a9-acea-646ba3563de7
+      - req-bb866ee3-2e93-4878-ac4a-3c7146368d24
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:08.214421", "expires":
-        "2019-01-08T20:15:08Z", "id": "99853aafb5c44df78dbb720182aaf9db", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:31.148391", "expires":
+        "2019-03-04T21:01:31Z", "id": "7a17d6895e5e4282bbb3bec861d721c0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ik_KtIkiSbORTXdNj-Pazw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FrrUeRG1RsCQCrWudmYHCg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:08 GMT
+      - Mon, 04 Mar 2019 20:01:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:08 GMT
+      - Mon, 04 Mar 2019 20:01:31 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-32c4b066-5079-4402-a035-4c4af952372b
+      - req-9692998a-a962-415d-91db-27ed0c2ec638
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:08.874034", "expires":
-        "2019-01-08T20:15:08Z", "id": "12e0488079984d1dbd4894c6effbba48", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:31.964554", "expires":
+        "2019-03-04T21:01:31Z", "id": "3743e0e230814a61a437fc8252247692", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Ylhy5HzGQN6D3KFcCbIgYg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NqBfocETR3ywaXS5wuuSqA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:31 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:09 GMT
+      - Mon, 04 Mar 2019 20:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-078ea5ad-7660-4ea3-97d8-6069457c5df8
+      - req-391e198f-af3b-4133-86ac-4d2512b46251
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:09.123306", "expires":
-        "2019-01-08T20:15:09Z", "id": "a23e3d9da0884ee49cdb9dbcaa4b84f0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:32.257628", "expires":
+        "2019-03-04T21:01:32Z", "id": "340353ac2b1e436dbfed4e647639cc58", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CrOQws49SYS4Jy7zNZiAnw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["jSP10H58QYi_lQAR9fLFbg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -295,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:09 GMT
+      - Mon, 04 Mar 2019 20:01:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9a5b0780-5a04-4842-b0ef-df2d76c81315
+      - req-7ab50a7d-f79a-409f-89c5-dfa0b14ed7e3
       Content-Length:
       - '4170'
       Connection:
@@ -310,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:09.374341", "expires":
-        "2019-01-08T20:15:09Z", "id": "211d75f39ab0424698eaaf908d84cb8f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:32.709982", "expires":
+        "2019-03-04T21:01:32Z", "id": "c2b16761016941018afc896b5bcf193d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["i8bPJ_7vQKWsdWjg4wwE4w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ac37nqLbQ9yowEYhAIZyzQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -358,7 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:32 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -376,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:09 GMT
+      - Mon, 04 Mar 2019 20:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-48217478-8119-47ae-8b27-e709a8479360
+      - req-f485b27b-fc57-4eea-bdb8-9df1f4c0ee6f
       Content-Length:
       - '4170'
       Connection:
@@ -391,10 +391,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:09.796393", "expires":
-        "2019-01-08T20:15:09Z", "id": "093af7a504b64e12b9677de25042a967", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:33.143362", "expires":
+        "2019-03-04T21:01:33Z", "id": "17b403c5143449a7ac65966a0abc9b76", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WjQYxWnAQP-gDpRPaiNMvw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PwWMJjPuTDSklp_57ONhjA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -439,7 +439,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -457,13 +457,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:09 GMT
+      - Mon, 04 Mar 2019 20:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aa63ad48-467a-4a57-843e-ef1ac80c257f
+      - req-1b458824-9515-43aa-b7ca-b2e6b8d1e062
       Content-Length:
       - '4170'
       Connection:
@@ -472,10 +472,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:10.045346", "expires":
-        "2019-01-08T20:15:10Z", "id": "e6dc1665f3c54ecdb53b66f7da29cd8d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:33.399216", "expires":
+        "2019-03-04T21:01:33Z", "id": "0dfd558f85f64360a4786119949ca9fb", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["mah5eFBZTcamj5tsj1K_5A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["cc7f4UvZTO2n1bnd8MR-RQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -520,7 +520,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -538,13 +538,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:10 GMT
+      - Mon, 04 Mar 2019 20:01:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e717e614-6df8-44f5-a40d-8981c20a25e1
+      - req-7f4fc034-d2ad-4605-9868-eef535778e4b
       Content-Length:
       - '4170'
       Connection:
@@ -553,10 +553,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:10.323633", "expires":
-        "2019-01-08T20:15:10Z", "id": "ccb458710b36481c952d07c25a0305ec", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:33.669055", "expires":
+        "2019-03-04T21:01:33Z", "id": "aef74e0c316e47019c21a3d300bd58c8", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["KpsvDS7lQIWqd0p3FuxqNA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["AUAHK39zSoyv6OWLwmgYPg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -601,7 +601,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -619,13 +619,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:10 GMT
+      - Mon, 04 Mar 2019 20:01:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f10643b6-b22c-463e-9062-1bee41ee8546
+      - req-cbf05399-91a1-4dd9-b1f8-60d19ce4d7a6
       Content-Length:
       - '4170'
       Connection:
@@ -634,10 +634,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:10.592041", "expires":
-        "2019-01-08T20:15:10Z", "id": "db42b3f6b52c4bce9b99ea861102f5d4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:34.154588", "expires":
+        "2019-03-04T21:01:34Z", "id": "4b40caa2b6ef4b4fa886af9b856f0bb7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9W1EWieMQ4Wga2s8d7K88Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["znVCxTJcR2qX8tOI20UYyw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -682,7 +682,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -700,13 +700,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:10 GMT
+      - Mon, 04 Mar 2019 20:01:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f026e53-9136-46b0-b556-06e4f4ecad99
+      - req-feeb9bfd-3554-49d5-b4eb-f2cedae2b664
       Content-Length:
       - '370'
       Connection:
@@ -715,13 +715,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:10.754209", "expires":
-        "2019-01-08T20:15:10Z", "id": "30932bc530e24eae90cee52978017aa4", "audit_ids":
-        ["V_Yr5smnT-aMYBz8RvvOCQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:34.326807", "expires":
+        "2019-03-04T21:01:34Z", "id": "d65741d8d2c442058f2fd48291627f35", "audit_ids":
+        ["fc9bVYRvSE6clywyHdOO6Q"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:34 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -736,20 +736,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 30932bc530e24eae90cee52978017aa4
+      - d65741d8d2c442058f2fd48291627f35
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:10 GMT
+      - Mon, 04 Mar 2019 20:01:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-20ffc707-1e62-43f4-9536-4baf2840e999
+      - req-809c346a-8524-45a3-8e48-eee3979a9d29
       Content-Length:
       - '500'
       Connection:
@@ -766,7 +766,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -781,7 +781,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -794,9 +794,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-b2c2fb82-9380-4d92-985e-3e818d3174f6
+      - req-2e9ad7e0-2367-45db-9ead-b5e2264891fa
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -810,7 +810,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -825,7 +825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -838,9 +838,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-e7c8b29e-2e06-4e86-941b-5cc0074a1519
+      - req-e4d53e1c-49c5-4092-9880-19dfdb4f8155
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -854,7 +854,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -869,7 +869,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -882,9 +882,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-fc4922c3-010d-45cf-ab24-d7de76175010
+      - req-35a388eb-0db7-49b2-969a-28802a719326
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -899,7 +899,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -914,7 +914,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -927,9 +927,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-7fb4e522-dda4-4cde-9811-a276c28d300c
+      - req-ef00e5ed-a3cb-418a-b9aa-4936f9df2bb0
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -939,7 +939,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -954,7 +954,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -967,15 +967,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-15416255-e0d0-4fbf-b365-3323d22468d7
+      - req-524f9fc2-2506-4184-86cd-5f844126347d
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -990,7 +990,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1003,15 +1003,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-3485410d-a66b-4bc9-bad0-34034578a415
+      - req-ff706677-d3c3-4d43-ad7b-66d559a092f5
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
@@ -1026,28 +1026,28 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '093af7a504b64e12b9677de25042a967'
+      - 17b403c5143449a7ac65966a0abc9b76
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be449fb7-027f-40b3-8404-63ebd2e45fb0
+      - req-9e61cd08-16a4-420b-9b1f-928ae1467207
       Content-Type:
       - application/json
       Content-Length:
       - '82'
       X-Openstack-Request-Id:
-      - req-be449fb7-027f-40b3-8404-63ebd2e45fb0
+      - req-9e61cd08-16a4-420b-9b1f-928ae1467207
       Date:
-      - Tue, 08 Jan 2019 19:15:11 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
         "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -1062,7 +1062,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1075,14 +1075,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-8732508b-00f3-4da1-a0ee-130163aadedc
+      - req-280d254a-36a4-4a9d-ba8d-f9b28eca2f7c
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1100,13 +1100,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c46b2e23-bc45-48b1-840c-e1f2831d71a2
+      - req-d94a3404-8323-4041-8c50-499a3f65f783
       Content-Length:
       - '4117'
       Connection:
@@ -1115,10 +1115,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:12.243222", "expires":
-        "2019-01-08T20:15:12Z", "id": "757cbe4428fa445d994102f439adf7ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:36.193853", "expires":
+        "2019-03-04T21:01:36Z", "id": "442f92b84e8340a8bd6e0032c51896e6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["frFE5mWnRLexYQSqagE17A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["H3symGdBTmuZvUBuI7T9-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1162,7 +1162,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1177,7 +1177,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 757cbe4428fa445d994102f439adf7ed
+      - 442f92b84e8340a8bd6e0032c51896e6
   response:
     status:
       code: 200
@@ -1188,7 +1188,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1197,7 +1197,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1215,13 +1215,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-86b00230-f95c-45ea-b03a-14a7b844da27
+      - req-66e51a1e-bcfb-453b-a2c5-44801c3fe538
       Content-Length:
       - '4131'
       Connection:
@@ -1230,10 +1230,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:12.519874", "expires":
-        "2019-01-08T20:15:12Z", "id": "a2c9c37aaec94cb8ae9d6f7e5e22a830", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:36.689318", "expires":
+        "2019-03-04T21:01:36Z", "id": "a17a42029e854580863ddefdc085d73e", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["7fe91ChDR1uqYNmMhxKh6Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["oXlr3IetTz6fHqAZ6a4LNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1277,7 +1277,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1292,7 +1292,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c9c37aaec94cb8ae9d6f7e5e22a830
+      - a17a42029e854580863ddefdc085d73e
   response:
     status:
       code: 200
@@ -1303,7 +1303,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1312,7 +1312,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1330,13 +1330,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e85cddb-6db0-4004-84ca-fc7d203e8be8
+      - req-af0c754a-67a2-4e55-9063-3fb1783a1317
       Content-Length:
       - '4118'
       Connection:
@@ -1345,10 +1345,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:12.803599", "expires":
-        "2019-01-08T20:15:12Z", "id": "391be0b3cd85444b8dfb459158a9a34a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:40.168350", "expires":
+        "2019-03-04T21:01:40Z", "id": "a6510a38ecf34de78579a794eae4a985", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["xaJfKPZgQ3umqYqUJ4jXjQ"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1jJ_13Y7SZO8zvtIjb5pNg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1392,7 +1392,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1407,7 +1407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 391be0b3cd85444b8dfb459158a9a34a
+      - a6510a38ecf34de78579a794eae4a985
   response:
     status:
       code: 200
@@ -1418,7 +1418,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:15:12 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1427,7 +1427,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1442,7 +1442,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 757cbe4428fa445d994102f439adf7ed
+      - 442f92b84e8340a8bd6e0032c51896e6
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1455,9 +1455,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-32978c2d-eee6-4cb4-88ec-d7ed27dc938a
+      - req-b883f5b7-7c6d-4d40-af93-9acf36f75cd2
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1466,7 +1466,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1481,7 +1481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a2c9c37aaec94cb8ae9d6f7e5e22a830
+      - a17a42029e854580863ddefdc085d73e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1494,9 +1494,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5aa033c3-2d00-40c3-b4b0-0e463c9f76fd
+      - req-0a3a3422-a666-4b9b-809a-00b40a470b38
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1505,7 +1505,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1520,7 +1520,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1533,9 +1533,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5c054486-4f10-4752-94aa-206af2cb6673
+      - req-e454613a-a613-4cb4-8487-d21cbfa35973
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1544,7 +1544,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1559,7 +1559,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 391be0b3cd85444b8dfb459158a9a34a
+      - a6510a38ecf34de78579a794eae4a985
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1572,9 +1572,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-bbd9c8a9-7f2b-4a7c-bb04-0555c29dfbd6
+      - req-cce23151-8a13-4c6a-a01d-6e4049b769a4
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -1583,7 +1583,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:40 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1601,13 +1601,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d15c81cd-f178-469d-9300-0887fb9e4b83
+      - req-73c9d6f9-4ea3-4f47-a732-87eccd5d7376
       Content-Length:
       - '4117'
       Connection:
@@ -1616,10 +1616,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:13.742053", "expires":
-        "2019-01-08T20:15:13Z", "id": "60c37361f1104cfd9b309e5c6258ef73", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:41.099172", "expires":
+        "2019-03-04T21:01:41Z", "id": "0fa62caf59b64024932bc2f85454a361", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BvkNHNtGS4KEjG607HUL8A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["6EV4Y8q0TCGVdIA_kAE44w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1663,7 +1663,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1681,13 +1681,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:13 GMT
+      - Mon, 04 Mar 2019 20:01:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f5bba67-8e0d-4512-bfeb-c495ef8c4b2c
+      - req-f14ea565-7216-4dfb-8a1e-835f0c517a43
       Content-Length:
       - '4131'
       Connection:
@@ -1696,10 +1696,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:13.925297", "expires":
-        "2019-01-08T20:15:13Z", "id": "d113045751f7490184b72e855caa5d2e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:41.307213", "expires":
+        "2019-03-04T21:01:41Z", "id": "6c10c7c48b904f32aedba7b367635b22", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["OiTE3VQ7QhWz4kmpOYsCAQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["OQM-SIgJSoCn-VKqlQ5lyA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1743,7 +1743,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1761,13 +1761,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:14 GMT
+      - Mon, 04 Mar 2019 20:01:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-33bc5304-07ee-47b4-b57b-11011b678658
+      - req-0094f684-a99e-4479-814a-251a4919c251
       Content-Length:
       - '4118'
       Connection:
@@ -1776,10 +1776,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:14.122521", "expires":
-        "2019-01-08T20:15:14Z", "id": "37d7691a1d2a4b96ba8c216fcdf4b8ce", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:41.499527", "expires":
+        "2019-03-04T21:01:41Z", "id": "7155cbdd616f4119b1331ea3fec6cdc4", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["U8IrLJlyRd-OapxVfT-2Kg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["9bqiIl2ZSV2SvetZZprl3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1823,7 +1823,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -1838,22 +1838,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 60c37361f1104cfd9b309e5c6258ef73
+      - 0fa62caf59b64024932bc2f85454a361
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ae253aa7-7d57-485e-b4ac-0e54f628c1ec
+      - req-1f286888-80a8-4725-9e3d-b2e87860e5b5
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ae253aa7-7d57-485e-b4ac-0e54f628c1ec
+      - req-1f286888-80a8-4725-9e3d-b2e87860e5b5
       Date:
-      - Tue, 08 Jan 2019 19:15:14 GMT
+      - Mon, 04 Mar 2019 20:01:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1863,7 +1863,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:41 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -1878,22 +1878,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d113045751f7490184b72e855caa5d2e
+      - 6c10c7c48b904f32aedba7b367635b22
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c0557375-c721-4d72-8679-d90a5ccab490
+      - req-5da047a6-d1ef-44f9-b7c7-42677999daf0
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-c0557375-c721-4d72-8679-d90a5ccab490
+      - req-5da047a6-d1ef-44f9-b7c7-42677999daf0
       Date:
-      - Tue, 08 Jan 2019 19:15:14 GMT
+      - Mon, 04 Mar 2019 20:01:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1903,7 +1903,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -1918,22 +1918,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - '093af7a504b64e12b9677de25042a967'
+      - 17b403c5143449a7ac65966a0abc9b76
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d2e1b3b9-c142-4b6e-94be-4d7d58fd4cc7
+      - req-f816fe52-1239-4983-b36c-71ec420006f1
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-d2e1b3b9-c142-4b6e-94be-4d7d58fd4cc7
+      - req-f816fe52-1239-4983-b36c-71ec420006f1
       Date:
-      - Tue, 08 Jan 2019 19:15:15 GMT
+      - Mon, 04 Mar 2019 20:01:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1943,7 +1943,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -1958,22 +1958,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 37d7691a1d2a4b96ba8c216fcdf4b8ce
+      - 7155cbdd616f4119b1331ea3fec6cdc4
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-65472d47-8857-4696-a126-c03f8d7a7f4c
+      - req-fbe92b10-b451-42be-965b-64b0993ae151
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-65472d47-8857-4696-a126-c03f8d7a7f4c
+      - req-fbe92b10-b451-42be-965b-64b0993ae151
       Date:
-      - Tue, 08 Jan 2019 19:15:15 GMT
+      - Mon, 04 Mar 2019 20:01:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -1983,7 +1983,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:42 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2001,13 +2001,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:15 GMT
+      - Mon, 04 Mar 2019 20:01:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-13b526bc-2d91-4cfb-8670-486c0ef32ca8
+      - req-4b34289c-605d-4807-bf9d-55e49670bbaf
       Content-Length:
       - '4117'
       Connection:
@@ -2016,10 +2016,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:15.543982", "expires":
-        "2019-01-08T20:15:15Z", "id": "ad9d6bac52444d67a35cc8df51601a87", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:42.995806", "expires":
+        "2019-03-04T21:01:42Z", "id": "4e41945157524ca6ab2a8c7581c6d0d4", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["A4SZrcTpTZWYM5g1giDZWQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["nkQYRGlPQBu0jl7KTqE1KQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2063,7 +2063,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2081,13 +2081,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:15 GMT
+      - Mon, 04 Mar 2019 20:01:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-657ab2c1-f82b-428e-93ba-e5fd174dfdb6
+      - req-327ffe4a-f3cc-4ad2-888e-1db45022513c
       Content-Length:
       - '4131'
       Connection:
@@ -2096,10 +2096,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:15.732720", "expires":
-        "2019-01-08T20:15:15Z", "id": "57ef4f503a2c4646b80341832face795", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:43.198083", "expires":
+        "2019-03-04T21:01:43Z", "id": "79882fb0551a4655aaf56d70255c7c50", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yBi949z2RS2nOvYhkMisBg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["y4HhO2cCQuCT1t7fz6kGww"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2143,7 +2143,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2161,13 +2161,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:15 GMT
+      - Mon, 04 Mar 2019 20:01:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c2183571-7ff3-46c4-98bb-1a7615731789
+      - req-a0869fd8-6685-45bc-a0ac-7d1c4686e3c5
       Content-Length:
       - '4118'
       Connection:
@@ -2176,10 +2176,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:15.922141", "expires":
-        "2019-01-08T20:15:15Z", "id": "c396cd8d73224baa87c240d672d28ff7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:43.393312", "expires":
+        "2019-03-04T21:01:43Z", "id": "047af518c2e14ca6ac8f87acbe1a3038", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["svKD8MupTrOXdMfb4Kjphw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["BYWuKDUpStyWabj1Gx_HAQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2223,7 +2223,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -2238,7 +2238,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ad9d6bac52444d67a35cc8df51601a87
+      - 4e41945157524ca6ab2a8c7581c6d0d4
   response:
     status:
       code: 200
@@ -2249,16 +2249,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-5ad90997-cbe3-4512-b7ed-efa35b44fd50
+      - req-12b15f85-50fd-447f-9b9b-e66a0f905a17
       Date:
-      - Tue, 08 Jan 2019 19:15:16 GMT
+      - Mon, 04 Mar 2019 20:01:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -2273,7 +2273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 57ef4f503a2c4646b80341832face795
+      - 79882fb0551a4655aaf56d70255c7c50
   response:
     status:
       code: 200
@@ -2284,16 +2284,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1bea0382-2184-4a49-9277-3bc453bb9d19
+      - req-a7553e88-e133-4f9f-aaf2-40726001575a
       Date:
-      - Tue, 08 Jan 2019 19:15:16 GMT
+      - Mon, 04 Mar 2019 20:01:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -2308,7 +2308,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 12e0488079984d1dbd4894c6effbba48
+      - 3743e0e230814a61a437fc8252247692
   response:
     status:
       code: 200
@@ -2319,16 +2319,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-9fa79dad-f804-4874-9846-8dc9a3e6fccd
+      - req-023dad31-bf55-4cde-836d-39476ed4de50
       Date:
-      - Tue, 08 Jan 2019 19:15:16 GMT
+      - Mon, 04 Mar 2019 20:01:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -2343,7 +2343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c396cd8d73224baa87c240d672d28ff7
+      - 047af518c2e14ca6ac8f87acbe1a3038
   response:
     status:
       code: 200
@@ -2354,16 +2354,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-b089a627-4207-4778-ae6c-38e32d84529b
+      - req-aaf751d1-a341-4069-be35-ef6b743a57f1
       Date:
-      - Tue, 08 Jan 2019 19:15:16 GMT
+      - Mon, 04 Mar 2019 20:01:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000
@@ -2378,7 +2378,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2391,9 +2391,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-696c050c-60ea-48ed-8cc5-ddea5da8d119
+      - req-0a7cb642-5c71-40a9-b8f4-d2aa9fb3d521
       Date:
-      - Tue, 08 Jan 2019 19:15:16 GMT
+      - Mon, 04 Mar 2019 20:01:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2403,7 +2403,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?all_tenants=True&limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2418,7 +2418,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2431,9 +2431,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6a351bb8-6d75-4f61-8bcb-24931bf81a1a
+      - req-dc3bb488-65e0-43c8-b2eb-94fae6a6cb13
       Date:
-      - Tue, 08 Jan 2019 19:15:17 GMT
+      - Mon, 04 Mar 2019 20:01:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2443,7 +2443,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2461,13 +2461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:17 GMT
+      - Mon, 04 Mar 2019 20:01:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e878393d-ee08-4991-9f2d-555cd8b0a4e1
+      - req-033cb07a-e9ee-4e3d-979a-4f12508297f9
       Content-Length:
       - '4117'
       Connection:
@@ -2476,10 +2476,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:17.432472", "expires":
-        "2019-01-08T20:15:17Z", "id": "a53d9b3400db478ea7b31f4fc610079f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:44.476046", "expires":
+        "2019-03-04T21:01:44Z", "id": "16b1c23a2aaa4f998572f5f1a192a31a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["IEdlFHdYQNKFdpUJ_diQow"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["E48nJkCgT6K8R1VtKPn8Bg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2523,7 +2523,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2541,13 +2541,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:17 GMT
+      - Mon, 04 Mar 2019 20:01:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d3d05911-af2c-4a9e-8ea0-cc7d84f63ba3
+      - req-64e5b77e-352c-4dc7-a3b3-9e26e135e1fe
       Content-Length:
       - '4131'
       Connection:
@@ -2556,10 +2556,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:17.636426", "expires":
-        "2019-01-08T20:15:17Z", "id": "77c07d6ad8784ece9d0389a3ea9d156e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:44.779855", "expires":
+        "2019-03-04T21:01:44Z", "id": "d8950250977a4baf9a1cb07a24b28694", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1MhTP4pmQ2Wm1qugVK8MZg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["GvBWFdQNSGWKqH_RQlT9Og"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2603,7 +2603,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2621,13 +2621,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:17 GMT
+      - Mon, 04 Mar 2019 20:01:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0166f407-3f75-4aec-a3c8-36e654ff50db
+      - req-898de784-1b09-48a3-ae33-662a00dc665c
       Content-Length:
       - '4118'
       Connection:
@@ -2636,10 +2636,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:17.825502", "expires":
-        "2019-01-08T20:15:17Z", "id": "bd657e0bf5614ed9bd162921ddf36984", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:01:45.126779", "expires":
+        "2019-03-04T21:01:45Z", "id": "56c70e6c48974855a327f6ec65474b79", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NgmFf9_QTaeQ5VLeZXv55Q"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kIM452shTw2C-7VG03fqbg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2683,7 +2683,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2698,7 +2698,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -2709,9 +2709,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-9d027fe0-6b2f-47e5-9c16-9885b1db2729
+      - req-aa05d31b-c36c-458b-b1bf-f03c354ee2f6
       Date:
-      - Tue, 08 Jan 2019 19:15:18 GMT
+      - Mon, 04 Mar 2019 20:01:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2745,7 +2745,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2760,7 +2760,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -2771,14 +2771,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d6599829-bda0-4ccb-be68-ca46785dbc36
+      - req-0824212d-835b-41ac-90f3-4229f3e0075b
       Date:
-      - Tue, 08 Jan 2019 19:15:18 GMT
+      - Mon, 04 Mar 2019 20:01:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2793,7 +2793,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77c07d6ad8784ece9d0389a3ea9d156e
+      - d8950250977a4baf9a1cb07a24b28694
   response:
     status:
       code: 200
@@ -2804,14 +2804,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-afd650f6-5b45-4e33-ba50-876cfad73bdc
+      - req-2a4264ca-1a5a-4b99-b8a1-6df5a16b3243
       Date:
-      - Tue, 08 Jan 2019 19:15:18 GMT
+      - Mon, 04 Mar 2019 20:01:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2826,7 +2826,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - db42b3f6b52c4bce9b99ea861102f5d4
+      - 4b40caa2b6ef4b4fa886af9b856f0bb7
   response:
     status:
       code: 200
@@ -2837,14 +2837,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-991ffdd7-a2f0-4189-9ac4-829e8dc08a39
+      - req-d2cca633-a37f-4aca-9cf7-933c5e345725
       Date:
-      - Tue, 08 Jan 2019 19:15:18 GMT
+      - Mon, 04 Mar 2019 20:01:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2859,7 +2859,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bd657e0bf5614ed9bd162921ddf36984
+      - 56c70e6c48974855a327f6ec65474b79
   response:
     status:
       code: 200
@@ -2870,14 +2870,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-472daf28-af61-41f9-b24b-c9bec079af76
+      - req-2c1095a2-d720-4e5a-a8b4-93f8655898db
       Date:
-      - Tue, 08 Jan 2019 19:15:18 GMT
+      - Mon, 04 Mar 2019 20:01:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2892,7 +2892,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -2903,9 +2903,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-909ea6ba-cf06-4ff6-b42b-0b4cb23bf9a6
+      - req-1ab6fae7-43d7-4a54-818f-f3108960892c
       Date:
-      - Tue, 08 Jan 2019 19:15:19 GMT
+      - Mon, 04 Mar 2019 20:01:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2932,7 +2932,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2947,7 +2947,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -2958,9 +2958,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-df56e16e-bdc6-4744-8f66-bacad121b4ce
+      - req-786bb8e8-534f-4046-8a13-aa719c34482c
       Date:
-      - Tue, 08 Jan 2019 19:15:19 GMT
+      - Mon, 04 Mar 2019 20:01:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2987,7 +2987,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -3002,7 +3002,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3013,9 +3013,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-d3c689e1-80a7-48c1-9f8e-b164a0b012b5
+      - req-01bb3876-c4f2-4e79-ae43-5b672938170c
       Date:
-      - Tue, 08 Jan 2019 19:15:19 GMT
+      - Mon, 04 Mar 2019 20:01:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3042,7 +3042,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3057,7 +3057,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3068,9 +3068,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-04bc319a-6c44-4c00-911b-425bc078beac
+      - req-4b009076-487c-430c-b108-873c53d0ab02
       Date:
-      - Tue, 08 Jan 2019 19:15:19 GMT
+      - Mon, 04 Mar 2019 20:01:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3082,7 +3082,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3097,7 +3097,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3108,9 +3108,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-247a1a14-b0db-46d8-9486-276a8b75fe4e
+      - req-55b4c486-f2a6-4d2f-9a2b-9bdce579fb03
       Date:
-      - Tue, 08 Jan 2019 19:15:19 GMT
+      - Mon, 04 Mar 2019 20:01:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3166,7 +3166,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3181,7 +3181,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3192,9 +3192,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5617adc6-ef54-41bc-8f47-a6ae42e1ca00
+      - req-18a305c1-847c-41de-9d62-c669d18d8380
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3206,7 +3206,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3221,7 +3221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3232,9 +3232,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-ff55b5a0-d1c2-44c9-a667-c5be82d44a31
+      - req-3a819d54-fe78-46a6-a3f0-74b6cc867adb
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3290,7 +3290,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3305,7 +3305,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3316,9 +3316,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-ffc89fa4-108b-4f68-a16c-6724d24640b3
+      - req-4af46d69-b0ba-4af5-a798-2b54c3f534e8
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3330,7 +3330,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3345,7 +3345,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a53d9b3400db478ea7b31f4fc610079f
+      - 16b1c23a2aaa4f998572f5f1a192a31a
   response:
     status:
       code: 200
@@ -3356,9 +3356,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-e8e6d723-0f17-4c33-b79c-373ccd3631ba
+      - req-bdc0e366-cffe-4296-b29a-256612bb6106
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3414,7 +3414,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?all_tenants=True&limit=1000
@@ -3429,7 +3429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3440,14 +3440,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d3961eb3-ae9c-47ed-8a31-a4c1466af8a0
+      - req-fae5b93a-1ea0-49ba-8923-494b3742114d
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000&all_tenants=True"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images
@@ -3462,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3473,9 +3473,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-c04b84f8-1f62-47fe-b559-d71360252568
+      - req-9991ebde-1035-4a6a-98f0-403400254f83
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -3517,7 +3517,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/78ab353a-8b32-4cb9-b00b-60a70bacae08/members
@@ -3532,7 +3532,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3543,14 +3543,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-d8ae0834-54fc-4c2a-b8e1-6396dc8ee36b
+      - req-02f55617-04dd-47cb-b602-d78f6c960c20
       Date:
-      - Tue, 08 Jan 2019 19:15:20 GMT
+      - Mon, 04 Mar 2019 20:01:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/c9e7d983-c1a3-45f5-be89-3cfa4d7d9c0f/members
@@ -3565,7 +3565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3576,14 +3576,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-63a237b6-d928-49ca-a770-3541d57de07c
+      - req-567bd1e5-829f-461a-802b-dc5574da0259
       Date:
-      - Tue, 08 Jan 2019 19:15:21 GMT
+      - Mon, 04 Mar 2019 20:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/2f6b4eb7-8fc2-4439-9dc2-560d7457c706/members
@@ -3598,7 +3598,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3609,14 +3609,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b4b41b05-318d-460e-9810-e0831925890f
+      - req-1a847d75-46a2-43e8-a2b2-616de3b544bf
       Date:
-      - Tue, 08 Jan 2019 19:15:21 GMT
+      - Mon, 04 Mar 2019 20:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b/members
@@ -3631,7 +3631,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 211d75f39ab0424698eaaf908d84cb8f
+      - c2b16761016941018afc896b5bcf193d
   response:
     status:
       code: 200
@@ -3642,14 +3642,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-669e267e-3925-4a7d-8fe1-b1b522ab7316
+      - req-83727a72-2bee-40da-8812-b63f93996866
       Date:
-      - Tue, 08 Jan 2019 19:15:21 GMT
+      - Mon, 04 Mar 2019 20:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"members": [], "schema": "/v2/schemas/members"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000
@@ -3664,7 +3664,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3677,9 +3677,9 @@ http_interactions:
       Content-Length:
       - '3998'
       X-Compute-Request-Id:
-      - req-112df7f9-8ae5-4d14-b343-c18067a85d30
+      - req-c1ae685f-05d5-48d2-985f-fc586a2010e7
       Date:
-      - Tue, 08 Jan 2019 19:15:21 GMT
+      - Mon, 04 Mar 2019 20:01:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3725,7 +3725,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3740,7 +3740,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3753,9 +3753,9 @@ http_interactions:
       Content-Length:
       - '4062'
       X-Compute-Request-Id:
-      - req-5bc44774-6e7e-4e40-915b-ad72080a9ff5
+      - req-f0f2f059-fe49-4ba5-b0f1-a40ef8ce2479
       Date:
-      - Tue, 08 Jan 2019 19:15:21 GMT
+      - Mon, 04 Mar 2019 20:01:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3801,7 +3801,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3816,7 +3816,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3829,9 +3829,9 @@ http_interactions:
       Content-Length:
       - '4144'
       X-Compute-Request-Id:
-      - req-cf8fcf72-2e84-4cda-8367-cf1bffe6e8be
+      - req-c99d9d78-c91c-44dc-8a38-30cb2e84d9a1
       Date:
-      - Tue, 08 Jan 2019 19:15:22 GMT
+      - Mon, 04 Mar 2019 20:01:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3879,7 +3879,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3894,7 +3894,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3907,9 +3907,9 @@ http_interactions:
       Content-Length:
       - '3813'
       X-Compute-Request-Id:
-      - req-c77a2c31-7b4d-44f5-9032-d77996682c6e
+      - req-2054f092-8412-4bb6-9758-9b2a33c48cf7
       Date:
-      - Tue, 08 Jan 2019 19:15:22 GMT
+      - Mon, 04 Mar 2019 20:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3951,7 +3951,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?all_tenants=True&limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3966,7 +3966,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3979,9 +3979,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-6c3937cc-4d93-4478-b7ea-f5005b5aacac
+      - req-2681e98f-d1c6-4ff0-8a48-5f37b8a775a2
       Date:
-      - Tue, 08 Jan 2019 19:15:22 GMT
+      - Mon, 04 Mar 2019 20:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -4004,7 +4004,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4019,7 +4019,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4032,14 +4032,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-a264e80f-4a23-4ec9-a28f-b1fa8a13bfe9
+      - req-53bb26eb-d09f-41cc-8448-0afa5de53ea9
       Date:
-      - Tue, 08 Jan 2019 19:15:22 GMT
+      - Mon, 04 Mar 2019 20:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4054,7 +4054,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4067,14 +4067,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-79d8329a-61dd-4628-9ff1-6f45f8213cfb
+      - req-eb141fb1-9d95-423a-942b-6901b3489444
       Date:
-      - Tue, 08 Jan 2019 19:15:22 GMT
+      - Mon, 04 Mar 2019 20:01:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4089,7 +4089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4102,14 +4102,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-2ebe42b3-2c4a-40be-a5b7-5ba6588ccb21
+      - req-c230379c-35ef-41b1-bb8a-bf4350f19250
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4124,7 +4124,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4137,14 +4137,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-ad4cf1bf-65c6-4497-921b-7a442e8c0864
+      - req-d3f2e597-5549-4b13-8535-2bca337c138b
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4159,7 +4159,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4172,14 +4172,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-0e8f5c9d-6979-427f-a41b-d574923359ae
+      - req-3b73a259-df91-4ed5-9901-af4fa3277be6
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4194,7 +4194,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4207,14 +4207,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-93f082df-9077-4811-a461-5312a5082681
+      - req-f2332bab-1289-48cd-adee-797e34b58d87
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4229,7 +4229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4242,14 +4242,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-f55a723b-7ab1-4c6e-b7aa-34abeb4d92c8
+      - req-9dcc552d-ae0d-44ab-a4fa-47f884cebe53
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4264,7 +4264,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4277,14 +4277,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-7ae761df-e32e-48dc-8cce-9444ca151134
+      - req-5dfd0b7f-e212-4c66-be71-55e1c8fd0147
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4299,7 +4299,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4312,14 +4312,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-25fe5937-0287-4369-8a32-2de97f0a6736
+      - req-3c906b9d-6175-4ce7-9a47-64c5fc93369b
       Date:
-      - Tue, 08 Jan 2019 19:15:23 GMT
+      - Mon, 04 Mar 2019 20:01:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000
@@ -4334,7 +4334,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4347,26 +4347,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-7f8d6060-4f11-4b7f-9a94-6b33654342e5
+      - req-a17e4fb9-ebb1-4806-accc-535a39e4c796
       Date:
-      - Tue, 08 Jan 2019 19:15:24 GMT
+      - Mon, 04 Mar 2019 20:01:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:01:53.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:01:51.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:01:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:16.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:01:51.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:16.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:01:53.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?all_tenants=True&limit=1000&marker=5
@@ -4381,7 +4381,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 99853aafb5c44df78dbb720182aaf9db
+      - 7a17d6895e5e4282bbb3bec861d721c0
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4394,26 +4394,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-00eebbf2-d083-4b38-bef2-68438ba4e898
+      - req-6d5e2209-ef34-405f-9b37-692abae9262e
       Date:
-      - Tue, 08 Jan 2019 19:15:24 GMT
+      - Mon, 04 Mar 2019 20:01:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:15:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:01:53.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:15:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:01:51.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:15:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:01:52.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:15:16.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:01:51.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:15:16.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:01:53.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:01:55 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4431,13 +4431,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:29 GMT
+      - Mon, 04 Mar 2019 20:02:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-08b28e32-57c1-4856-93ba-85c2c5754d75
+      - req-19088f59-74c3-4806-9137-b3d91bba3b3e
       Content-Length:
       - '4170'
       Connection:
@@ -4446,10 +4446,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:29.270367", "expires":
-        "2019-01-08T20:15:29Z", "id": "141bc694f7304dce8b5782f501a9b2a1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:00.082534", "expires":
+        "2019-03-04T21:02:00Z", "id": "4554eac2ce4340268c2fd03a5954c737", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["64HqdpLGTN6YglQNax3PBQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ZN60pKs0RIasaI_yVacTSA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4494,7 +4494,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:00 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4512,13 +4512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:29 GMT
+      - Mon, 04 Mar 2019 20:02:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-710a8ce4-7928-4c70-ba2c-a792e26df7ed
+      - req-9248eb73-5b9e-4d46-b610-32feef8db499
       Content-Length:
       - '4170'
       Connection:
@@ -4527,10 +4527,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:29.449318", "expires":
-        "2019-01-08T20:15:29Z", "id": "2795d98521a24e6e8d9048a18883c0c9", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:00.287359", "expires":
+        "2019-03-04T21:02:00Z", "id": "f008127be0954be6aefd470a75f867e2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZCiSsKueQf-nmWRBHiZO6Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["LSbkpUfPQM2hk_W69-GmuQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4575,7 +4575,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000
@@ -4590,7 +4590,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -4601,9 +4601,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-6f4daa51-2ce0-464f-ab7c-a64dac457c6a
+      - req-54b07a7a-dbdf-497f-8b9a-a771c3c4ba45
       Date:
-      - Tue, 08 Jan 2019 19:15:29 GMT
+      - Mon, 04 Mar 2019 20:02:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -4645,7 +4645,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -4660,7 +4660,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -4671,9 +4671,9 @@ http_interactions:
       Content-Length:
       - '3418'
       X-Openstack-Request-Id:
-      - req-0de1b706-eb0c-437d-887f-f94abeac0cb7
+      - req-2959d0e0-a85c-4681-853f-e722c659baf2
       Date:
-      - Tue, 08 Jan 2019 19:15:29 GMT
+      - Mon, 04 Mar 2019 20:02:00 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -4716,7 +4716,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -4731,7 +4731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -4742,9 +4742,9 @@ http_interactions:
       Content-Length:
       - '2751'
       X-Openstack-Request-Id:
-      - req-7b5a813f-f3f6-494c-b8db-58dbb3f8b432
+      - req-ff0cb01c-602c-497c-8c12-b1c46c2a8026
       Date:
-      - Tue, 08 Jan 2019 19:15:29 GMT
+      - Mon, 04 Mar 2019 20:02:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -4779,7 +4779,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -4794,7 +4794,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -4805,9 +4805,9 @@ http_interactions:
       Content-Length:
       - '7097'
       X-Openstack-Request-Id:
-      - req-2a27b7ac-8b57-4c2e-ac42-b40d23236447
+      - req-4538b0c1-5110-4689-ab64-c159c2e7667f
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?all_tenants=True&limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -4894,7 +4894,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -4909,7 +4909,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -4920,22 +4920,32 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-ab668145-e4df-42cd-94bd-fbc3851dbf6c
+      - req-91542577-6f34-4dbd-9140-3546953dedb1
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
-        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
-        98}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        0, "router:external": true, "shared": false, "provider:network_type": "flat",
+        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
         "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "provider:segmentation_id":
+        98}, {"status": "ACTIVE", "subnets": ["82ca5926-43cb-4312-a23f-727d5c0f5bae"],
         "name": "EmsRefreshSpec-NetworkPrivate_3", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -4975,24 +4985,14 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
         "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
-        "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": true, "shared": false, "provider:network_type": "flat",
-        "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000
@@ -5007,7 +5007,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -5018,166 +5018,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-afc48b05-38f6-4c18-93c9-59d4d8bc7229
+      - req-501166bc-c329-46fb-bb09-d05e2bb498d6
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4452f940-aa44-4686-9706-c70597c8c2dc
-      Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5243,6 +5105,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -5256,7 +5124,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:01 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?all_tenants=True&limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f008127be0954be6aefd470a75f867e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1e83981f-8cd0-4c32-9599-b39d5288018b
+      Date:
+      - Mon, 04 Mar 2019 20:02:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:02:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000
@@ -5271,7 +5271,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -5282,9 +5282,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ff94783c-8a40-427e-91af-80c7de277092
+      - req-b97a60ee-818b-4586-adf7-da295f958e8a
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5316,7 +5316,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?all_tenants=True&limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -5331,7 +5331,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -5342,9 +5342,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-4b81bc4b-082d-4897-a838-297f393fd92d
+      - req-068dcc08-d64d-497f-8be9-40d97619bb43
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -5376,7 +5376,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:02 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000
@@ -5391,7 +5391,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -5402,9 +5402,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-779692e0-fe43-4581-9a79-f93ccb78ba8a
+      - req-65654644-9713-419b-931f-0ee98a7ae9aa
       Date:
-      - Tue, 08 Jan 2019 19:15:30 GMT
+      - Mon, 04 Mar 2019 20:02:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -5807,7 +5807,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?all_tenants=True&limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -5822,7 +5822,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -5833,9 +5833,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-db65c03e-a88d-4d3b-8893-74e633a0a64f
+      - req-2787d4b6-102f-4e93-b125-413d82e43e59
       Date:
-      - Tue, 08 Jan 2019 19:15:31 GMT
+      - Mon, 04 Mar 2019 20:02:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6238,7 +6238,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000
@@ -6253,7 +6253,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -6264,9 +6264,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-5026eab3-bd53-4e0b-8605-48bc43063eb1
+      - req-542aa581-96f5-4b9e-9b94-b36350d2ad4c
       Date:
-      - Tue, 08 Jan 2019 19:15:31 GMT
+      - Mon, 04 Mar 2019 20:02:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6308,7 +6308,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?all_tenants=True&limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -6323,7 +6323,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2795d98521a24e6e8d9048a18883c0c9
+      - f008127be0954be6aefd470a75f867e2
   response:
     status:
       code: 200
@@ -6334,9 +6334,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6cdd49d4-4982-48ce-a4e5-794ac8e30a34
+      - req-b050a9e3-1ec3-4a72-a26c-89898f6566a7
       Date:
-      - Tue, 08 Jan 2019 19:15:31 GMT
+      - Mon, 04 Mar 2019 20:02:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -6378,7 +6378,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:03 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6396,13 +6396,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:32 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc0a088b-7407-4edc-a3b1-a6c403c7bbe9
+      - req-26ff6cf1-cc27-4be0-9860-b9e3c087e331
       Content-Length:
       - '4170'
       Connection:
@@ -6411,10 +6411,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:32.505585", "expires":
-        "2019-01-08T20:15:32Z", "id": "a2dc3b7f553a4183a2f2f845c9115452", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:05.109029", "expires":
+        "2019-03-04T21:02:05Z", "id": "cdf61506bd7f43f49980f7bcabe3139c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yPq_jLUrRuqWKogLf_WJfw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DhPTbnUDQJmcEzqR_1m_Pg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6459,7 +6459,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6477,13 +6477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:32 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-52e43623-6192-496b-ae9a-d5227c0d2037
+      - req-a9584cea-e883-4690-8150-086b40017ffd
       Content-Length:
       - '4170'
       Connection:
@@ -6492,10 +6492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:32.700243", "expires":
-        "2019-01-08T20:15:32Z", "id": "1966b3ba15c64503b4017d43487383c0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:05.322655", "expires":
+        "2019-03-04T21:02:05Z", "id": "4ef39af2b3104f8681fb6466e49ede0d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["vZ_3bUikShW_n4QaxvoriQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["oQ8BvbwORHCvtyRTABDhRw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6540,7 +6540,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6558,13 +6558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:32 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f14b275d-958c-40a4-b7c7-ed45877b09df
+      - req-8d0c9b83-adb2-4a1a-8854-2516bd7726e3
       Content-Length:
       - '370'
       Connection:
@@ -6573,13 +6573,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:32.891690", "expires":
-        "2019-01-08T20:15:32Z", "id": "27a6b91d70d644079955dd4f3c2af291", "audit_ids":
-        ["kQpWRx1JT6i1HotDgynoEA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:05.490824", "expires":
+        "2019-03-04T21:02:05Z", "id": "9e898f16dafe415b88d85b14b9d0fd1a", "audit_ids":
+        ["0xxjaxBfTIy1mWKx1Q9jLA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:05 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6594,20 +6594,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 27a6b91d70d644079955dd4f3c2af291
+      - 9e898f16dafe415b88d85b14b9d0fd1a
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:33 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-820d185b-fa31-4f6d-bdeb-15bd36de380e
+      - req-eeef17e2-679f-4e45-a930-b14bec8785a5
       Content-Length:
       - '500'
       Connection:
@@ -6624,7 +6624,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6642,13 +6642,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:33 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9fa48e1a-ca13-4a71-ae05-0770cb0f0718
+      - req-2d654551-6554-40b3-9b5a-c385b752d6ab
       Content-Length:
       - '4117'
       Connection:
@@ -6657,10 +6657,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:33.227481", "expires":
-        "2019-01-08T20:15:33Z", "id": "13d6cf42229245309a8c158a2dc84cec", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:05.837334", "expires":
+        "2019-03-04T21:02:05Z", "id": "556eb8aba0974331ad9c740818ad4fed", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["dgyXEpCcSIOXiJIS2ONbkA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["beMKdfP5TUOn0gwESbJUIQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6704,7 +6704,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6722,13 +6722,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:33 GMT
+      - Mon, 04 Mar 2019 20:02:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6448be3e-b4ce-44ab-b096-d44673e642c9
+      - req-30287457-5c17-4454-8fd1-f0f6a356367e
       Content-Length:
       - '4131'
       Connection:
@@ -6737,10 +6737,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:33.414139", "expires":
-        "2019-01-08T20:15:33Z", "id": "c7b1a8640017489286a501cc5ea0d870", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:06.033737", "expires":
+        "2019-03-04T21:02:06Z", "id": "b6704256bf0445bdbd64501c5f546919", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ztJ8s9NXTGWz2axS6Qz2Ew"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["teNA7lfqQsCyKfb9dqhxKQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6784,7 +6784,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6802,13 +6802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:33 GMT
+      - Mon, 04 Mar 2019 20:02:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cb5ea33f-1013-4b92-9821-e666d4dbb5e1
+      - req-5fdca699-4456-432d-aba6-447597e66654
       Content-Length:
       - '4118'
       Connection:
@@ -6817,10 +6817,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:33.623709", "expires":
-        "2019-01-08T20:15:33Z", "id": "cc39effe74c04d0a83e6256ea86a2648", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:06.227159", "expires":
+        "2019-03-04T21:02:06Z", "id": "72b73b2de4734482aea23711f4a1144a", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dADQYa_gQ9SDJ4746i-2xg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Cpjho65WROGoZgj2lHY_1w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6864,7 +6864,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -6879,22 +6879,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8403e599-cfcb-4e24-b9ed-580a5e436fab
+      - req-89624daf-01d0-4fda-8085-627c43bc0f1b
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-8403e599-cfcb-4e24-b9ed-580a5e436fab
+      - req-89624daf-01d0-4fda-8085-627c43bc0f1b
       Date:
-      - Tue, 08 Jan 2019 19:15:33 GMT
+      - Mon, 04 Mar 2019 20:02:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -6927,7 +6927,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -6942,22 +6942,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2921a8d3-31de-48ac-8139-a9b98b408660
+      - req-90f5fb41-c7a8-415b-b5f5-bc471414f9f6
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-2921a8d3-31de-48ac-8139-a9b98b408660
+      - req-90f5fb41-c7a8-415b-b5f5-bc471414f9f6
       Date:
-      - Tue, 08 Jan 2019 19:15:34 GMT
+      - Mon, 04 Mar 2019 20:02:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -6998,7 +6998,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -7013,22 +7013,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b5cc78c5-2c6d-4128-9359-2fd046c9dc34
+      - req-49d43b47-8fd5-4b03-a55a-b60870d28c7c
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-b5cc78c5-2c6d-4128-9359-2fd046c9dc34
+      - req-49d43b47-8fd5-4b03-a55a-b60870d28c7c
       Date:
-      - Tue, 08 Jan 2019 19:15:34 GMT
+      - Mon, 04 Mar 2019 20:02:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -7062,7 +7062,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -7077,27 +7077,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-509a087b-6d84-4a0c-b904-a22e24d8fc7d
+      - req-7f6e67e2-7cb8-4d8f-9a68-7fe14c52ba53
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-509a087b-6d84-4a0c-b904-a22e24d8fc7d
+      - req-7f6e67e2-7cb8-4d8f-9a68-7fe14c52ba53
       Date:
-      - Tue, 08 Jan 2019 19:15:34 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -7112,27 +7112,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7b1a8640017489286a501cc5ea0d870
+      - b6704256bf0445bdbd64501c5f546919
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7bd6f56e-e917-4beb-a3e0-54f6613ac6bd
+      - req-7e108970-08eb-4606-8d55-3cc10d5bdcb5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7bd6f56e-e917-4beb-a3e0-54f6613ac6bd
+      - req-7e108970-08eb-4606-8d55-3cc10d5bdcb5
       Date:
-      - Tue, 08 Jan 2019 19:15:37 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -7147,27 +7147,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1966b3ba15c64503b4017d43487383c0
+      - 4ef39af2b3104f8681fb6466e49ede0d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-b0816f8e-b280-4d77-b8a5-29f8472fbb00
+      - req-760ad281-00de-4642-904d-c1a858d0b4fa
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-b0816f8e-b280-4d77-b8a5-29f8472fbb00
+      - req-760ad281-00de-4642-904d-c1a858d0b4fa
       Date:
-      - Tue, 08 Jan 2019 19:15:37 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -7182,27 +7182,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc39effe74c04d0a83e6256ea86a2648
+      - 72b73b2de4734482aea23711f4a1144a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0e942597-453d-47a8-bf6e-2328a45505a4
+      - req-e8d57452-e418-4f1a-99a0-a401c130772d
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0e942597-453d-47a8-bf6e-2328a45505a4
+      - req-e8d57452-e418-4f1a-99a0-a401c130772d
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -7217,22 +7217,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9046ba8a-ac66-47ea-802e-1ddb8ffca0ef
+      - req-09c09ba0-19fe-47c5-9f80-85d3b76909f8
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-9046ba8a-ac66-47ea-802e-1ddb8ffca0ef
+      - req-09c09ba0-19fe-47c5-9f80-85d3b76909f8
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7247,7 +7247,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -7262,22 +7262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-12f9f80f-aab3-40ba-ade3-6159fe0ff554
+      - req-c9057ed6-537d-4756-a53d-17c17713aa6f
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-12f9f80f-aab3-40ba-ade3-6159fe0ff554
+      - req-c9057ed6-537d-4756-a53d-17c17713aa6f
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -7292,7 +7292,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -7307,27 +7307,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7b1a8640017489286a501cc5ea0d870
+      - b6704256bf0445bdbd64501c5f546919
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fc7c7470-2eb8-479a-89ee-b5f51dfe2477
+      - req-ac99da26-f0a8-4d0d-b358-8b33719c9115
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-fc7c7470-2eb8-479a-89ee-b5f51dfe2477
+      - req-ac99da26-f0a8-4d0d-b358-8b33719c9115
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -7342,27 +7342,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7b1a8640017489286a501cc5ea0d870
+      - b6704256bf0445bdbd64501c5f546919
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-819780b8-3f77-4fd4-9a4a-3451712600c7
+      - req-d819687c-a81a-4bd3-ada4-98aef20f659d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-819780b8-3f77-4fd4-9a4a-3451712600c7
+      - req-d819687c-a81a-4bd3-ada4-98aef20f659d
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -7377,27 +7377,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1966b3ba15c64503b4017d43487383c0
+      - 4ef39af2b3104f8681fb6466e49ede0d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-644c4bd6-f9e3-487c-83cb-b0fc97f0933f
+      - req-4814d36b-064b-4124-be84-fe25f2444533
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-644c4bd6-f9e3-487c-83cb-b0fc97f0933f
+      - req-4814d36b-064b-4124-be84-fe25f2444533
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -7412,27 +7412,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1966b3ba15c64503b4017d43487383c0
+      - 4ef39af2b3104f8681fb6466e49ede0d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ffda0dee-c8a8-4492-8f35-49247b71fab2
+      - req-d3b16f47-4413-49e8-816b-b0436d98b93c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-ffda0dee-c8a8-4492-8f35-49247b71fab2
+      - req-d3b16f47-4413-49e8-816b-b0436d98b93c
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -7447,27 +7447,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc39effe74c04d0a83e6256ea86a2648
+      - 72b73b2de4734482aea23711f4a1144a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-164c38a5-8df5-478b-80db-615e2d7411ad
+      - req-18cefdce-b215-47f3-a3f8-c83429dad433
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-164c38a5-8df5-478b-80db-615e2d7411ad
+      - req-18cefdce-b215-47f3-a3f8-c83429dad433
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -7482,27 +7482,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc39effe74c04d0a83e6256ea86a2648
+      - 72b73b2de4734482aea23711f4a1144a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d23681f7-48b1-4096-b29f-ef55287a776b
+      - req-a5fb7ddd-21bc-4206-a63d-7ea13267ac3c
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-d23681f7-48b1-4096-b29f-ef55287a776b
+      - req-a5fb7ddd-21bc-4206-a63d-7ea13267ac3c
       Date:
-      - Tue, 08 Jan 2019 19:15:38 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -7517,27 +7517,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5e32f590-61af-46da-8004-da895cdd322f
+      - req-d2bdc64e-cc01-4870-a1c4-249cb44dbdbd
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5e32f590-61af-46da-8004-da895cdd322f
+      - req-d2bdc64e-cc01-4870-a1c4-249cb44dbdbd
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -7552,27 +7552,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 13d6cf42229245309a8c158a2dc84cec
+      - 556eb8aba0974331ad9c740818ad4fed
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-8c72e712-88c6-49da-a583-f0df8c3234e9
+      - req-57bf2b4c-bedf-420c-b929-9c17cceeaa0f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-8c72e712-88c6-49da-a583-f0df8c3234e9
+      - req-57bf2b4c-bedf-420c-b929-9c17cceeaa0f
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -7587,27 +7587,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7b1a8640017489286a501cc5ea0d870
+      - b6704256bf0445bdbd64501c5f546919
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a58b8dc-5fcf-464b-b13d-9b34308d640b
+      - req-e196f803-6ce8-46a8-b95e-8bf6fa0c621b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4a58b8dc-5fcf-464b-b13d-9b34308d640b
+      - req-e196f803-6ce8-46a8-b95e-8bf6fa0c621b
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -7622,27 +7622,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c7b1a8640017489286a501cc5ea0d870
+      - b6704256bf0445bdbd64501c5f546919
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-bf0abdf4-9391-4bc0-9f44-ab118096afa7
+      - req-6991f236-c209-4ffa-925e-abeaab1daa16
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-bf0abdf4-9391-4bc0-9f44-ab118096afa7
+      - req-6991f236-c209-4ffa-925e-abeaab1daa16
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -7657,27 +7657,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1966b3ba15c64503b4017d43487383c0
+      - 4ef39af2b3104f8681fb6466e49ede0d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-095b5669-a817-41b8-bf21-7091b4a24e7a
+      - req-14df1d5c-4148-47e3-8756-c6494e3a0d71
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-095b5669-a817-41b8-bf21-7091b4a24e7a
+      - req-14df1d5c-4148-47e3-8756-c6494e3a0d71
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -7692,27 +7692,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1966b3ba15c64503b4017d43487383c0
+      - 4ef39af2b3104f8681fb6466e49ede0d
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-10360e43-714c-45a3-9f9b-a968a7480210
+      - req-f925420e-1e3b-419d-8d2e-2dc0e5f39def
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-10360e43-714c-45a3-9f9b-a968a7480210
+      - req-f925420e-1e3b-419d-8d2e-2dc0e5f39def
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -7727,27 +7727,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc39effe74c04d0a83e6256ea86a2648
+      - 72b73b2de4734482aea23711f4a1144a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2468616f-dd6d-4473-a50c-0a5d4ee4d79b
+      - req-7617e117-3d2d-4579-bb28-2c07b295dc46
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-2468616f-dd6d-4473-a50c-0a5d4ee4d79b
+      - req-7617e117-3d2d-4579-bb28-2c07b295dc46
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -7762,27 +7762,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc39effe74c04d0a83e6256ea86a2648
+      - 72b73b2de4734482aea23711f4a1144a
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7f2614c5-7c23-43a2-8455-c03977f5abab
+      - req-b10d51ec-1f35-4af8-b134-e6ac9ef67e4f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7f2614c5-7c23-43a2-8455-c03977f5abab
+      - req-b10d51ec-1f35-4af8-b134-e6ac9ef67e4f
       Date:
-      - Tue, 08 Jan 2019 19:15:39 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:09 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7800,13 +7800,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:09 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7931e21d-3f96-448a-a744-23801ae46f84
+      - req-cf9c0688-1bee-436b-9bbf-6f7b57213b7e
       Content-Length:
       - '4170'
       Connection:
@@ -7815,10 +7815,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:40.071607", "expires":
-        "2019-01-08T20:15:40Z", "id": "94d87ed07ddb4d6391e7e24edcd93ffd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:09.992663", "expires":
+        "2019-03-04T21:02:09Z", "id": "a705416f452d4d26913b3c30b93c80b7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pW3qjlYXSNOMfjla70vKmg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["MasVao7GQ7uNGm2d2NdpNw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7863,7 +7863,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7881,13 +7881,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4bf04af5-36cd-406e-8f88-5838066dc0c4
+      - req-835819b0-445b-4671-872a-ac0eabe17111
       Content-Length:
       - '4170'
       Connection:
@@ -7896,10 +7896,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:40.262931", "expires":
-        "2019-01-08T20:15:40Z", "id": "4c0482710382465bbc19fc5f2e848b3d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:10.205946", "expires":
+        "2019-03-04T21:02:10Z", "id": "3f6da68d7eed4a47b9d0301388c24912", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Yz36JguGQ1Oj-u2iNGcafw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["Dz3T_eq9SqSTXu7A4OTTPA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -7944,7 +7944,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7962,13 +7962,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c0de0552-cc26-4fb2-b7a3-25b6ada1ef4f
+      - req-c4cb537a-d3c2-4556-ba22-6e7789977759
       Content-Length:
       - '370'
       Connection:
@@ -7977,13 +7977,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:40.419931", "expires":
-        "2019-01-08T20:15:40Z", "id": "dff964ce9f184af4a194141052d61462", "audit_ids":
-        ["sCpJ8wi7QrqPdF7T6tGlVA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:10.373260", "expires":
+        "2019-03-04T21:02:10Z", "id": "04410b8f3639428abface9da5a86c12f", "audit_ids":
+        ["LojhKOZZSCGbiihsFfOItw"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -7998,20 +7998,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dff964ce9f184af4a194141052d61462
+      - 04410b8f3639428abface9da5a86c12f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-297d1a88-e9dc-4770-839f-148635981ca1
+      - req-0c74a0ce-6bc0-407d-958c-e1945ca9a7ff
       Content-Length:
       - '500'
       Connection:
@@ -8028,7 +8028,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8046,13 +8046,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-88431748-b852-4dd2-bfa1-f4e1d3cf2d08
+      - req-f382bac1-2462-4984-b85c-3a26444f37c1
       Content-Length:
       - '4117'
       Connection:
@@ -8061,10 +8061,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:40.744262", "expires":
-        "2019-01-08T20:15:40Z", "id": "dc960256935a4829ab522f29fb5aad97", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:10.718018", "expires":
+        "2019-03-04T21:02:10Z", "id": "7563fb0b3b2d469bb7e1fab974f63f9a", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["5HE6Tr2ORbe38_YoKIS26g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["p3p4PlahSEShuBQrrDNJ8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -8108,7 +8108,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8126,13 +8126,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:40 GMT
+      - Mon, 04 Mar 2019 20:02:10 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-43658e0b-44d8-4ae9-9063-932764283e8b
+      - req-b54c41dc-9c7d-4d57-98f3-5dc89562ffa4
       Content-Length:
       - '4131'
       Connection:
@@ -8141,10 +8141,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:40.952483", "expires":
-        "2019-01-08T20:15:40Z", "id": "5efc50b5fd4144799bc5e84bc94e7906", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:10.927063", "expires":
+        "2019-03-04T21:02:10Z", "id": "d4e7d97d103d47768c866328d6d0e716", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["UC2qAr0yT0qK6Dv9GqNqGQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ttVtvHtXQmeQsHvi8pAXqw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -8188,7 +8188,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -8206,13 +8206,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:15:41 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-edec8ffc-4023-4524-94d4-86354f887269
+      - req-a127bcc0-a56e-4a5e-8cb5-27e0ebeb4c0e
       Content-Length:
       - '4118'
       Connection:
@@ -8221,10 +8221,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:15:41.164407", "expires":
-        "2019-01-08T20:15:41Z", "id": "94260733a4a04e24aeab6ccd7572048a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:02:11.142916", "expires":
+        "2019-03-04T21:02:11Z", "id": "7d4d58dcb2c4482ea34ce3c17b2b6239", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["O7WANmpMSY-F2dgFS63_bA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["dAIx84GvSDOEJ2LIOS7z-g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -8268,7 +8268,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -8283,7 +8283,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc960256935a4829ab522f29fb5aad97
+      - 7563fb0b3b2d469bb7e1fab974f63f9a
   response:
     status:
       code: 200
@@ -8312,15 +8312,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx88f12435549840f9903f1-005c34f6dd
+      - txc9f124d225974d00bdada-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:41 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -8335,7 +8335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc960256935a4829ab522f29fb5aad97
+      - 7563fb0b3b2d469bb7e1fab974f63f9a
   response:
     status:
       code: 200
@@ -8364,14 +8364,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - tx9b4f95c058e74a2a820ec-005c34f6dd
+      - tx98294190d06d4dc98a74c-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:41 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -8386,7 +8386,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5efc50b5fd4144799bc5e84bc94e7906
+      - d4e7d97d103d47768c866328d6d0e716
   response:
     status:
       code: 200
@@ -8399,22 +8399,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974941.69128'
+      - '1551729731.57916'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974941.69128'
+      - '1551729731.57916'
       X-Trans-Id:
-      - tx498640d3144a44ffa787f-005c34f6dd
+      - tx078625f14b7c4f369ae80-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:41 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -8429,7 +8429,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4c0482710382465bbc19fc5f2e848b3d
+      - 3f6da68d7eed4a47b9d0301388c24912
   response:
     status:
       code: 200
@@ -8442,22 +8442,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974941.85780'
+      - '1551729731.74141'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974941.85780'
+      - '1551729731.74141'
       X-Trans-Id:
-      - txbd142eb60f5d42ae8e617-005c34f6dd
+      - txd8f14a691ff3425888eae-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:41 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -8472,7 +8472,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 94260733a4a04e24aeab6ccd7572048a
+      - 7d4d58dcb2c4482ea34ce3c17b2b6239
   response:
     status:
       code: 200
@@ -8485,22 +8485,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546974942.02259'
+      - '1551729731.89415'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546974942.02259'
+      - '1551729731.89415'
       X-Trans-Id:
-      - tx1d385397c8ed49aeb6907-005c34f6dd
+      - txff0a451f8a0643f8abacc-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:42 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:11 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -8515,7 +8515,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc960256935a4829ab522f29fb5aad97
+      - 7563fb0b3b2d469bb7e1fab974f63f9a
   response:
     status:
       code: 200
@@ -8536,9 +8536,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txbe4f4b32534f479a84388-005c34f6de
+      - tx42823f0f2b85450bbb547-005c7d8443
       Date:
-      - Tue, 08 Jan 2019 19:15:42 GMT
+      - Mon, 04 Mar 2019 20:02:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -8548,7 +8548,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -8563,7 +8563,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc960256935a4829ab522f29fb5aad97
+      - 7563fb0b3b2d469bb7e1fab974f63f9a
   response:
     status:
       code: 200
@@ -8584,14 +8584,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx08ae1e134d2546b2ba609-005c34f6de
+      - txd7c68a0eb8724cf7a0105-005c7d8444
       Date:
-      - Tue, 08 Jan 2019 19:15:42 GMT
+      - Mon, 04 Mar 2019 20:02:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -8606,7 +8606,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - dc960256935a4829ab522f29fb5aad97
+      - 7563fb0b3b2d469bb7e1fab974f63f9a
   response:
     status:
       code: 200
@@ -8627,12 +8627,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx0f4bfb75b5404358a9b16-005c34f6de
+      - tx227b2482889d4b74837c9-005c7d8444
       Date:
-      - Tue, 08 Jan 2019 19:15:42 GMT
+      - Mon, 04 Mar 2019 20:02:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:15:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:02:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_network_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:24 GMT
+      - Mon, 04 Mar 2019 20:04:24 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e45070df-8562-49a5-996a-00dc51b9f165
+      - req-e31a95d7-4372-4a6b-8252-169c6aaee17a
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:24.916035", "expires":
-        "2019-01-08T20:17:24Z", "id": "479321cb2ce5472a91d67c5ce1447bcb", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:24.820684", "expires":
+        "2019-03-04T21:04:24Z", "id": "2e70ac4dba134dd1a59448923ffc549c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["r1_jEwY8RgqIjeGppUZitA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["uCfjbgENT3-JsfEU0udBCQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:24 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
+      - Mon, 04 Mar 2019 20:04:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,132 +143,15 @@ http_interactions:
       Content-Length:
       - '97'
       X-Compute-Request-Id:
-      - req-a9922a3a-99ad-45b4-b3be-85902813c427
+      - req-093ee557-8980-40f6-9216-e446995bab5a
       Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "hosts":
         null, "zoneName": "nova"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
-- request:
-    method: post
-    uri: http://11.22.33.44:5000/v2.0/tokens
-    body:
-      encoding: UTF-8
-      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
-      Server:
-      - Apache/2.4.6 (Red Hat Enterprise Linux)
-      Vary:
-      - X-Auth-Token,Accept-Encoding
-      X-Openstack-Request-Id:
-      - req-e81f990c-4a4e-4b05-afca-7f943d3a6ab7
-      Content-Length:
-      - '4170'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:25.386157", "expires":
-        "2019-01-08T20:17:25Z", "id": "a6ca609511384a2db25cf1cf44efc23c", "tenant":
-        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1Kb874DiQPi19oxZTEiitA"]}, "serviceCatalog":
-        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
-        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
-        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
-        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
-        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
-        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
-        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
-        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
-        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
-        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
-        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
-        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
-        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
-        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
-        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
-        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
-        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
-        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
-        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
-        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
-        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
-        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
-        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
-        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
-        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
-        "725d26e4ae494cc689c60f857e347267"]}}}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Compute-Request-Id:
-      - req-bdd5e5fd-c317-43f6-b485-8d020d92b6ec
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '82'
-      X-Openstack-Request-Id:
-      - req-bdd5e5fd-c317-43f6-b485-8d020d92b6ec
-      Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
-        "nova"}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -286,13 +169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c57996e9-1643-4774-a31f-68ac9dd4512e
+      - req-756da477-61a4-4b0d-8648-2ea1a5e89380
       Content-Length:
       - '370'
       Connection:
@@ -301,13 +184,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:25.695187", "expires":
-        "2019-01-08T20:17:25Z", "id": "f4c84f27cf7d418b86685f95f507417b", "audit_ids":
-        ["LD-OxlWgSrmd8u3PGCKdNQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:26.274542", "expires":
+        "2019-03-04T21:04:26Z", "id": "e9a9499f9ea1491ba2d98b385bad987d", "audit_ids":
+        ["jk_TOEfnRC6zkj7ttCD7FA"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -322,20 +205,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4c84f27cf7d418b86685f95f507417b
+      - e9a9499f9ea1491ba2d98b385bad987d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5ebe35b5-f4de-450a-bb8c-3eb9d0a72295
+      - req-bf9f0137-0520-413a-b906-42a5bf110e1a
       Content-Length:
       - '500'
       Connection:
@@ -352,7 +235,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:25 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -370,13 +253,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:25 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c14f341a-7b81-4ac9-8a4e-f04fbc7988c0
+      - req-8b97d3a4-b836-42f8-8370-4944845bcda0
       Content-Length:
       - '4117'
       Connection:
@@ -385,10 +268,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:26.036324", "expires":
-        "2019-01-08T20:17:26Z", "id": "31655a1d4338432da409ea11f191757a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:26.612357", "expires":
+        "2019-03-04T21:04:26Z", "id": "2261a117e1e34a7bad548131c5933df8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["sYR7s1YmQgmJG2IEHGB2dg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zC5AQTjUTvWVijivg9JWqg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -432,7 +315,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -447,7 +330,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
   response:
     status:
       code: 200
@@ -458,7 +341,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -467,7 +350,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -485,13 +368,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9754ba4f-38c1-4bad-a722-29418b04b57c
+      - req-549e7d7e-578d-4fa1-97c8-d4cf311ecef9
       Content-Length:
       - '4131'
       Connection:
@@ -500,10 +383,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:26.310072", "expires":
-        "2019-01-08T20:17:26Z", "id": "c9608acb08f44c3a92f9ffc78a67863d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:26.953927", "expires":
+        "2019-03-04T21:04:26Z", "id": "47f2afbbfa5f4411979a900f0994fdd5", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["fZMJYmgpT3CWSLalYI6fzQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["SxRnza1zRHaQr5jAA1RRFA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -547,7 +430,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -562,7 +445,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
   response:
     status:
       code: 200
@@ -573,7 +456,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -582,7 +465,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -600,13 +483,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-68278792-87ec-4d2f-8151-a9d07c18208d
+      - req-6fe1e1d0-02af-4850-bc29-4ba6c4130fa3
       Content-Length:
       - '4118'
       Connection:
@@ -615,10 +498,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:26.603747", "expires":
-        "2019-01-08T20:17:26Z", "id": "bc9cdb205a564aa18172d2f9b1240edd", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:28.291170", "expires":
+        "2019-03-04T21:04:28Z", "id": "a3f143f7b78e4cdbaee45e31e71919b7", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["FcWnjfnMSmmFoprafhJhbA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["Jqyj_6MbQo2-sWv-YywBLQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -662,7 +545,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -677,7 +560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
   response:
     status:
       code: 200
@@ -688,7 +571,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -697,7 +580,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000
@@ -712,7 +595,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -725,26 +608,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-bfc35108-1617-4305-bd8a-748f9ebf7412
+      - req-9f130bb8-1d22-4ee7-bf98-07abba18aa66
       Date:
-      - Tue, 08 Jan 2019 19:17:26 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:16.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:26 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-services?limit=1000&marker=5
@@ -759,7 +642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -772,26 +655,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-812252b7-1837-48e3-97a0-63517f8c6060
+      - req-76b1d0c8-6af6-4fa6-9536-d107fc48ed0e
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000
@@ -806,7 +689,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -819,26 +702,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6b3502b1-dc21-4d16-8df6-730e8da8e39a
+      - req-d2ed543b-97b3-4f8e-abfb-423c4f784637
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-services?limit=1000&marker=5
@@ -853,7 +736,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -866,26 +749,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-2fa6602b-04a9-4f8d-9a8b-b8f1a08a9e01
+      - req-bf0a6be5-14fc-48df-8c57-4c883383647b
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000
@@ -900,7 +783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -913,26 +796,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-c7de8b05-b429-493b-8c4c-a192ff670b8b
+      - req-166474a1-fa00-4098-9ace-16999e033f50
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-services?limit=1000&marker=5
@@ -947,7 +830,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -960,26 +843,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-a0c27d37-ca92-4711-990c-5e8efdfd8ac5
+      - req-74b74b21-7d26-4d4c-94dd-97880d091cb3
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000
@@ -994,7 +877,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1007,26 +890,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-408fef7e-c858-48f2-9b32-ba6b29fe397f
+      - req-8a213051-301b-479c-a2ad-4aa2f4fd6513
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-services?limit=1000&marker=5
@@ -1041,7 +924,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1054,26 +937,26 @@ http_interactions:
       Content-Length:
       - '1125'
       X-Compute-Request-Id:
-      - req-6fbb534a-90b2-4bba-8b61-587838e64a33
+      - req-0d5c9534-b98b-4b7e-b5f2-94c85afab987
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"services": [{"status": "enabled", "binary": "nova-consoleauth", "host":
         "11.22.33.44", "zone": "internal", "state":
-        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-01-08T19:17:24.000000"},
+        "up", "disabled_reason": null, "id": 1, "updated_at": "2019-03-04T20:04:23.000000"},
         {"status": "enabled", "binary": "nova-scheduler", "host": "11.22.33.44",
         "zone": "internal", "state": "up", "disabled_reason": null, "id": 2, "updated_at":
-        "2019-01-08T19:17:23.000000"}, {"status": "enabled", "binary": "nova-conductor",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-conductor",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-01-08T19:17:23.000000"},
+        "state": "up", "disabled_reason": null, "id": 3, "updated_at": "2019-03-04T20:04:22.000000"},
         {"status": "enabled", "binary": "nova-compute", "host": "11.22.33.44",
         "zone": "nova", "state": "up", "disabled_reason": null, "id": 4, "updated_at":
-        "2019-01-08T19:17:26.000000"}, {"status": "enabled", "binary": "nova-cert",
+        "2019-03-04T20:04:21.000000"}, {"status": "enabled", "binary": "nova-cert",
         "host": "11.22.33.44", "zone": "internal",
-        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-01-08T19:17:26.000000"}]}'
+        "state": "up", "disabled_reason": null, "id": 5, "updated_at": "2019-03-04T20:04:23.000000"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:27 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000
@@ -1088,7 +971,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1101,9 +984,9 @@ http_interactions:
       Content-Length:
       - '1010'
       X-Compute-Request-Id:
-      - req-ef0e3875-cfb7-49f2-bccd-3f81279b9bd9
+      - req-018e744d-de75-48ac-9257-5ebb1464254b
       Date:
-      - Tue, 08 Jan 2019 19:17:27 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.tiny", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/1",
@@ -1117,7 +1000,7 @@ http_interactions:
         0, "disk": 20, "id": "2"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=2
@@ -1132,7 +1015,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1145,9 +1028,9 @@ http_interactions:
       Content-Length:
       - '1014'
       X-Compute-Request-Id:
-      - req-aa548265-c472-49b1-9d1a-739a4489e156
+      - req-a30b709b-0b28-4342-8293-08158cec438f
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.medium", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/3",
@@ -1161,7 +1044,7 @@ http_interactions:
         0, "disk": 80, "id": "4"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=4
@@ -1176,7 +1059,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1189,9 +1072,9 @@ http_interactions:
       Content-Length:
       - '1026'
       X-Compute-Request-Id:
-      - req-892ca00c-3e46-4e63-b026-bc26c81615bc
+      - req-737f9f2a-da89-410a-9ed5-8a849a5e7474
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.xlarge", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/5",
@@ -1206,7 +1089,7 @@ http_interactions:
         1, "disk": 1, "id": "6"}], "flavors_links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6",
         "rel": "next"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/detail?all_tenants=True&is_public=None&limit=1000&marker=6
@@ -1221,7 +1104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1234,9 +1117,9 @@ http_interactions:
       Content-Length:
       - '448'
       X-Compute-Request-Id:
-      - req-f906a620-529d-4f5f-87f1-47b76c3e5a1c
+      - req-83af526a-4b1f-4819-a47e-13d3d591b842
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavors": [{"name": "m1.ems_refresh_spec_private", "links": [{"href":
@@ -1246,7 +1129,7 @@ http_interactions:
         8, "swap": "", "os-flavor-access:is_public": false, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         0, "disk": 160, "id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/7/os-flavor-access
@@ -1261,7 +1144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1274,15 +1157,15 @@ http_interactions:
       Content-Length:
       - '88'
       X-Compute-Request-Id:
-      - req-ec1f8c20-7b5a-48f4-9e20-c451436f0d07
+      - req-458a0470-fb9c-412e-bf90-08174f28b965
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor_access": [{"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "flavor_id": "7"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1300,13 +1183,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-637ada11-18b1-4254-8e55-c8d4858b7bee
+      - req-632ea7e3-f10e-4ff3-a898-3d0cef56ec6a
       Content-Length:
       - '4170'
       Connection:
@@ -1315,10 +1198,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:28.613061", "expires":
-        "2019-01-08T20:17:28Z", "id": "1c78fa58fb8d472ca426c0d6ba4026d8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:30.455281", "expires":
+        "2019-03-04T21:04:30Z", "id": "acb69ca4249e4af7907a09bb5c0d0afa", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["LuNxO7sGTcmWZUwLZENS4Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ovlgN5NtR8CX-1kBUCGMQA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1363,7 +1246,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1381,13 +1264,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-57360733-bc18-4555-97d6-74da25045aec
+      - req-8e2a793a-6b88-4c05-a706-be81505c8399
       Content-Length:
       - '4117'
       Connection:
@@ -1396,10 +1279,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:28.803282", "expires":
-        "2019-01-08T20:17:28Z", "id": "5ecf918a85ec4d87baf843efd8ab323c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:30.661858", "expires":
+        "2019-03-04T21:04:30Z", "id": "72d059cca8fc439eb1cf6f892e7b8650", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zfxDThnVT4y4Og0qVti52g"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ssREqzSjQwywc4F9oVZf8w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1443,7 +1326,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1461,13 +1344,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:28 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-800ac645-01e4-4fcd-a72f-1190b49298b9
+      - req-159593e4-98f8-46a4-a105-d2a7c6114014
       Content-Length:
       - '4131'
       Connection:
@@ -1476,10 +1359,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:29.026005", "expires":
-        "2019-01-08T20:17:29Z", "id": "75489cadc6fc4b15a0a730c1a0048431", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:30.849751", "expires":
+        "2019-03-04T21:04:30Z", "id": "0ef2fbf376fa4af4a3226dd4ba9fdbd9", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["hTa1D1r7SHyVNFZuji_M8Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["yjSjv0nYTMePdIbSAAf3wQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1523,7 +1406,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1541,13 +1424,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:29 GMT
+      - Mon, 04 Mar 2019 20:04:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-702419d0-8d0f-4cf5-987e-a1845e0fa928
+      - req-f2adee67-b5f6-4033-817d-5300bea75771
       Content-Length:
       - '4118'
       Connection:
@@ -1556,10 +1439,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:29.221630", "expires":
-        "2019-01-08T20:17:29Z", "id": "b98e3237e92e4d9086b0a22d098a6de7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:31.064511", "expires":
+        "2019-03-04T21:04:31Z", "id": "854205b1362f4f23baebf36e46522737", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KDoLKYyvR3CVy_qCcZXQWg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["HSBfCyuXT_i3G8K0mi57lA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1603,7 +1486,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1618,7 +1501,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ecf918a85ec4d87baf843efd8ab323c
+      - 72d059cca8fc439eb1cf6f892e7b8650
   response:
     status:
       code: 200
@@ -1629,9 +1512,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-b4fe7a28-11b3-400d-9b9b-5eada3bf94bb
+      - req-13e16b71-2452-4bc3-a569-922e6e9bdf84
       Date:
-      - Tue, 08 Jan 2019 19:17:29 GMT
+      - Mon, 04 Mar 2019 20:04:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1673,7 +1556,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1688,7 +1571,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5ecf918a85ec4d87baf843efd8ab323c
+      - 72d059cca8fc439eb1cf6f892e7b8650
   response:
     status:
       code: 200
@@ -1699,14 +1582,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-407d99fc-d61c-4a27-8fb1-42864fec5b9d
+      - req-0a0409a9-f3ac-4244-88cd-8f6bd9b796c2
       Date:
-      - Tue, 08 Jan 2019 19:17:29 GMT
+      - Mon, 04 Mar 2019 20:04:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1721,7 +1604,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75489cadc6fc4b15a0a730c1a0048431
+      - 0ef2fbf376fa4af4a3226dd4ba9fdbd9
   response:
     status:
       code: 200
@@ -1732,9 +1615,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-aba5e9f4-d60f-48e3-8550-7aebb5473cf4
+      - req-9c6fc122-d478-410b-ac31-11f0fc51f4b0
       Date:
-      - Tue, 08 Jan 2019 19:17:29 GMT
+      - Mon, 04 Mar 2019 20:04:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1776,7 +1659,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1791,7 +1674,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 75489cadc6fc4b15a0a730c1a0048431
+      - 0ef2fbf376fa4af4a3226dd4ba9fdbd9
   response:
     status:
       code: 200
@@ -1802,14 +1685,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-37427c30-1b88-4dce-b780-d6f7441d9ba3
+      - req-7d8a7f2e-7120-4032-ab1c-e8d7d8bae906
       Date:
-      - Tue, 08 Jan 2019 19:17:29 GMT
+      - Mon, 04 Mar 2019 20:04:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:29 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1824,7 +1707,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c78fa58fb8d472ca426c0d6ba4026d8
+      - acb69ca4249e4af7907a09bb5c0d0afa
   response:
     status:
       code: 200
@@ -1835,9 +1718,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-212b3de4-991e-4827-bb72-882ba40df270
+      - req-8eb4ad4f-5e13-41c0-8c13-9bbca30f7452
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1879,7 +1762,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:31 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1894,7 +1777,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c78fa58fb8d472ca426c0d6ba4026d8
+      - acb69ca4249e4af7907a09bb5c0d0afa
   response:
     status:
       code: 200
@@ -1905,14 +1788,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-480120de-9ef1-4c45-89c0-781132aeec9d
+      - req-98c3074e-86fd-4e8d-a358-d1be7d048361
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000
@@ -1927,7 +1810,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b98e3237e92e4d9086b0a22d098a6de7
+      - 854205b1362f4f23baebf36e46522737
   response:
     status:
       code: 200
@@ -1938,9 +1821,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-83812b7d-04b2-4709-8407-8870fc870f64
+      - req-cfab6875-5f0b-4d9b-ba37-30fce73089db
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [{"image_state": "available", "container_format": "bare",
@@ -1982,7 +1865,7 @@ http_interactions:
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}], "schema":
         "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images?limit=1000&marker=bb799f70-5e02-461b-8324-17ee88259c7b
@@ -1997,7 +1880,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b98e3237e92e4d9086b0a22d098a6de7
+      - 854205b1362f4f23baebf36e46522737
   response:
     status:
       code: 200
@@ -2008,14 +1891,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-078161e7-a278-45ca-86da-3c14e9e7c757
+      - req-d4c7db2d-413d-4ce2-9e33-2e1ae2d38604
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"images": [], "schema": "/v2/schemas/images", "first": "/v2/images?limit=1000"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -2030,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2043,9 +1926,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d257f5de-6970-48e9-a475-d96938f4c2b9
+      - req-14533019-c5ed-4db9-82a9-80cfc969f465
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2055,7 +1938,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2070,7 +1953,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2083,9 +1966,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-851b7842-7de5-4970-9084-c5afcd394553
+      - req-db1792bc-9df9-4d4f-8e8d-734a8724be9f
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2095,7 +1978,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -2110,7 +1993,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2123,9 +2006,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-42d37bc3-3e17-4f28-ba5c-1ebdccb0b86d
+      - req-fc443a59-5eb4-49cc-99b6-4f170404b250
       Date:
-      - Tue, 08 Jan 2019 19:17:30 GMT
+      - Mon, 04 Mar 2019 20:04:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2135,7 +2018,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2150,7 +2033,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2163,9 +2046,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6aa5aa74-21e2-4631-8c29-4064f5ce8e4a
+      - req-41df939a-5196-4eca-88e9-136cdd19d326
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2175,7 +2058,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -2190,7 +2073,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2203,9 +2086,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7689900d-4474-418c-bfb5-ea14f902638b
+      - req-0e0f6098-36d1-41f4-97d6-50edd1da5923
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2215,7 +2098,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2230,7 +2113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2243,9 +2126,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-426bf4c7-2004-4a8d-9941-469397c0baab
+      - req-2b9ca98a-f868-4dce-8dce-ded5b70f7d80
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2255,7 +2138,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -2270,7 +2153,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2283,9 +2166,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-925a0db8-8ba5-4903-b617-e99f6272dc59
+      - req-48be6074-1e99-4251-97b8-830dbb094ba1
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2295,7 +2178,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -2310,7 +2193,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -2323,9 +2206,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-6fb09ec2-2563-47b0-9eaf-c84669bb4cbf
+      - req-9ce2957a-4adf-419a-a3dd-3439e913a929
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -2335,7 +2218,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2353,13 +2236,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8fd4e997-1512-4f85-8b6e-3b278d077e05
+      - req-7f3cee27-ce3e-4ce8-9ba3-cdadba2786a7
       Content-Length:
       - '4170'
       Connection:
@@ -2368,10 +2251,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:31.724322", "expires":
-        "2019-01-08T20:17:31Z", "id": "0a917220ce5c4889ad4d94ac156e655e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:33.814761", "expires":
+        "2019-03-04T21:04:33Z", "id": "f846bc5a220e4c199029634c1ef0ee7b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qjCjrx1tRUCm8v10bkcRSg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["CFh2KHFZSgWXu3fzSkJUMQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2416,7 +2299,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2434,13 +2317,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:31 GMT
+      - Mon, 04 Mar 2019 20:04:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2a99bbe-b438-4240-bd2f-16a2b11df0c1
+      - req-90e6d475-e31a-44f8-8f52-f03d9a557cc5
       Content-Length:
       - '4117'
       Connection:
@@ -2449,10 +2332,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:31.948781", "expires":
-        "2019-01-08T20:17:31Z", "id": "f509df5757e74758a2b63e4819463a65", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:34.007865", "expires":
+        "2019-03-04T21:04:33Z", "id": "8df13c638a304ef6a1322554d92dcba8", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EXwc1C3KQCixF0uiJNV_dA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["maKMfwMgRPSGbIsJXPWwZQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2496,7 +2379,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:31 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2514,13 +2397,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8f8d17f6-21a8-4a76-8a6d-616673f29875
+      - req-119b0bb4-bbc0-43c4-a773-9438e4838ea4
       Content-Length:
       - '4131'
       Connection:
@@ -2529,10 +2412,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:32.135399", "expires":
-        "2019-01-08T20:17:32Z", "id": "2ee6650c05444248b0b854907a40fdf2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:34.329749", "expires":
+        "2019-03-04T21:04:34Z", "id": "df9393a0e20e4538b7478cf4ff3ce104", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Xdwbr5OMSj-ZdBN6WLVQGQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["KENg915DT8etw5h3cJCCGw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2576,7 +2459,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2594,13 +2477,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-16d3e3a3-2d74-41f7-b63e-9e0149a9f9c9
+      - req-307392d3-9292-470a-b770-2b943bcaba40
       Content-Length:
       - '4118'
       Connection:
@@ -2609,10 +2492,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:32.337446", "expires":
-        "2019-01-08T20:17:32Z", "id": "270db59df7e743448fffb4f8a84baec7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:34.633910", "expires":
+        "2019-03-04T21:04:34Z", "id": "faf39557344548b3b225405dc2875b59", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["bSadGX6bQEWNKt5eSIhcQw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["3bxHsn8RToaWyymdPBr3Zw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2656,7 +2539,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -2671,7 +2554,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -2682,9 +2565,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-ebd0a89d-ceec-4868-965a-57ac74161a05
+      - req-6fe77344-e43f-4686-a376-8dd5c214d8da
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -2718,7 +2601,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -2733,7 +2616,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -2744,14 +2627,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-32d0b4e3-7b6c-4acd-9d1b-ed2fc040e2f5
+      - req-ce048c28-023a-4ec0-a677-ac00d3fc37a0
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -2766,7 +2649,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ee6650c05444248b0b854907a40fdf2
+      - df9393a0e20e4538b7478cf4ff3ce104
   response:
     status:
       code: 200
@@ -2777,14 +2660,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-55a0319b-6c6f-48dc-ad32-75227f117568
+      - req-2f4e3051-98fc-49f6-9616-9ebd8c125b5a
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -2799,7 +2682,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0a917220ce5c4889ad4d94ac156e655e
+      - f846bc5a220e4c199029634c1ef0ee7b
   response:
     status:
       code: 200
@@ -2810,14 +2693,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-d61488c5-5f43-4cdf-b6cc-318086699413
+      - req-a8389798-d3db-4c34-a7e0-fee4d4ee663b
       Date:
-      - Tue, 08 Jan 2019 19:17:32 GMT
+      - Mon, 04 Mar 2019 20:04:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:32 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -2832,7 +2715,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 270db59df7e743448fffb4f8a84baec7
+      - faf39557344548b3b225405dc2875b59
   response:
     status:
       code: 200
@@ -2843,14 +2726,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-108ecbd0-fc67-4112-a361-6467942f9e55
+      - req-d58332dd-cb33-4fcd-ba6c-7ed9a2e8f919
       Date:
-      - Tue, 08 Jan 2019 19:17:33 GMT
+      - Mon, 04 Mar 2019 20:04:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -2865,7 +2748,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -2876,9 +2759,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-b569581b-8c7c-4d5e-a3b5-816d5177eef3
+      - req-23a36ab7-1593-41c3-831c-8d54fff0365c
       Date:
-      - Tue, 08 Jan 2019 19:17:33 GMT
+      - Mon, 04 Mar 2019 20:04:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2905,7 +2788,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:33 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -2920,7 +2803,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -2931,9 +2814,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-ff811cc8-2f9b-4bbe-a05c-94038a0f6d46
+      - req-eeb80e66-974c-46a6-aa23-c527d3e3408d
       Date:
-      - Tue, 08 Jan 2019 19:17:34 GMT
+      - Mon, 04 Mar 2019 20:04:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -2960,7 +2843,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -2975,7 +2858,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -2986,9 +2869,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-22ce9b39-34af-4674-acfd-2ca30972b2cc
+      - req-190ee1c5-8ff9-4333-acb7-d1bcc288a413
       Date:
-      - Tue, 08 Jan 2019 19:17:34 GMT
+      - Mon, 04 Mar 2019 20:04:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -3015,7 +2898,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/template
@@ -3030,7 +2913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3041,9 +2924,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fbcfc7c4-e79e-4935-adab-692db21e3906
+      - req-635bc0b0-1927-4ece-82b8-1566c5631583
       Date:
-      - Tue, 08 Jan 2019 19:17:34 GMT
+      - Mon, 04 Mar 2019 20:04:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3099,7 +2982,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -3114,7 +2997,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3125,9 +3008,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7a0b313d-7f76-4a8e-84a8-f2c44332de38
+      - req-fa32d16b-9e20-48da-b7a3-6832d0331790
       Date:
-      - Tue, 08 Jan 2019 19:17:34 GMT
+      - Mon, 04 Mar 2019 20:04:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3139,7 +3022,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000
@@ -3154,7 +3037,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3167,9 +3050,9 @@ http_interactions:
       Content-Length:
       - '3981'
       X-Compute-Request-Id:
-      - req-81986861-830d-4e50-8764-bdfc06f8aace
+      - req-5c6cb914-64c7-4014-b7f5-aee5cf0b06a3
       Date:
-      - Tue, 08 Jan 2019 19:17:34 GMT
+      - Mon, 04 Mar 2019 20:04:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b",
@@ -3215,7 +3098,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:34 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=96fef14f-5338-4d58-8b89-58b627b27b9b
@@ -3230,7 +3113,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3243,9 +3126,9 @@ http_interactions:
       Content-Length:
       - '4045'
       X-Compute-Request-Id:
-      - req-d30e5eb5-b184-48fa-8932-ecc6ef0d73bb
+      - req-d4b8c073-3aab-4520-bcfc-34e8b3ca8105
       Date:
-      - Tue, 08 Jan 2019 19:17:35 GMT
+      - Mon, 04 Mar 2019 20:04:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876",
@@ -3291,7 +3174,7 @@ http_interactions:
         [], "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 3, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca1fc357-ee31-45e9-a38d-98723d6c8876
@@ -3306,7 +3189,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3319,9 +3202,9 @@ http_interactions:
       Content-Length:
       - '4127'
       X-Compute-Request-Id:
-      - req-7fe66b7e-6671-47f1-b187-236b98bc5dac
+      - req-376f561d-da40-45fd-b9e8-4d8d1a2b21ff
       Date:
-      - Tue, 08 Jan 2019 19:17:35 GMT
+      - Mon, 04 Mar 2019 20:04:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
@@ -3369,7 +3252,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -3384,7 +3267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3397,9 +3280,9 @@ http_interactions:
       Content-Length:
       - '3796'
       X-Compute-Request-Id:
-      - req-f33cb36b-d726-44f8-a855-19790ebbfabc
+      - req-5f52d4c5-083c-4fd8-bc3a-a870a1853208
       Date:
-      - Tue, 08 Jan 2019 19:17:35 GMT
+      - Mon, 04 Mar 2019 20:04:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers_links": [{"href": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac",
@@ -3441,7 +3324,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:35 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/detail?limit=1000&marker=aa5907f3-8209-4dd0-b3ef-600431d85bac
@@ -3456,7 +3339,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3469,9 +3352,9 @@ http_interactions:
       Content-Length:
       - '1816'
       X-Compute-Request-Id:
-      - req-8ed2c69f-c78b-4df5-9a74-a66fafc9c0c9
+      - req-943a513a-f244-449a-bb00-84ffb462a368
       Date:
-      - Tue, 08 Jan 2019 19:17:35 GMT
+      - Mon, 04 Mar 2019 20:04:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": [{"status": "SHUTOFF", "updated": "2018-01-17T14:49:17Z",
@@ -3494,7 +3377,7 @@ http_interactions:
         "accessIPv4": "", "accessIPv6": "", "OS-EXT-STS:power_state": 4, "config_drive":
         "", "metadata": {}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/servers/detail?limit=1000
@@ -3509,7 +3392,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3522,14 +3405,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-877cd519-db2f-4297-9ea8-afb7bf11ea98
+      - req-dfd0ccec-72f9-4af3-bb44-eb869fd7ffeb
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/detail?limit=1000
@@ -3544,7 +3427,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3557,14 +3440,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-8706ba37-f07e-480a-a859-fefc39dc447e
+      - req-4ad5677c-3583-43bd-a7c9-cefeef2813ed
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/servers/detail?limit=1000
@@ -3579,7 +3462,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3592,14 +3475,14 @@ http_interactions:
       Content-Length:
       - '15'
       X-Compute-Request-Id:
-      - req-51ab7bd8-ad8d-458e-a5a3-6c4bd7b4aef8
+      - req-254342ec-f723-4428-8b7d-e2935d76ce5a
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"servers": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/template
@@ -3614,7 +3497,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3625,9 +3508,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-9f6b2172-d2a8-4e7e-8977-4aa113e20b3e
+      - req-ac161080-6686-46f3-996a-5b346f62886f
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:39 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3683,7 +3566,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -3698,7 +3581,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3709,9 +3592,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-5ae02e7d-dbf0-4b22-9acc-b9a2d5fa0710
+      - req-a2202f1f-2f4f-476e-b377-3ddf151e241b
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3723,7 +3606,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -3738,7 +3621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3749,9 +3632,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-fa7de303-4ad9-4630-a448-c40a101419da
+      - req-4c349bad-a685-48af-8085-6764476d56bc
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -3807,7 +3690,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -3822,7 +3705,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f509df5757e74758a2b63e4819463a65
+      - 8df13c638a304ef6a1322554d92dcba8
   response:
     status:
       code: 200
@@ -3833,9 +3716,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-386ec5b8-b4d5-4e08-94c3-8b2eb5856722
+      - req-abcd2ce4-dd32-4f49-92f8-cef08380bb57
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -3847,7 +3730,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -3862,7 +3745,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3875,9 +3758,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-9a2b595e-2aa6-4d2a-ac5d-38b67a6e7ddc
+      - req-a14a417e-352e-4c4c-8beb-e35be583678a
       Date:
-      - Tue, 08 Jan 2019 19:17:36 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3886,7 +3769,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -3901,7 +3784,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - c9608acb08f44c3a92f9ffc78a67863d
+      - 47f2afbbfa5f4411979a900f0994fdd5
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3914,9 +3797,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-5970292f-888b-4e7e-8c29-e59e1aa4a891
+      - req-884ebeec-4126-4102-bceb-bfb93a18ebb9
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3925,7 +3808,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -3940,7 +3823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3953,9 +3836,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-8d160c5a-35c4-4fae-943a-de8ee4352076
+      - req-e0028bb6-ddef-4dba-a096-2f9d6af1831f
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -3964,7 +3847,7 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -3979,7 +3862,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bc9cdb205a564aa18172d2f9b1240edd
+      - a3f143f7b78e4cdbaee45e31e71919b7
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -3992,9 +3875,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Compute-Request-Id:
-      - req-ee0dd41e-2724-4786-a9eb-af43ba561644
+      - req-bc6abdd1-2bc4-493c-985c-3c500a89b55c
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"injected_file_content_bytes": 10240, "metadata_items":
@@ -4003,7 +3886,88 @@ http_interactions:
         10, "security_group_rules": 20, "injected_files": 5, "cores": 20, "fixed_ips":
         -1, "injected_file_path_bytes": 255, "security_groups": 10}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:41 GMT
+- request:
+    method: post
+    uri: http://11.22.33.44:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: '{"auth":{"passwordCredentials":{"username":"admin","password":"password_2WpEraURh"},"tenantName":"admin"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Mar 2019 20:04:41 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux)
+      Vary:
+      - X-Auth-Token,Accept-Encoding
+      X-Openstack-Request-Id:
+      - req-45190183-0537-44f3-971f-04ea9f055103
+      Content-Length:
+      - '4170'
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:41.243596", "expires":
+        "2019-03-04T21:04:41Z", "id": "d628840d7b6d4da1967fa1470cfd7230", "tenant":
+        {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
+        "name": "admin"}, "audit_ids": ["wh6D7-VYT729y5M5rp7rlA"]}, "serviceCatalog":
+        [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
+        "http://10.8.99.233:9696", "region": "RegionOne", "internalURL": "http://10.8.99.233:9696",
+        "id": "5b097055aff24a40aa4cd2d7317c9108", "publicURL": "http://10.8.99.233:9696"}],
+        "endpoints_links": [], "type": "network", "name": "neutron"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "13c4208d548d4bcdaedfe8296b6559ee", "publicURL": "http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volumev2", "name": "cinderv2"}, {"endpoints":
+        [{"adminURL": "http://127.0.0.1:8774/v3", "region": "RegionOne", "internalURL":
+        "http://127.0.0.1:8774/v3", "id": "3874f107e1a0461596883a12743dbcc0", "publicURL":
+        "http://127.0.0.1:8774/v3"}], "endpoints_links": [], "type": "computev3",
+        "name": "novav3"}, {"endpoints": [{"adminURL": "http://10.8.99.233:9292",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:9292", "id": "75fcb24891654062ae1703e6b92f6018",
+        "publicURL": "http://10.8.99.233:9292"}], "endpoints_links": [], "type": "image",
+        "name": "glance"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8777",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8777", "id": "2c972a2880d1453aad86104dcda88a55",
+        "publicURL": "http://10.8.99.233:8777"}], "endpoints_links": [], "type": "metering",
+        "name": "ceilometer"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "410c753013fb430c9998f22f68c4cb18", "publicURL": "http://10.8.99.233:8776/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8773/services/Admin", "region": "RegionOne",
+        "internalURL": "http://10.8.99.233:8773/services/Cloud", "id": "2833b001aa814ddf9216479d379cdac1",
+        "publicURL": "http://10.8.99.233:8773/services/Cloud"}], "endpoints_links":
+        [], "type": "ec2", "name": "nova_ec2"}, {"endpoints": [{"adminURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "region": "RegionOne", "internalURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a",
+        "id": "a29a931a5667478c8b3724506a286144", "publicURL": "http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "orchestration", "name": "heat"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:8080", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a", "id":
+        "7a2262abf515414ea08b3beedc87e51e", "publicURL": "http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a"}],
+        "endpoints_links": [], "type": "object-store", "name": "swift"}, {"endpoints":
+        [{"adminURL": "http://10.8.99.233:35357/v2.0", "region": "RegionOne", "internalURL":
+        "http://10.8.99.233:5000/v2.0", "id": "5d1b7edf24e14ce29abaeee69e84e529",
+        "publicURL": "http://10.8.99.233:5000/v2.0"}], "endpoints_links": [], "type":
+        "identity", "name": "keystone"}], "user": {"username": "admin", "roles_links":
+        [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [{"name": "admin"},
+        {"name": "_member_"}, {"name": "heat_stack_owner"}], "name": "admin"}, "metadata":
+        {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
+        "725d26e4ae494cc689c60f857e347267"]}}}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4021,13 +3985,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-96cd3bc3-0057-4242-ba05-a1ed7612682a
+      - req-99e40d54-ae46-47c9-b369-56fb1fa96d88
       Content-Length:
       - '4117'
       Connection:
@@ -4036,10 +4000,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:37.476489", "expires":
-        "2019-01-08T20:17:37Z", "id": "897f85fb408f4fa7bd146f92c577ada2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:41.651829", "expires":
+        "2019-03-04T21:04:41Z", "id": "758e28c20eb040808831d1f233d6afcf", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["fZguIyg7Q2-qdVVtjp_fSw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["3xfV8TeyRpeXk3ixG4lSeg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4083,7 +4047,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4101,13 +4065,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:41 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2055745a-c660-48f1-9f50-6d0975fbc5d5
+      - req-f117ef1d-adb5-4408-a55a-c45ba479737d
       Content-Length:
       - '4131'
       Connection:
@@ -4116,10 +4080,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:37.672542", "expires":
-        "2019-01-08T20:17:37Z", "id": "fd6028be696f431481288d373310a021", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:41.920230", "expires":
+        "2019-03-04T21:04:41Z", "id": "99f5fec7e7264e0b95e60ab36c7f168f", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["eqWqdS8aRuq8n3iwdi-xjA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["rV_PHL7xRmqPE1gu8GtvbQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4163,7 +4127,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:41 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4181,13 +4145,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:37 GMT
+      - Mon, 04 Mar 2019 20:04:42 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e591b02c-d843-4330-9355-8bb54e2cc6ab
+      - req-6d9b3a01-3767-4747-8c4f-70db6d8b26b5
       Content-Length:
       - '4118'
       Connection:
@@ -4196,10 +4160,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:37.867113", "expires":
-        "2019-01-08T20:17:37Z", "id": "a4e61da95e9e4b5fb1d75a643bebd7fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:42.188723", "expires":
+        "2019-03-04T21:04:42Z", "id": "d137be3e233a4ebfbf3b80c591dc07d3", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vbLAJX0WRteLPFWWi6C82w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hRXVg6W-R-y2Ld_ynnY6Bg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4243,7 +4207,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a//os-quota-sets/69f8f7205ade4aa59084c32c83e60b5a
@@ -4258,22 +4222,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f6dfdbf6-9a21-4243-8ae1-6f80a6c63e55
+      - req-14c18a47-b533-42d2-b9d8-0d424b4c25af
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-f6dfdbf6-9a21-4243-8ae1-6f80a6c63e55
+      - req-14c18a47-b533-42d2-b9d8-0d424b4c25af
       Date:
-      - Tue, 08 Jan 2019 19:17:38 GMT
+      - Mon, 04 Mar 2019 20:04:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4283,7 +4247,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "69f8f7205ade4aa59084c32c83e60b5a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8//os-quota-sets/b458a5c25c3749758f4c0661940b3ba8
@@ -4298,22 +4262,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd6028be696f431481288d373310a021
+      - 99f5fec7e7264e0b95e60ab36c7f168f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-397473bb-d72c-4cdb-81b4-2bfe9026984f
+      - req-d242ae8d-fe1c-4408-8f2d-14d628ea4658
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-397473bb-d72c-4cdb-81b4-2bfe9026984f
+      - req-d242ae8d-fe1c-4408-8f2d-14d628ea4658
       Date:
-      - Tue, 08 Jan 2019 19:17:38 GMT
+      - Mon, 04 Mar 2019 20:04:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4323,7 +4287,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "b458a5c25c3749758f4c0661940b3ba8"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a//os-quota-sets/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4338,22 +4302,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
+      - d628840d7b6d4da1967fa1470cfd7230
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ab72425a-1621-4368-a2d7-2c3f01288822
+      - req-2ffc313c-42e9-43b3-b1e4-2f2e76f4bc87
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-ab72425a-1621-4368-a2d7-2c3f01288822
+      - req-2ffc313c-42e9-43b3-b1e4-2f2e76f4bc87
       Date:
-      - Tue, 08 Jan 2019 19:17:38 GMT
+      - Mon, 04 Mar 2019 20:04:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4363,7 +4327,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e54e5c3c19e34720b05661f2ea1ea00a"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608//os-quota-sets/e8f744b1fc6a487681d35fb275252608
@@ -4378,22 +4342,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e61da95e9e4b5fb1d75a643bebd7fe
+      - d137be3e233a4ebfbf3b80c591dc07d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-1a52b635-f75d-44c2-8992-d0358773aa92
+      - req-05cb0bda-51c5-4f5e-9f76-b08aca3c1751
       Content-Type:
       - application/json
       Content-Length:
       - '441'
       X-Openstack-Request-Id:
-      - req-1a52b635-f75d-44c2-8992-d0358773aa92
+      - req-05cb0bda-51c5-4f5e-9f76-b08aca3c1751
       Date:
-      - Tue, 08 Jan 2019 19:17:39 GMT
+      - Mon, 04 Mar 2019 20:04:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota_set": {"per_volume_gigabytes": -1, "snapshots_iscsi": -1, "gigabytes":
@@ -4403,7 +4367,7 @@ http_interactions:
         -1, "backups": 10, "volumes_EmsRefreshSpec-VolumeType": -1, "gigabytes_iscsi":
         -1, "id": "e8f744b1fc6a487681d35fb275252608"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4421,13 +4385,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:39 GMT
+      - Mon, 04 Mar 2019 20:04:43 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f8456dab-d99f-477c-bee0-84961012d2d9
+      - req-5b8da58e-f060-4a91-8b85-e87bd6a2a69d
       Content-Length:
       - '4170'
       Connection:
@@ -4436,10 +4400,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:39.444504", "expires":
-        "2019-01-08T20:17:39Z", "id": "eb2a3185574341419ca1210faf09c28c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:43.889158", "expires":
+        "2019-03-04T21:04:43Z", "id": "bd1927f05fc440b19d7a460c65042a7d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["CYhU6chlQnSjhV1RvXl-Jg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["n7dN1ISSS9-SDCr8DdEr9Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -4484,7 +4448,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:43 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4502,13 +4466,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:39 GMT
+      - Mon, 04 Mar 2019 20:04:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6a715abe-7194-4f8a-a735-6419e3074076
+      - req-54f24835-dd42-496d-a6de-cb50f5404b0b
       Content-Length:
       - '4117'
       Connection:
@@ -4517,10 +4481,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:39.629739", "expires":
-        "2019-01-08T20:17:39Z", "id": "9e016e7082124a47a7b3c172821deca1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:44.107245", "expires":
+        "2019-03-04T21:04:44Z", "id": "a39f89acb99d4d72a00b99e12433ba04", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZoKPNGvsRMSTgX8ZbqXv0A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["-3QWplQbQ5Cl5chcMefk3Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -4564,7 +4528,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4582,13 +4546,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:39 GMT
+      - Mon, 04 Mar 2019 20:04:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-37243e0f-163b-43ab-86b7-89fb8caa05e2
+      - req-a41e1862-1125-45df-9848-7f1163c6d00c
       Content-Length:
       - '4131'
       Connection:
@@ -4597,10 +4561,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:39.816282", "expires":
-        "2019-01-08T20:17:39Z", "id": "1cf65f95ca414e68a294c3673b951f9f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:44.315454", "expires":
+        "2019-03-04T21:04:44Z", "id": "48d694993cb54e429b26be1a1dd63661", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["C2DCBubsTPWhwFDvBE4NtQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Ccg2po6dRWe3YQD3om7C0Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -4644,7 +4608,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:44 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4662,13 +4626,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:39 GMT
+      - Mon, 04 Mar 2019 20:04:44 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5f041fd9-1d4f-409d-af1c-96ce52081244
+      - req-acc4461a-1f8d-4973-9054-49a9641b8e3a
       Content-Length:
       - '4118'
       Connection:
@@ -4677,10 +4641,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:40.018279", "expires":
-        "2019-01-08T20:17:40Z", "id": "f96e69ec3f224fa182bab4e00005737f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:44.657646", "expires":
+        "2019-03-04T21:04:44Z", "id": "ed35474721a2420b96d3dfa3bdf69b97", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["drPjRJbDSHyie02sn8VYCg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["KMPlaQ4NQXuV1EjjU33AoQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -4724,7 +4688,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/69f8f7205ade4aa59084c32c83e60b5a
@@ -4739,7 +4703,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - a39f89acb99d4d72a00b99e12433ba04
   response:
     status:
       code: 200
@@ -4750,16 +4714,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-732466fc-80ed-4d2f-ad91-d6758c307fe7
+      - req-d595fd6c-9a68-4631-a486-3be5b734bbe2
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 20, "network": 20, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/b458a5c25c3749758f4c0661940b3ba8
@@ -4774,7 +4738,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1cf65f95ca414e68a294c3673b951f9f
+      - 48d694993cb54e429b26be1a1dd63661
   response:
     status:
       code: 200
@@ -4785,16 +4749,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-932b8d53-2bba-45e5-8fc1-87b517e6dec0
+      - req-b1b762e9-845f-482d-b1c4-cd2835204b26
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e54e5c3c19e34720b05661f2ea1ea00a
@@ -4809,7 +4773,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb2a3185574341419ca1210faf09c28c
+      - bd1927f05fc440b19d7a460c65042a7d
   response:
     status:
       code: 200
@@ -4820,16 +4784,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-a3c9fab4-c022-4d35-8e00-96803d1e61a7
+      - req-79c4adf7-249d-4f3a-9747-2de14a4c5131
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0//quotas/e8f744b1fc6a487681d35fb275252608
@@ -4844,7 +4808,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f96e69ec3f224fa182bab4e00005737f
+      - ed35474721a2420b96d3dfa3bdf69b97
   response:
     status:
       code: 200
@@ -4855,16 +4819,16 @@ http_interactions:
       Content-Length:
       - '171'
       X-Openstack-Request-Id:
-      - req-1daee2d1-0309-4151-93b8-64f63627ea57
+      - req-7f9e4cd6-5f21-45c4-98b1-a59ebf8da46d
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"quota": {"subnet": 10, "network": 10, "floatingip": 50, "subnetpool":
         -1, "security_group_rule": 100, "security_group": 10, "router": 10, "rbac_policy":
         10, "port": 50}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/4bb36934-fd61-4a19-ab9d-28fbbda0c7f0/os-volume_attachments
@@ -4879,7 +4843,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4892,15 +4856,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-71e1c4ad-e95a-4f75-9b9e-522842ca5abb
+      - req-9ca86bde-fc99-4ab5-b2e5-a6426739d76c
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vda", "serverId": "4bb36934-fd61-4a19-ab9d-28fbbda0c7f0",
         "id": "b124469d-a857-4b39-abe9-d0e63985f834", "volumeId": "b124469d-a857-4b39-abe9-d0e63985f834"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -4915,7 +4879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 31655a1d4338432da409ea11f191757a
+      - 2261a117e1e34a7bad548131c5933df8
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4928,15 +4892,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c6a09163-23ef-41d1-a8e9-b8b9ade6e364
+      - req-1359f35e-c827-4da5-bcec-24d4fd84425e
       Date:
-      - Tue, 08 Jan 2019 19:17:40 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:40 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:45 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -4954,13 +4918,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:45 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8e95bbb1-e5ca-490c-a5dc-35934e244e57
+      - req-11dc61e0-98d8-4c7e-bb34-2eefb0a10621
       Content-Length:
       - '4170'
       Connection:
@@ -4969,10 +4933,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:41.146934", "expires":
-        "2019-01-08T20:17:41Z", "id": "8c0cd4b247054ad59b15e4efc503dc74", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:45.988042", "expires":
+        "2019-03-04T21:04:45Z", "id": "a0494f2a364242649475c9195bdb3a9b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3ELQYFZzQfqohUU1FIYAOg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ZxEYXd1vQOq6FHsAOf8kjQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5017,7 +4981,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:46 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -5035,13 +4999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9ef6d5ca-c07a-4c2c-ae89-a9c622dbf6e2
+      - req-c80d4735-4c37-49bf-9e90-154431b8abaa
       Content-Length:
       - '4170'
       Connection:
@@ -5050,10 +5014,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:41.336759", "expires":
-        "2019-01-08T20:17:41Z", "id": "59ab7ad9974b4d37ad3ad14097e333b0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:46.184255", "expires":
+        "2019-03-04T21:04:46Z", "id": "3c0c80c1850c40669b4d66c59391de64", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NCtg3ANxSmKATiV8AiTe0Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PG2oLQDUTmWNXSwfUG82cA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -5098,7 +5062,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-aggregates
@@ -5113,7 +5077,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 479321cb2ce5472a91d67c5ce1447bcb
+      - 2e70ac4dba134dd1a59448923ffc549c
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5126,14 +5090,14 @@ http_interactions:
       Content-Length:
       - '18'
       X-Compute-Request-Id:
-      - req-4f5db2f4-edd8-4924-b9a6-3dd906956ca4
+      - req-9b7e9cc9-ea0d-4c6f-97e7-cd4552b646c4
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"aggregates": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available
@@ -5148,22 +5112,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-88d5ec08-0e45-445e-b9dc-7a55822693e8
+      - req-83c2b548-93f9-4efe-b56a-e99b66b583b7
       Content-Type:
       - application/json
       Content-Length:
       - '2723'
       X-Openstack-Request-Id:
-      - req-88d5ec08-0e45-445e-b9dc-7a55822693e8
+      - req-83c2b548-93f9-4efe-b56a-e99b66b583b7
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&status=available&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5196,7 +5160,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd&status=available
@@ -5211,22 +5175,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-91a05fae-8207-47ea-9d86-b0ac1e7eae39
+      - req-4c659fa1-bc74-4627-ac0d-e8a4980f2ac9
       Content-Type:
       - application/json
       Content-Length:
       - '1180'
       X-Openstack-Request-Id:
-      - req-91a05fae-8207-47ea-9d86-b0ac1e7eae39
+      - req-4c659fa1-bc74-4627-ac0d-e8a4980f2ac9
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": [{"migration_status": null, "attachments": [], "links":
@@ -5243,7 +5207,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-FromSnapshot", "bootable": "false", "created_at":
         "2016-11-11T13:49:26.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000&status=available
@@ -5258,27 +5222,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd6028be696f431481288d373310a021
+      - 99f5fec7e7264e0b95e60ab36c7f168f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7528c307-7690-4559-97db-154c29ec51d5
+      - req-6df55acf-5940-4b5e-a431-8965b3335fb7
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-7528c307-7690-4559-97db-154c29ec51d5
+      - req-6df55acf-5940-4b5e-a431-8965b3335fb7
       Date:
-      - Tue, 08 Jan 2019 19:17:41 GMT
+      - Mon, 04 Mar 2019 20:04:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000&status=available
@@ -5293,27 +5257,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
+      - d628840d7b6d4da1967fa1470cfd7230
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a39e8a1f-b0f3-44ed-b86e-21092149baf9
+      - req-1a53f313-23a7-4083-a87c-a39e0a12d751
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-a39e8a1f-b0f3-44ed-b86e-21092149baf9
+      - req-1a53f313-23a7-4083-a87c-a39e0a12d751
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000&status=available
@@ -5328,27 +5292,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e61da95e9e4b5fb1d75a643bebd7fe
+      - d137be3e233a4ebfbf3b80c591dc07d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-88079fe0-4a25-4df8-8b60-c2b8c6748ac5
+      - req-aaca4a31-3652-4c44-ba07-55ba1241a03c
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-88079fe0-4a25-4df8-8b60-c2b8c6748ac5
+      - req-aaca4a31-3652-4c44-ba07-55ba1241a03c
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -5363,22 +5327,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-7f3d05bd-8880-4fcd-bd30-20f8018aae69
+      - req-e82951a4-53f9-47ef-b84b-c39236da0b37
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-7f3d05bd-8880-4fcd-bd30-20f8018aae69
+      - req-e82951a4-53f9-47ef-b84b-c39236da0b37
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5393,7 +5357,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available
@@ -5408,22 +5372,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d8cf426b-451e-4d79-9ecc-45a85810a499
+      - req-44caba63-84a9-4679-a6ed-67b333726f7c
       Content-Type:
       - application/json
       Content-Length:
       - '1081'
       X-Openstack-Request-Id:
-      - req-d8cf426b-451e-4d79-9ecc-45a85810a499
+      - req-44caba63-84a9-4679-a6ed-67b333726f7c
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&status=available&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -5438,7 +5402,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -5453,27 +5417,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd6028be696f431481288d373310a021
+      - 99f5fec7e7264e0b95e60ab36c7f168f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-73fb7dca-47d6-4371-b4d0-f0f4e5b0e8a3
+      - req-954d38ab-8090-447b-9f8e-8cf3364e678e
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-73fb7dca-47d6-4371-b4d0-f0f4e5b0e8a3
+      - req-954d38ab-8090-447b-9f8e-8cf3364e678e
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000&status=available
@@ -5488,27 +5452,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd6028be696f431481288d373310a021
+      - 99f5fec7e7264e0b95e60ab36c7f168f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c67b8956-860c-485d-b134-7c866bb80648
+      - req-c0fb99c8-f13c-4713-9da5-01933133e5c8
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c67b8956-860c-485d-b134-7c866bb80648
+      - req-c0fb99c8-f13c-4713-9da5-01933133e5c8
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -5523,27 +5487,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
+      - d628840d7b6d4da1967fa1470cfd7230
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-adff0fe9-2d29-476c-bb59-9b3d9642f2ca
+      - req-003165ec-229d-4e7f-affd-310e9dd8137d
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-adff0fe9-2d29-476c-bb59-9b3d9642f2ca
+      - req-003165ec-229d-4e7f-affd-310e9dd8137d
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000&status=available
@@ -5558,27 +5522,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
+      - d628840d7b6d4da1967fa1470cfd7230
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c43d5996-143f-4bcb-a9d1-93ddf5b20971
+      - req-d2f99fce-4575-492e-948a-dc5ec40f8260
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-c43d5996-143f-4bcb-a9d1-93ddf5b20971
+      - req-d2f99fce-4575-492e-948a-dc5ec40f8260
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -5593,27 +5557,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e61da95e9e4b5fb1d75a643bebd7fe
+      - d137be3e233a4ebfbf3b80c591dc07d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-df6fa49f-199f-44c7-99aa-8f83dfa0d64d
+      - req-6bfa4621-df2e-4204-8b65-d8c4fbf83224
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-df6fa49f-199f-44c7-99aa-8f83dfa0d64d
+      - req-6bfa4621-df2e-4204-8b65-d8c4fbf83224
       Date:
-      - Tue, 08 Jan 2019 19:17:42 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000&status=available
@@ -5628,27 +5592,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e61da95e9e4b5fb1d75a643bebd7fe
+      - d137be3e233a4ebfbf3b80c591dc07d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-be93239e-5168-49ae-92d9-c71cf4eeb3ff
+      - req-f9879062-4135-4853-9128-d175c79e1cac
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-be93239e-5168-49ae-92d9-c71cf4eeb3ff
+      - req-f9879062-4135-4853-9128-d175c79e1cac
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -5663,22 +5627,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-a6531800-4933-4f29-b744-b1e636e42347
+      - req-129d8c23-9d34-4d51-bc0d-7659916bad51
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-a6531800-4933-4f29-b744-b1e636e42347
+      - req-129d8c23-9d34-4d51-bc0d-7659916bad51
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -5711,7 +5675,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -5726,22 +5690,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-57146209-a46d-4db3-b15e-0b2013340ad4
+      - req-0a4c9266-0131-48f4-afa6-77b9269832be
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-57146209-a46d-4db3-b15e-0b2013340ad4
+      - req-0a4c9266-0131-48f4-afa6-77b9269832be
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -5782,7 +5746,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -5797,22 +5761,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-16c74f28-de27-4f3f-8382-fdd544daecae
+      - req-0a66776a-f8fc-40a8-b82e-4eac5845b0db
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-16c74f28-de27-4f3f-8382-fdd544daecae
+      - req-0a66776a-f8fc-40a8-b82e-4eac5845b0db
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -5846,7 +5810,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -5861,27 +5825,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 897f85fb408f4fa7bd146f92c577ada2
+      - 758e28c20eb040808831d1f233d6afcf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-855a30d5-cf41-44b9-9c72-7ffe11483132
+      - req-e39c5f7d-c5b1-43b4-a69e-fc6c2251d1a0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-855a30d5-cf41-44b9-9c72-7ffe11483132
+      - req-e39c5f7d-c5b1-43b4-a69e-fc6c2251d1a0
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -5896,27 +5860,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd6028be696f431481288d373310a021
+      - 99f5fec7e7264e0b95e60ab36c7f168f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-19eab773-6e9d-437c-817d-47064a821e86
+      - req-3fdd7452-bf85-467d-97b8-662a443857b5
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-19eab773-6e9d-437c-817d-47064a821e86
+      - req-3fdd7452-bf85-467d-97b8-662a443857b5
       Date:
-      - Tue, 08 Jan 2019 19:17:43 GMT
+      - Mon, 04 Mar 2019 20:04:49 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -5931,27 +5895,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a6ca609511384a2db25cf1cf44efc23c
+      - d628840d7b6d4da1967fa1470cfd7230
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6d04eeaa-d3f8-487d-9cdf-ae2cd8d9da50
+      - req-fdc2203e-9678-46a2-8786-2407faebeb41
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6d04eeaa-d3f8-487d-9cdf-ae2cd8d9da50
+      - req-fdc2203e-9678-46a2-8786-2407faebeb41
       Date:
-      - Tue, 08 Jan 2019 19:17:44 GMT
+      - Mon, 04 Mar 2019 20:04:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:50 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -5966,27 +5930,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a4e61da95e9e4b5fb1d75a643bebd7fe
+      - d137be3e233a4ebfbf3b80c591dc07d3
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0288c4c0-41b4-4dd4-8415-a0bd5187a67b
+      - req-a106b42a-a259-4298-bf9d-89d436acf8d0
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-0288c4c0-41b4-4dd4-8415-a0bd5187a67b
+      - req-a106b42a-a259-4298-bf9d-89d436acf8d0
       Date:
-      - Tue, 08 Jan 2019 19:17:44 GMT
+      - Mon, 04 Mar 2019 20:04:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:50 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6004,13 +5968,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:45 GMT
+      - Mon, 04 Mar 2019 20:04:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f1708493-4f24-4218-a61e-3a8e11ac564c
+      - req-4fcf5681-7b26-47d8-a015-1869550dd3f1
       Content-Length:
       - '4170'
       Connection:
@@ -6019,10 +5983,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:45.362844", "expires":
-        "2019-01-08T20:17:45Z", "id": "723d5159860c49f0a0a201f2ad1b79ff", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:51.372522", "expires":
+        "2019-03-04T21:04:51Z", "id": "39202ed92279470498207dc94c202a0e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["_UZxRsQOTSCek-t5_VHMCg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YIxFzoFjRM2JRZkD0LO5JA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6067,7 +6031,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6085,13 +6049,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:45 GMT
+      - Mon, 04 Mar 2019 20:04:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-50f3c219-1728-426a-b65a-b0d002349931
+      - req-cba3caee-78df-4bcb-bb71-0af4b9e5c2a0
       Content-Length:
       - '4170'
       Connection:
@@ -6100,10 +6064,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:45.559230", "expires":
-        "2019-01-08T20:17:45Z", "id": "f6e65830be014fe8ae85b543627fc233", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:51.563060", "expires":
+        "2019-03-04T21:04:51Z", "id": "a3c3e455db0a41bd84973372071ee5b4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hVqWEoztQiaJoRKPYevTsA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["sg16POX7SAWCtr0X5PkZWg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6148,7 +6112,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks
@@ -6163,7 +6127,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -6174,37 +6138,27 @@ http_interactions:
       Content-Length:
       - '5330'
       X-Openstack-Request-Id:
-      - req-0420059b-1ddc-44d2-b96b-68bbe9201b97
+      - req-57e270d4-834f-4d24-ba4c-7f60d6cc2c74
       Date:
-      - Tue, 08 Jan 2019 19:17:45 GMT
+      - Mon, 04 Mar 2019 20:04:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"networks": [{"status": "ACTIVE", "subnets": ["68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "d71653c5-34d2-47bd-9cd2-d93330a34d44"], "name": "EmsRefreshSpec-NetworkPublic_50",
-        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
-        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
-        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
-        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
-        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
-        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
-        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
-        53}, {"status": "ACTIVE", "subnets": ["841b5584-f86f-4abd-9bc2-f445b8bc860b",
-        "39628ee0-d5ff-4a88-ae66-80442e5feefd"], "name": "EmsRefreshSpec-NetworkPrivate_30",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
-        79}, {"status": "ACTIVE", "subnets": ["edfcb49b-e917-4897-b8ae-859ef3dae2de",
-        "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
-        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
-        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
-        57}, {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
+      string: '{"networks": [{"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
         "name": "EmsRefreshSpec-NetworkPublic", "provider:physical_network": "public_net_0",
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
+        null}, {"status": "ACTIVE", "subnets": ["39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "841b5584-f86f-4abd-9bc2-f445b8bc860b"], "name": "EmsRefreshSpec-NetworkPrivate_30",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "provider:segmentation_id":
+        79}, {"status": "ACTIVE", "subnets": ["826fd5a9-7a7a-4c40-a9b1-bd69041bbad4",
+        "edfcb49b-e917-4897-b8ae-859ef3dae2de"], "name": "EmsRefreshSpec-IsolatedNetworkPrivate_2",
+        "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
+        "vxlan", "id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "provider:segmentation_id":
+        57}, {"status": "ACTIVE", "subnets": ["2092b802-1034-4fb8-9c5e-1ec61d1e463f"],
         "name": "EmsRefreshSpec-NetworkPrivate_20", "provider:physical_network": null,
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
@@ -6234,19 +6188,29 @@ http_interactions:
         "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
         0, "router:external": true, "shared": false, "provider:network_type": "flat",
         "id": "64bf0546-b600-4bd7-a519-9353bde2e235", "provider:segmentation_id":
-        null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
+        null}, {"status": "ACTIVE", "subnets": ["d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2"], "name": "EmsRefreshSpec-NetworkPublic_50",
+        "provider:physical_network": "public_net_5", "admin_state_up": true, "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "mtu": 0, "router:external": true, "shared":
+        false, "provider:network_type": "flat", "id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "provider:segmentation_id": null}, {"status": "ACTIVE", "subnets": ["448a986a-19a9-4684-ab6e-25cbf19ae30d"],
         "name": "EmsRefreshSpec-IsolatedNetworkPrivate_1", "provider:physical_network":
         null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "560b4210-2b5a-4439-8d24-203e09478f48", "provider:segmentation_id":
-        54}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
+        54}, {"status": "ACTIVE", "subnets": ["bb23bb48-804d-4416-bac3-231db23841e8"],
+        "name": "EmsRefreshSpec-NetworkPrivate_2", "provider:physical_network": null,
+        "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "mtu":
+        0, "router:external": false, "shared": false, "provider:network_type": "vxlan",
+        "id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "provider:segmentation_id":
+        53}, {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
         "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6264,13 +6228,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:45 GMT
+      - Mon, 04 Mar 2019 20:04:51 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d4c219e4-7b26-4722-87ec-e4e3c3cd678e
+      - req-e2b80cfd-707f-4d33-8046-4aecbd1cafa1
       Content-Length:
       - '4170'
       Connection:
@@ -6279,10 +6243,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:45.933616", "expires":
-        "2019-01-08T20:17:45Z", "id": "e5fea3c256484af88414a3f3f28861ad", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:51.938092", "expires":
+        "2019-03-04T21:04:51Z", "id": "9bb1925cdad2400992e64904a15920b7", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7ONY8PXJTBKvcY3UneyQ2Q"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ZS_evSGbTDmg5F30zbdDYA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -6327,7 +6291,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:45 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:51 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6345,13 +6309,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:46 GMT
+      - Mon, 04 Mar 2019 20:04:52 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9ee0210-a66b-4e8e-9b28-bb3b0a5e957f
+      - req-088876ec-9ecb-432e-ad17-69e413495c69
       Content-Length:
       - '370'
       Connection:
@@ -6360,13 +6324,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:46.091991", "expires":
-        "2019-01-08T20:17:46Z", "id": "60d2006e1b964ca185211e5af5098dc9", "audit_ids":
-        ["VGwGPBG8RGKnICUt2aaHYw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:52.101971", "expires":
+        "2019-03-04T21:04:52Z", "id": "20bbc6e828cb4f32836d0bb59edb340d", "audit_ids":
+        ["GntIqoyBQ5SPnsL_ht9klg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:53 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -6381,20 +6345,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 60d2006e1b964ca185211e5af5098dc9
+      - 20bbc6e828cb4f32836d0bb59edb340d
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:46 GMT
+      - Mon, 04 Mar 2019 20:04:53 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-531a4f77-da31-4805-81b3-1f7e8e443530
+      - req-0a24377e-6d53-4f3d-a86f-06f4ea3d4ea0
       Content-Length:
       - '500'
       Connection:
@@ -6411,7 +6375,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:53 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6429,13 +6393,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:46 GMT
+      - Mon, 04 Mar 2019 20:04:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8e4acc97-b840-413d-9c8b-082a69633a6b
+      - req-ed7d0b49-ecf6-4e02-ba6d-3c86ab79fab2
       Content-Length:
       - '4117'
       Connection:
@@ -6444,10 +6408,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:46.415578", "expires":
-        "2019-01-08T20:17:46Z", "id": "4136d03b6eea4acb836829e248bbe1b5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:54.171628", "expires":
+        "2019-03-04T21:04:54Z", "id": "cf24f2ff842b49109659a48da3bc1667", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["P9hCWZG7QgaMpOGAy9TP5Q"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["EVhIN6dtQlOKuwYTHNbCAw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -6491,7 +6455,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6509,13 +6473,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:46 GMT
+      - Mon, 04 Mar 2019 20:04:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e701b26-5e94-4e2e-88c5-cfa986b0cab2
+      - req-01ae623a-0354-419e-9193-bc76ef6b3ddf
       Content-Length:
       - '4131'
       Connection:
@@ -6524,10 +6488,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:46.606212", "expires":
-        "2019-01-08T20:17:46Z", "id": "f09ba266906940bdbeb273e162789fb8", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:54.385531", "expires":
+        "2019-03-04T21:04:54Z", "id": "775e1bcbb6644c06bfe68b789b0091a4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["zv6QcIigRHaE65-8n8LX4Q"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DkrAqX3MSeGkory797fpZA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -6571,7 +6535,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:54 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -6589,13 +6553,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:46 GMT
+      - Mon, 04 Mar 2019 20:04:54 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-575cb78d-fdcf-4ac7-b176-b5865167f11b
+      - req-10e57b61-626f-4f95-977f-ffc1ec42316a
       Content-Length:
       - '4118'
       Connection:
@@ -6604,10 +6568,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:46.794604", "expires":
-        "2019-01-08T20:17:46Z", "id": "7ae5d5c6a04a49d29208fc3ed7a6deda", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:54.569963", "expires":
+        "2019-03-04T21:04:54Z", "id": "e972649b9fc6484a8b7dd4bf8c8153bb", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["1CIqrZQ3TyukkShFGxwMwg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["VjZrAZuMRWOgiG6lltsWqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -6651,7 +6615,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&show_nested=true
@@ -6666,7 +6630,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -6677,9 +6641,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-d9811526-88ad-4038-8a33-cd86cf1d7341
+      - req-aa802255-cce2-41ff-a9d6-978069ae0699
       Date:
-      - Tue, 08 Jan 2019 19:17:47 GMT
+      - Mon, 04 Mar 2019 20:04:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -6713,7 +6677,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks?limit=1000&marker=091e1e54-e01c-4ec5-a0ab-b00bee4d425c&show_nested=true
@@ -6728,7 +6692,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -6739,14 +6703,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-f6349c7e-f587-4810-923f-893c334c17d0
+      - req-3986ff4c-6011-4ce2-9f5f-fb11c989183e
       Date:
-      - Tue, 08 Jan 2019 19:17:47 GMT
+      - Mon, 04 Mar 2019 20:04:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:54 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/b458a5c25c3749758f4c0661940b3ba8/stacks?limit=1000&show_nested=true
@@ -6761,7 +6725,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f09ba266906940bdbeb273e162789fb8
+      - 775e1bcbb6644c06bfe68b789b0091a4
   response:
     status:
       code: 200
@@ -6772,14 +6736,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-ec857870-0095-446f-aad1-309b7df21e18
+      - req-674c9931-971f-4797-b1a3-8d67e0795a42
       Date:
-      - Tue, 08 Jan 2019 19:17:47 GMT
+      - Mon, 04 Mar 2019 20:04:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e54e5c3c19e34720b05661f2ea1ea00a/stacks?limit=1000&show_nested=true
@@ -6794,7 +6758,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e5fea3c256484af88414a3f3f28861ad
+      - 9bb1925cdad2400992e64904a15920b7
   response:
     status:
       code: 200
@@ -6805,14 +6769,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-98eaef23-9b50-4afa-8cc8-a1b0438eaeb5
+      - req-863dc9da-86c6-4dbf-81fa-49ad91c35f8e
       Date:
-      - Tue, 08 Jan 2019 19:17:47 GMT
+      - Mon, 04 Mar 2019 20:04:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/e8f744b1fc6a487681d35fb275252608/stacks?limit=1000&show_nested=true
@@ -6827,7 +6791,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7ae5d5c6a04a49d29208fc3ed7a6deda
+      - e972649b9fc6484a8b7dd4bf8c8153bb
   response:
     status:
       code: 200
@@ -6838,14 +6802,14 @@ http_interactions:
       Content-Length:
       - '14'
       X-Openstack-Request-Id:
-      - req-327c54aa-a703-499a-9ebb-7cd0d9051495
+      - req-12ab0026-4fe7-4529-8f0d-6bfdce672056
       Date:
-      - Tue, 08 Jan 2019 19:17:47 GMT
+      - Mon, 04 Mar 2019 20:04:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146
@@ -6860,7 +6824,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -6871,9 +6835,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-63404109-18d1-46a0-b7e4-f275951e5a60
+      - req-c5551ebb-d237-4709-926b-5a8840da6be9
       Date:
-      - Tue, 08 Jan 2019 19:17:48 GMT
+      - Mon, 04 Mar 2019 20:04:55 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6900,7 +6864,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:55 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17
@@ -6915,7 +6879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -6926,9 +6890,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-7fc1c8a3-29b5-4b96-8c7f-485b71432abf
+      - req-6ba6e951-66ea-426a-a0a6-da0a66ae86cc
       Date:
-      - Tue, 08 Jan 2019 19:17:48 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -6955,7 +6919,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c
@@ -6970,7 +6934,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -6981,9 +6945,9 @@ http_interactions:
       Content-Length:
       - '1864'
       X-Openstack-Request-Id:
-      - req-4b724a64-041b-45ad-a3cf-5217bbbe0150
+      - req-a7e8732d-95e0-43bf-871d-34bb5c3c2496
       Date:
-      - Tue, 08 Jan 2019 19:17:48 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stack": {"disable_rollback": true, "description": "Heat WordPress
@@ -7010,7 +6974,7 @@ http_interactions:
         a beautiful website or blog. This template installs a single-instance WordPress
         deployment using a local MySQL database to store the data.\n"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack3/45d2af82-eff9-4483-a1f0-f19c44d96146/resources
@@ -7025,7 +6989,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -7036,9 +7000,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-7335a377-ff2a-4b14-a95a-8ced95b1d67a
+      - req-6668881e-4bcd-46f7-be05-c1eae4530dfd
       Date:
-      - Tue, 08 Jan 2019 19:17:49 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7050,7 +7014,7 @@ http_interactions:
         changed", "physical_resource_id": "aa5907f3-8209-4dd0-b3ef-600431d85bac",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack2/4cf24b12-29fc-4529-a8ed-6b079dea7c17/resources
@@ -7065,7 +7029,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -7076,9 +7040,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c569ff7f-0548-48ce-99da-8f2426f35284
+      - req-8ea73538-84f1-4f03-807a-e6f4564426bc
       Date:
-      - Tue, 08 Jan 2019 19:17:49 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7090,7 +7054,7 @@ http_interactions:
         changed", "physical_resource_id": "219a737c-b4ad-430d-944a-a92a4834b12d",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -7105,7 +7069,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 4136d03b6eea4acb836829e248bbe1b5
+      - cf24f2ff842b49109659a48da3bc1667
   response:
     status:
       code: 200
@@ -7116,9 +7080,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-c69cad3e-3770-4cc7-b458-0ad8b067c72d
+      - req-b17ee5be-8ef1-4fcb-a8a7-8f9adfccaf8c
       Date:
-      - Tue, 08 Jan 2019 19:17:49 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -7130,7 +7094,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7148,13 +7112,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:49 GMT
+      - Mon, 04 Mar 2019 20:04:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bfde8410-5d8c-481a-bbc3-baf82063a46d
+      - req-b00126e0-dd12-4081-b231-26e0cf067e91
       Content-Length:
       - '4117'
       Connection:
@@ -7163,10 +7127,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:49.710327", "expires":
-        "2019-01-08T20:17:49Z", "id": "6b3d39e0d095434897ab610617f9d3d2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:56.927180", "expires":
+        "2019-03-04T21:04:56Z", "id": "42fefc40f58344b1811f73a76bdb5ed6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["w_75lqOwTaq5lqaB4iHZWw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["MD-LqVCMQUez-9pHUwWX9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -7210,7 +7174,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7228,13 +7192,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:49 GMT
+      - Mon, 04 Mar 2019 20:04:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-59e84792-2000-4d0b-9253-05bd2aa906ab
+      - req-e3704f3b-ad4b-4d9e-b4e9-601e66f79f31
       Content-Length:
       - '4131'
       Connection:
@@ -7243,10 +7207,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:49.895559", "expires":
-        "2019-01-08T20:17:49Z", "id": "f4a2af38042d422a85b3db478ef4c8e0", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:57.117263", "expires":
+        "2019-03-04T21:04:57Z", "id": "f68e0f8c48eb44c59849ddb2ff37e912", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BUYt0bY4RqimjfHuDD3UjQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["IxwZlU70TDmpxvaiLTSH9g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -7290,7 +7254,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -7308,13 +7272,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:50 GMT
+      - Mon, 04 Mar 2019 20:04:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f2e83167-f7ac-4542-a893-dddad8d599c6
+      - req-b0851be0-0efc-446b-8714-b0b99571e7de
       Content-Length:
       - '4118'
       Connection:
@@ -7323,10 +7287,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:50.085364", "expires":
-        "2019-01-08T20:17:50Z", "id": "7d0595959e4b41aaa315dd66885e8b22", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:57.307959", "expires":
+        "2019-03-04T21:04:57Z", "id": "85787735b9f040a980a2377a46f4063d", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["n7zqCFuyT1WBHZob58LOBw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["HB4jnRc5Rdmc238I5yggnA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -7370,7 +7334,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -7385,7 +7349,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -7396,46 +7360,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e8c59010-eac5-4e38-acc7-f48426c6a5df
+      - req-924a5f5d-11bf-4643-b1b0-8738f1ba125f
       Date:
-      - Tue, 08 Jan 2019 19:17:50 GMT
+      - Mon, 04 Mar 2019 20:04:57 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -7489,20 +7435,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -7517,7 +7481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -7528,16 +7492,39 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-9bd4c740-a617-44a3-a5aa-3495d310e45f
+      - req-448e9510-684a-4c57-97f0-9d4414482a12
       Date:
-      - Tue, 08 Jan 2019 19:17:50 GMT
+      - Mon, 04 Mar 2019 20:04:57 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -7546,12 +7533,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -7604,6 +7585,115 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:57 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - f68e0f8c48eb44c59849ddb2ff37e912
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1e57a9b9-e1ab-4ddc-8105-35158ada8dc3
+      Date:
+      - Mon, 04 Mar 2019 20:04:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -7621,6 +7711,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -7634,7 +7730,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -7649,7 +7745,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -7660,206 +7756,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-40a50613-8306-45b4-b03b-7b38f0d17744
+      - req-d622454d-8a1f-4b1c-8b16-bbe874778f3a
       Date:
-      - Tue, 08 Jan 2019 19:17:50 GMT
+      - Mon, 04 Mar 2019 20:04:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-93ce04f7-2762-45c4-9feb-49d3b8ae0a9e
-      Date:
-      - Tue, 08 Jan 2019 19:17:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -7885,62 +7820,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-bbff6460-ec2e-4ad6-9544-32a509d06d46
-      Date:
-      - Tue, 08 Jan 2019 19:17:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
@@ -7964,719 +7843,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-61397531-6cd5-4333-ba93-1a8da047d4e3
-      Date:
-      - Tue, 08 Jan 2019 19:17:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a4ef1492-a661-446f-b382-b6900bf8fda1
-      Date:
-      - Tue, 08 Jan 2019 19:17:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a084389e-23ca-4874-a095-358af7113aa3
-      Date:
-      - Tue, 08 Jan 2019 19:17:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-0d18d3e8-b620-4326-bd1e-dfdbccb1a89f
-      Date:
-      - Tue, 08 Jan 2019 19:17:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4fb69d51-107c-4aab-936f-750c5cdecb1f
-      Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -8690,7 +7862,403 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:58 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a3c3e455db0a41bd84973372071ee5b4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b30cc3e9-42ae-426f-a7d9-839ff6067b2d
+      Date:
+      - Mon, 04 Mar 2019 20:04:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a3c3e455db0a41bd84973372071ee5b4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9e225ad6-f104-4aa7-b4ba-42246e230044
+      Date:
+      - Mon, 04 Mar 2019 20:04:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5a1a8b67-7da2-4941-8e3a-571a9b013b70
+      Date:
+      - Mon, 04 Mar 2019 20:04:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -8705,7 +8273,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -8716,46 +8284,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-fd779cc1-1e48-4d33-aa6b-03768572ce76
+      - req-cd208085-0fa0-4ebd-957a-2f23795b11c3
       Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
+      - Mon, 04 Mar 2019 20:05:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -8775,103 +8325,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-dc351446-3f37-436f-97a9-c94e0de9edce
-      Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -8924,169 +8377,20 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f7c90e1f-3293-4948-b62d-a1d867af1433
-      Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -9101,7 +8405,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -9112,12 +8416,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-30f327d3-0922-4f72-8751-1f22817ddfd9
+      - req-91b439c2-b7ec-40b4-8df6-f7706382573a
       Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
+      - Mon, 04 Mar 2019 20:05:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -9152,6 +8503,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e935869b-e607-49ec-9184-5fbbca4fdfd6
+      Date:
+      - Mon, 04 Mar 2019 20:05:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -9205,20 +8623,566 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-74d57a5b-e44a-4f8a-8305-9f2d504cdf84
+      Date:
+      - Mon, 04 Mar 2019 20:05:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1f77ea8a-4845-4769-aea1-9f46aa28c515
+      Date:
+      - Mon, 04 Mar 2019 20:05:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9445c441-135c-49a2-ad4c-1890204a2163
+      Date:
+      - Mon, 04 Mar 2019 20:05:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:00 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85787735b9f040a980a2377a46f4063d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b91b9212-6d0b-4672-b70e-97c73d5afae5
+      Date:
+      - Mon, 04 Mar 2019 20:05:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9233,7 +9197,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -9244,9 +9208,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-1164fc06-fd82-45a2-88ce-f8ba8e758e0f
+      - req-82796df7-a4df-47b4-90a3-e708df3dc4f8
       Date:
-      - Tue, 08 Jan 2019 19:17:52 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9288,7 +9252,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9303,7 +9267,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -9314,9 +9278,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-e2c47838-3ffc-43fd-bb27-a7feace7764c
+      - req-9bcaf0a1-b7a1-4992-91f3-f562c3b12aeb
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9358,7 +9322,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9373,7 +9337,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -9384,9 +9348,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-6d51b8a3-0609-4c49-a0de-f8614fcad742
+      - req-201d79a8-e271-4307-9b45-f5e6983b006d
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9428,7 +9392,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9443,7 +9407,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -9454,9 +9418,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-ba4258f8-fcdf-4f26-8bbf-bb9f3e317a5d
+      - req-717f736c-a84e-451a-9309-4d0c96e903a9
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9498,7 +9462,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9513,7 +9477,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -9524,9 +9488,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-0eb961f7-d252-4830-bf01-87e07bd36d47
+      - req-a7b1a31f-e708-4e41-9bd2-a4afabb2f3e6
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9568,7 +9532,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9583,7 +9547,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -9594,9 +9558,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-3f277a5c-7732-4e45-98e9-1db125fde445
+      - req-bed51538-4de7-4de4-9dd0-4809af404816
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9638,7 +9602,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000
@@ -9653,7 +9617,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -9664,9 +9628,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-74279d83-8d9b-41e2-88a4-667bce249d6f
+      - req-ea37e17e-a7b9-4358-b8f2-40f9b3c234a8
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9708,7 +9672,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?limit=1000&marker=ee601a91-f6ac-4a46-a599-87cfd83094a3
@@ -9723,7 +9687,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -9734,9 +9698,9 @@ http_interactions:
       Content-Length:
       - '3275'
       X-Openstack-Request-Id:
-      - req-cebca75f-c276-4363-87f7-65b4c67116e2
+      - req-71510712-9bc1-44d0-9cf6-54fd671786b0
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -9778,7 +9742,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "45b4c75a-f2bf-4fb6-8503-9a1263ac1e93", "id":
         "ee601a91-f6ac-4a46-a599-87cfd83094a3"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -9793,7 +9757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -9804,9 +9768,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-168029e7-1333-41ef-85eb-9ca913be17cc
+      - req-02df505b-0092-4dfb-8591-031c8389b061
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10209,7 +10173,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -10224,7 +10188,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -10235,9 +10199,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-dff6f2f9-f677-449a-b602-67fe076f71bb
+      - req-c77a0abe-bf67-45c1-82d4-eb9f0dcc6194
       Date:
-      - Tue, 08 Jan 2019 19:17:53 GMT
+      - Mon, 04 Mar 2019 20:05:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -10640,7 +10604,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:53 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -10655,7 +10619,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -10666,9 +10630,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-ab0b6c72-b652-4fb1-9b6d-5bb01fe05d4a
+      - req-f72fe572-4149-4d02-9ee6-a87dadb9574f
       Date:
-      - Tue, 08 Jan 2019 19:17:54 GMT
+      - Mon, 04 Mar 2019 20:05:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11071,7 +11035,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11086,7 +11050,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -11097,9 +11061,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-6aa39040-bb01-4c12-baa7-7f9173706ef0
+      - req-cd9e0c6a-ffde-4cad-970f-f32629e12cd7
       Date:
-      - Tue, 08 Jan 2019 19:17:54 GMT
+      - Mon, 04 Mar 2019 20:05:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11502,7 +11466,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -11517,7 +11481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -11528,9 +11492,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8f543aa3-f775-4405-9c9e-75bb98d34b27
+      - req-75bd1467-fc23-4b9d-9b1f-55b9e841fcd0
       Date:
-      - Tue, 08 Jan 2019 19:17:54 GMT
+      - Mon, 04 Mar 2019 20:05:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -11933,7 +11897,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -11948,7 +11912,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -11959,9 +11923,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-b6469f8f-91fc-40da-849f-ad2c37fd8d0b
+      - req-5bebd7e1-2cf1-4db0-a8de-c03c78f04017
       Date:
-      - Tue, 08 Jan 2019 19:17:54 GMT
+      - Mon, 04 Mar 2019 20:05:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12364,7 +12328,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:54 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000
@@ -12379,7 +12343,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -12390,9 +12354,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-8c20479c-7983-423c-a54a-bd55f19bcdb1
+      - req-034eae30-f2ad-490f-8b85-a607fb4f7b74
       Date:
-      - Tue, 08 Jan 2019 19:17:54 GMT
+      - Mon, 04 Mar 2019 20:05:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -12795,7 +12759,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?limit=1000&marker=dee8791c-23b3-4e65-846d-49aeaba18036
@@ -12810,7 +12774,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -12821,9 +12785,9 @@ http_interactions:
       Content-Length:
       - '33175'
       X-Openstack-Request-Id:
-      - req-4abb52ff-0dea-4bfb-86f3-80ef4f4261bd
+      - req-0d5089d1-a86f-4f1f-8e1f-dc8b3ebcd9b0
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -13226,7 +13190,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:1b:02:f0"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13241,7 +13205,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13252,9 +13216,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-fd36b8c1-9e91-4f28-adcc-d329445be522
+      - req-ec1cab4f-ad24-4ec1-a3f8-a5b7e3bad75a
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13286,7 +13250,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13301,7 +13265,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13312,9 +13276,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-b2d5d949-e5fc-46a3-84da-372527bcd327
+      - req-41cd44ee-ffff-458d-b628-f4b0ffba20f8
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13346,7 +13310,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13361,7 +13325,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -13372,9 +13336,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ab593560-83a6-4d1c-ad45-51ec8ec1755a
+      - req-d73948be-b9e7-4013-8d57-caeb987850fd
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13406,7 +13370,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13421,7 +13385,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -13432,9 +13396,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-a9478aeb-0931-47e5-aa1c-eedfca5ac1cf
+      - req-af01d019-a76a-4648-a2e3-9c2b8ef1ab01
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13466,7 +13430,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13481,7 +13445,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -13492,9 +13456,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-54c3038c-ba07-4c94-a840-86f901fa0d86
+      - req-8f858a90-0837-49ae-8e39-44637420cab8
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13526,7 +13490,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13541,7 +13505,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -13552,9 +13516,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-ed3ff913-64b8-43b3-a879-7edf5dd60e0a
+      - req-eb31b8bf-a95e-40f2-b5b8-993b840f43ff
       Date:
-      - Tue, 08 Jan 2019 19:17:55 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13586,7 +13550,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000
@@ -13601,7 +13565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -13612,9 +13576,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-78fde213-af25-40e5-b087-17988017312b
+      - req-963d265a-dbf5-4617-98e0-df50819fbf91
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13646,7 +13610,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers?limit=1000&marker=a41c036a-c34e-454b-851d-5eefd03888cb
@@ -13661,7 +13625,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -13672,9 +13636,9 @@ http_interactions:
       Content-Length:
       - '2443'
       X-Openstack-Request-Id:
-      - req-dfca87c8-7e30-4136-8527-39f1bc01e541
+      - req-aed86e8e-a57c-4480-866a-d6fc3e52df6a
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"routers": [{"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -13706,7 +13670,7 @@ http_interactions:
         true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "distributed": false,
         "routes": [], "ha": false, "id": "a41c036a-c34e-454b-851d-5eefd03888cb"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -13721,7 +13685,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13732,9 +13696,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-75e4b62e-9cf3-4db3-97bc-c4eaacc50fc7
+      - req-bc9bf6a7-d769-45fc-b754-21b05eb61e35
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -13776,7 +13740,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -13791,7 +13755,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13802,9 +13766,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-c9c89a6e-77c6-4c2b-8913-ef3de8d1c4dd
+      - req-6540eff1-c0be-42dc-b449-79514f9d56b9
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -13847,7 +13811,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -13862,7 +13826,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13873,9 +13837,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-925e3977-831e-49ab-acb6-2fdf5dde1902
+      - req-fec085b9-d299-40bc-9d96-ad88c32c9345
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -13910,7 +13874,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -13925,7 +13889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6b3d39e0d095434897ab610617f9d3d2
+      - 42fefc40f58344b1811f73a76bdb5ed6
   response:
     status:
       code: 200
@@ -13936,9 +13900,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-0be49a63-3ddd-4506-9dbb-2c34da1067e8
+      - req-9d3f98c5-98fa-4e3e-a94b-87f08a3b9430
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14025,7 +13989,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14040,7 +14004,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -14051,9 +14015,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-4b4c6147-51d4-42e1-b4fa-d73bf4b3fd91
+      - req-e2056bc2-1a36-4a1e-a07a-81f9ca0f2a86
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14095,7 +14059,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14110,7 +14074,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -14121,9 +14085,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-72be60cd-abec-4324-8a67-dc153b7e14b3
+      - req-757b8c67-0aa2-4a7f-a08f-21a592647727
       Date:
-      - Tue, 08 Jan 2019 19:17:56 GMT
+      - Mon, 04 Mar 2019 20:05:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14166,7 +14130,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14181,7 +14145,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -14192,9 +14156,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-2e62e671-c156-4d89-9ca1-aa94b70deede
+      - req-5446b0ee-48c3-4b22-b2ac-b03bd75ed243
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14229,7 +14193,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14244,7 +14208,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f4a2af38042d422a85b3db478ef4c8e0
+      - f68e0f8c48eb44c59849ddb2ff37e912
   response:
     status:
       code: 200
@@ -14255,9 +14219,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-92a47ecb-8a8d-4b67-861f-bbe3e79e80b2
+      - req-a43795e6-2753-46ad-a29c-3b565c385cda
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14344,7 +14308,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14359,7 +14323,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -14370,9 +14334,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-768dc072-eebe-4730-afa8-7211fa519975
+      - req-b9a66712-6bda-479f-8ffa-1fd6bc05bb71
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14414,7 +14378,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:09 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14429,7 +14393,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -14440,9 +14404,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-2002892d-4fab-4e7d-bce5-ae8c74643b3c
+      - req-840ea7ca-067e-430d-a4aa-e39ef385018f
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14485,7 +14449,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14500,7 +14464,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -14511,9 +14475,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-23be362f-26b3-4e0a-9f89-57b79a9da8fa
+      - req-90c3cc12-7b89-4d54-b801-cbc87e31b2ff
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14548,7 +14512,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14563,7 +14527,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f6e65830be014fe8ae85b543627fc233
+      - a3c3e455db0a41bd84973372071ee5b4
   response:
     status:
       code: 200
@@ -14574,9 +14538,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-efd76d68-12d7-4929-b31a-faae702156c5
+      - req-9b723a31-1811-4db6-b234-feaab4335de0
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14663,7 +14627,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000
@@ -14678,7 +14642,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -14689,9 +14653,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-688429bf-42ad-4e89-952f-52911307a8d8
+      - req-726f7bfe-036c-4939-8c0a-ed59369a8d6d
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef",
@@ -14733,7 +14697,7 @@ http_interactions:
         null, "port_range_min": null, "id": "ff24dfac-169a-4238-b78b-ed1536a0bf06",
         "security_group_id": "5b2b42a6-1271-4c4a-b062-8e8ba299acef"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=5b2b42a6-1271-4c4a-b062-8e8ba299acef
@@ -14748,7 +14712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -14759,9 +14723,9 @@ http_interactions:
       Content-Length:
       - '3384'
       X-Openstack-Request-Id:
-      - req-3e763c5c-4231-4ba6-8b69-61885c7e65c6
+      - req-53004388-816e-4d17-afa2-1b0b9300a41c
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab",
@@ -14804,7 +14768,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "c06c0e71-2c18-43a9-ace9-91242f0251e2",
         "security_group_id": "98bfc20c-a897-42c5-b33c-f0d8317667ab"}], "name": "default"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=98bfc20c-a897-42c5-b33c-f0d8317667ab
@@ -14819,7 +14783,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -14830,9 +14794,9 @@ http_interactions:
       Content-Length:
       - '2717'
       X-Openstack-Request-Id:
-      - req-707d5374-aa8a-4689-81f6-448d2c765485
+      - req-6b90db1b-98d0-482d-9317-84a7d4ca94a3
       Date:
-      - Tue, 08 Jan 2019 19:17:57 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4",
@@ -14867,7 +14831,7 @@ http_interactions:
         null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:57 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -14882,7 +14846,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7d0595959e4b41aaa315dd66885e8b22
+      - 85787735b9f040a980a2377a46f4063d
   response:
     status:
       code: 200
@@ -14893,9 +14857,9 @@ http_interactions:
       Content-Length:
       - '7080'
       X-Openstack-Request-Id:
-      - req-c6c7d26c-efee-4a4e-8bf6-b7ced644838c
+      - req-9eb610c2-824f-4415-8609-1bfc204fe8ff
       Date:
-      - Tue, 08 Jan 2019 19:17:58 GMT
+      - Mon, 04 Mar 2019 20:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups_links": [{"href": "http://10.8.99.233:9696/v2.0/security-groups?limit=1000&marker=fd147cb7-7456-43d9-a01f-c06e21b4e6fb&page_reverse=True",
@@ -14982,7 +14946,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:58 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:10 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15000,13 +14964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:03 GMT
+      - Mon, 04 Mar 2019 20:05:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-217ce157-4521-4082-92f3-b1c1b9ea4838
+      - req-fba4c3dc-b978-49d4-9200-480905b1887a
       Content-Length:
       - '4170'
       Connection:
@@ -15015,10 +14979,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:03.791439", "expires":
-        "2019-01-08T20:18:03Z", "id": "8d66419db10b403d803cc097acf91932", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:11.452783", "expires":
+        "2019-03-04T21:05:11Z", "id": "57d1c5510aa24ccfb2ae76c722561512", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["C-iDMr9nROSGV26d3yHiHw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gsTd2VrqQJaVUDR6dXjILA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15063,7 +15027,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15081,13 +15045,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:03 GMT
+      - Mon, 04 Mar 2019 20:05:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-720d5e4d-7e5b-41b2-872d-76e0b86e3833
+      - req-5a06019c-e0cd-4236-93d5-8cc319b0fd73
       Content-Length:
       - '4170'
       Connection:
@@ -15096,10 +15060,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:03.982279", "expires":
-        "2019-01-08T20:18:03Z", "id": "77d0eb3076654e798d6dbb0dd001e1c5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:11.656053", "expires":
+        "2019-03-04T21:05:11Z", "id": "4bd1ef777d30421cbec4f84a143bed0e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3Yj31A_eQDOB40UHEtjplQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["H6NGGK6LQxKMlUEgFk17QQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -15144,7 +15108,43 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-availability-zone.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4bd1ef777d30421cbec4f84a143bed0e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Compute-Request-Id:
+      - req-c795d5d8-0254-4e40-aee9-8d74d41c5840
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+      X-Openstack-Request-Id:
+      - req-c795d5d8-0254-4e40-aee9-8d74d41c5840
+      Date:
+      - Mon, 04 Mar 2019 20:05:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"availabilityZoneInfo": [{"zoneState": {"available": true}, "zoneName":
+        "nova"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:11 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15162,13 +15162,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:04 GMT
+      - Mon, 04 Mar 2019 20:05:11 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b4d795d9-be65-4f6c-b185-b81f11035901
+      - req-5a5b9ea4-d19c-4e72-867e-26e813d3bbf8
       Content-Length:
       - '370'
       Connection:
@@ -15177,13 +15177,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:04.144424", "expires":
-        "2019-01-08T20:18:04Z", "id": "e45a5387f9bc4ee1aa84ca6f6626876a", "audit_ids":
-        ["HUeXa4zwSGuXobhCnTRZ3A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:11.977601", "expires":
+        "2019-03-04T21:05:11Z", "id": "a381d3effa234ff9a2a867cdd6868c28", "audit_ids":
+        ["NWQvHcZgRP2b60qDXQO93A"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:11 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -15198,20 +15198,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e45a5387f9bc4ee1aa84ca6f6626876a
+      - a381d3effa234ff9a2a867cdd6868c28
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:04 GMT
+      - Mon, 04 Mar 2019 20:05:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-903e7c20-7c48-4ac4-8cef-b3be947464b9
+      - req-81a9e31a-4fb4-4c24-8d95-50f81347a650
       Content-Length:
       - '500'
       Connection:
@@ -15228,7 +15228,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15246,13 +15246,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:04 GMT
+      - Mon, 04 Mar 2019 20:05:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f1b00524-054d-44f1-a0aa-35327453d3f9
+      - req-81d738c0-3306-498c-bde0-f1f4d1aaa9a3
       Content-Length:
       - '4117'
       Connection:
@@ -15261,10 +15261,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:04.466373", "expires":
-        "2019-01-08T20:18:04Z", "id": "bcb4e7ac487641889fb54856bbf6a5c4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:12.315400", "expires":
+        "2019-03-04T21:05:12Z", "id": "2d48cab0fe7945dabc252c1ba1ee1e9c", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["0k_TVGE2RkCHChxMg4emLg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["e5Q8C7_ESmicHjK7V7euGg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -15308,7 +15308,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15326,13 +15326,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:04 GMT
+      - Mon, 04 Mar 2019 20:05:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ee6db666-d982-4c85-be12-0f69bae19a1b
+      - req-28884370-cc7b-4e2a-91ec-efd391c1e078
       Content-Length:
       - '4131'
       Connection:
@@ -15341,10 +15341,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:04.649698", "expires":
-        "2019-01-08T20:18:04Z", "id": "7a539570305d4485ad9e31ebb8bc7016", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:12.507656", "expires":
+        "2019-03-04T21:05:12Z", "id": "195446dfd863411bae0110a3e70ccebc", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["BkR8voJzTw2yyUoZOlx-zQ"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["FEwhPopPQ_CNrNWEYGBo4Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -15388,7 +15388,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:12 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -15406,13 +15406,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:04 GMT
+      - Mon, 04 Mar 2019 20:05:12 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-393b3145-1c24-4a07-b09b-5fae5439bc04
+      - req-7a5014ab-e5b5-48be-ac5c-76ff8a4b8f8d
       Content-Length:
       - '4118'
       Connection:
@@ -15421,10 +15421,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:04.834874", "expires":
-        "2019-01-08T20:18:04Z", "id": "d4f4e5abdbbd4d2d927b4b73ef9a6bf5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:12.695808", "expires":
+        "2019-03-04T21:05:12Z", "id": "c52f7783b5e249e2b50f7240ab6c51cf", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DfrFCuTHTnSyOpvddPZJhw"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["DhBVqXNRTA66DtQmU_NpaA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -15468,7 +15468,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000
@@ -15483,22 +15483,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6037d868-3616-4bee-800d-34b398d7aabc
+      - req-2de185a9-0335-4e46-a2be-23fd987bcc9d
       Content-Type:
       - application/json
       Content-Length:
       - '2706'
       X-Openstack-Request-Id:
-      - req-6037d868-3616-4bee-800d-34b398d7aabc
+      - req-2de185a9-0335-4e46-a2be-23fd987bcc9d
       Date:
-      - Tue, 08 Jan 2019 19:18:05 GMT
+      - Mon, 04 Mar 2019 20:05:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd",
@@ -15531,7 +15531,7 @@ http_interactions:
         null, "name": "EmsRefreshSpec-Volume-4", "bootable": "true", "created_at":
         "2016-11-11T13:49:53.000000", "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:12 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=9bb99818-b339-4e31-b87f-e4181ec48acd
@@ -15546,22 +15546,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-49df10fe-13d1-49a0-931a-360fb3dac8e0
+      - req-e40ce447-ca75-41e5-89d1-f74bcca2757b
       Content-Type:
       - application/json
       Content-Length:
       - '3284'
       X-Openstack-Request-Id:
-      - req-49df10fe-13d1-49a0-931a-360fb3dac8e0
+      - req-e40ce447-ca75-41e5-89d1-f74bcca2757b
       Date:
-      - Tue, 08 Jan 2019 19:18:05 GMT
+      - Mon, 04 Mar 2019 20:05:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce",
@@ -15602,7 +15602,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Volume-2", "bootable": "false", "created_at": "2016-11-11T13:49:43.000000",
         "volume_type": "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -15617,22 +15617,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-2b352bb9-29ea-4c0f-b0b5-622d4c07918d
+      - req-6f02e233-2633-4f5d-9c6e-a87edf92a2b4
       Content-Type:
       - application/json
       Content-Length:
       - '2753'
       X-Openstack-Request-Id:
-      - req-2b352bb9-29ea-4c0f-b0b5-622d4c07918d
+      - req-6f02e233-2633-4f5d-9c6e-a87edf92a2b4
       Date:
-      - Tue, 08 Jan 2019 19:18:05 GMT
+      - Mon, 04 Mar 2019 20:05:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448",
@@ -15666,7 +15666,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:13 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/detail?limit=1000&marker=0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -15681,27 +15681,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4ba576ac-6e8b-461f-bcfd-7917077d388b
+      - req-0346c920-c836-4072-bffd-79f8323daa4f
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4ba576ac-6e8b-461f-bcfd-7917077d388b
+      - req-0346c920-c836-4072-bffd-79f8323daa4f
       Date:
-      - Tue, 08 Jan 2019 19:18:05 GMT
+      - Mon, 04 Mar 2019 20:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/volumes/detail?limit=1000
@@ -15716,27 +15716,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-3ea6ca23-6d1e-4216-9125-c24d54becab7
+      - req-717822d7-98ac-42e9-ae12-ef9eb8295177
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-3ea6ca23-6d1e-4216-9125-c24d54becab7
+      - req-717822d7-98ac-42e9-ae12-ef9eb8295177
       Date:
-      - Tue, 08 Jan 2019 19:18:05 GMT
+      - Mon, 04 Mar 2019 20:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/detail?limit=1000
@@ -15751,27 +15751,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-99586b00-8dd0-4537-97bd-69ae182c9006
+      - req-934db25a-6cc8-4cd6-9518-3f3e71b4414b
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-99586b00-8dd0-4537-97bd-69ae182c9006
+      - req-934db25a-6cc8-4cd6-9518-3f3e71b4414b
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/volumes/detail?limit=1000
@@ -15786,27 +15786,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-63162a8b-0c1c-482c-85f6-f8d12a44e76f
+      - req-1a49fafc-9a59-4105-89e9-717012d92045
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-63162a8b-0c1c-482c-85f6-f8d12a44e76f
+      - req-1a49fafc-9a59-4105-89e9-717012d92045
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumes": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:14 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail
@@ -15821,22 +15821,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-84a001b5-be30-413a-984a-4ba399c59943
+      - req-057152e3-5d2d-46a6-a172-c5a83e3b24ed
       Content-Type:
       - application/json
       Content-Length:
       - '1053'
       X-Openstack-Request-Id:
-      - req-84a001b5-be30-413a-984a-4ba399c59943
+      - req-057152e3-5d2d-46a6-a172-c5a83e3b24ed
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -15851,7 +15851,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000
@@ -15866,22 +15866,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dd9e9aa5-5486-4fe5-a15f-3cafe1f6fcda
+      - req-24ededac-81cb-4372-baba-65891c51edd8
       Content-Type:
       - application/json
       Content-Length:
       - '1064'
       X-Openstack-Request-Id:
-      - req-dd9e9aa5-5486-4fe5-a15f-3cafe1f6fcda
+      - req-24ededac-81cb-4372-baba-65891c51edd8
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots_links": [{"href": "http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/snapshots/detail?limit=1000&marker=76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
@@ -15896,7 +15896,7 @@ http_interactions:
         "created_at": "2016-11-11T13:49:36.000000", "size": 1, "id": "76fa5c8e-f63a-4b6c-b2d2-458f54cc94ec",
         "description": "EmsRefreshSpec-VolumeSnapshot description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail
@@ -15911,27 +15911,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e14d46fb-e3e2-44ca-8d34-04ca18e71b75
+      - req-93f9380b-a24c-4bee-b6b0-4c12d30667c0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e14d46fb-e3e2-44ca-8d34-04ca18e71b75
+      - req-93f9380b-a24c-4bee-b6b0-4c12d30667c0
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/snapshots/detail?limit=1000
@@ -15946,27 +15946,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-68eb45ea-eb99-4c86-938b-a83532c88ec8
+      - req-452f46a6-7a8c-4178-84c7-ced7247c2e32
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-68eb45ea-eb99-4c86-938b-a83532c88ec8
+      - req-452f46a6-7a8c-4178-84c7-ced7247c2e32
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail
@@ -15981,27 +15981,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e78a5c4b-5ec4-454e-aeab-1c9b78db3e3e
+      - req-3f732882-a513-48b8-bee6-ee26f6be49b2
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e78a5c4b-5ec4-454e-aeab-1c9b78db3e3e
+      - req-3f732882-a513-48b8-bee6-ee26f6be49b2
       Date:
-      - Tue, 08 Jan 2019 19:18:06 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/snapshots/detail?limit=1000
@@ -16016,27 +16016,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-aec887f4-4e17-47c5-b760-87d9f09ef7be
+      - req-8cdf91e2-eaca-4376-aa3b-e5ce441d0ca0
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-aec887f4-4e17-47c5-b760-87d9f09ef7be
+      - req-8cdf91e2-eaca-4376-aa3b-e5ce441d0ca0
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail
@@ -16051,27 +16051,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-927a13f5-79d1-4b73-9411-93a20fc64e50
+      - req-38b75e8e-5322-43c3-812f-c51be01ddb54
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-927a13f5-79d1-4b73-9411-93a20fc64e50
+      - req-38b75e8e-5322-43c3-812f-c51be01ddb54
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/snapshots/detail?limit=1000
@@ -16086,27 +16086,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e3b2b0bd-107b-49ca-996d-a144d9cbcf19
+      - req-ac417651-62d9-48fd-aac3-db6120aa5a18
       Content-Type:
       - application/json
       Content-Length:
       - '17'
       X-Openstack-Request-Id:
-      - req-e3b2b0bd-107b-49ca-996d-a144d9cbcf19
+      - req-ac417651-62d9-48fd-aac3-db6120aa5a18
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"snapshots": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail
@@ -16121,27 +16121,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-707df953-9b27-4dc6-8f85-f3983f712a1a
+      - req-1370927f-211c-4aa3-a1d6-65f8ee0e7bbe
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-707df953-9b27-4dc6-8f85-f3983f712a1a
+      - req-1370927f-211c-4aa3-a1d6-65f8ee0e7bbe
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/backups/detail?limit=1000
@@ -16156,27 +16156,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-c1a01698-9a5b-426c-a51c-04b53c58fbd8
+      - req-c4174c6f-2f92-41c1-901f-ff1606b50c69
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-c1a01698-9a5b-426c-a51c-04b53c58fbd8
+      - req-c4174c6f-2f92-41c1-901f-ff1606b50c69
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail
@@ -16191,27 +16191,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-9c9a0413-15d3-4e6c-953d-2a940603f644
+      - req-77e2b67c-3c59-4543-816e-c4e1f4629c88
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-9c9a0413-15d3-4e6c-953d-2a940603f644
+      - req-77e2b67c-3c59-4543-816e-c4e1f4629c88
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/backups/detail?limit=1000
@@ -16226,27 +16226,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-191ae4c3-2786-466f-a733-96bbafeef8c3
+      - req-aac57779-c4e3-46f2-8529-c44b9da07704
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-191ae4c3-2786-466f-a733-96bbafeef8c3
+      - req-aac57779-c4e3-46f2-8529-c44b9da07704
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail
@@ -16261,27 +16261,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-5256f0cc-000b-4a9b-8702-e627d9177acd
+      - req-7cbeef34-5d0f-49b8-95a8-20fde152dac8
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-5256f0cc-000b-4a9b-8702-e627d9177acd
+      - req-7cbeef34-5d0f-49b8-95a8-20fde152dac8
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/backups/detail?limit=1000
@@ -16296,27 +16296,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-4a02c81c-6845-42e2-8749-1fbbe6d56372
+      - req-d6fe05b6-817d-4553-bba9-52148f286331
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-4a02c81c-6845-42e2-8749-1fbbe6d56372
+      - req-d6fe05b6-817d-4553-bba9-52148f286331
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail
@@ -16331,27 +16331,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6bca81cb-92cf-4d7f-850d-eb29c73252ef
+      - req-aa2f30ad-2a9e-42f8-8c56-24322f722c38
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-6bca81cb-92cf-4d7f-850d-eb29c73252ef
+      - req-aa2f30ad-2a9e-42f8-8c56-24322f722c38
       Date:
-      - Tue, 08 Jan 2019 19:18:07 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/backups/detail?limit=1000
@@ -16366,27 +16366,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-463ebbc0-731b-4264-a439-36db087d8db8
+      - req-5ef111ae-6d63-4f8e-b4df-54b5db366bc4
       Content-Type:
       - application/json
       Content-Length:
       - '15'
       X-Openstack-Request-Id:
-      - req-463ebbc0-731b-4264-a439-36db087d8db8
+      - req-5ef111ae-6d63-4f8e-b4df-54b5db366bc4
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"backups": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000
@@ -16401,22 +16401,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dbbb7696-0e14-4678-abb9-723e9569005e
+      - req-913f8720-8634-4ef2-9f7b-9e6dcf344874
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-dbbb7696-0e14-4678-abb9-723e9569005e
+      - req-913f8720-8634-4ef2-9f7b-9e6dcf344874
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16428,7 +16428,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16443,22 +16443,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bcb4e7ac487641889fb54856bbf6a5c4
+      - 2d48cab0fe7945dabc252c1ba1ee1e9c
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-eacbff49-a8b7-49e0-8702-b1ed8f42ac19
+      - req-a71c4881-2a83-462c-b210-bae65a005edd
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-eacbff49-a8b7-49e0-8702-b1ed8f42ac19
+      - req-a71c4881-2a83-462c-b210-bae65a005edd
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16470,7 +16470,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000
@@ -16485,22 +16485,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-f3cb66f8-b6a1-4c91-a6cb-894a859c81c2
+      - req-a59f07a7-72b2-49c3-8963-b62c8ed27b38
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-f3cb66f8-b6a1-4c91-a6cb-894a859c81c2
+      - req-a59f07a7-72b2-49c3-8963-b62c8ed27b38
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16512,7 +16512,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/b458a5c25c3749758f4c0661940b3ba8/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16527,22 +16527,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7a539570305d4485ad9e31ebb8bc7016
+      - 195446dfd863411bae0110a3e70ccebc
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-ebf93972-dbb1-480b-845f-1295682e5b2f
+      - req-0e44e6ce-bff9-407c-a248-efac372ebb91
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-ebf93972-dbb1-480b-845f-1295682e5b2f
+      - req-0e44e6ce-bff9-407c-a248-efac372ebb91
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16554,7 +16554,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000
@@ -16569,22 +16569,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-0acd497a-39d3-481c-ae80-87fa76feb663
+      - req-6e9c9ceb-91ec-47c3-8bc5-9e3fb1243a11
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-0acd497a-39d3-481c-ae80-87fa76feb663
+      - req-6e9c9ceb-91ec-47c3-8bc5-9e3fb1243a11
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16596,7 +16596,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16611,22 +16611,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 77d0eb3076654e798d6dbb0dd001e1c5
+      - 4bd1ef777d30421cbec4f84a143bed0e
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-6a96dc5a-6f01-4aa3-ace3-b0d729061f13
+      - req-7eedd48b-d159-4b78-b32c-326724562815
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-6a96dc5a-6f01-4aa3-ace3-b0d729061f13
+      - req-7eedd48b-d159-4b78-b32c-326724562815
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16638,7 +16638,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000
@@ -16653,22 +16653,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-027a8606-f3e6-4dc1-8ffa-88c855329e16
+      - req-cb7793af-8ee7-4c4b-a279-1bd3417be16c
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-027a8606-f3e6-4dc1-8ffa-88c855329e16
+      - req-cb7793af-8ee7-4c4b-a279-1bd3417be16c
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16680,7 +16680,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e8f744b1fc6a487681d35fb275252608/types?limit=1000&marker=0d07f8c3-f295-48c7-b632-6b7d8bd860eb
@@ -16695,22 +16695,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d4f4e5abdbbd4d2d927b4b73ef9a6bf5
+      - c52f7783b5e249e2b50f7240ab6c51cf
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-880ed410-76e4-4bd4-a46a-86f840080549
+      - req-0ed182e2-d05a-4d66-a528-c49e0acf6322
       Content-Type:
       - application/json
       Content-Length:
       - '562'
       X-Openstack-Request-Id:
-      - req-880ed410-76e4-4bd4-a46a-86f840080549
+      - req-0ed182e2-d05a-4d66-a528-c49e0acf6322
       Date:
-      - Tue, 08 Jan 2019 19:18:08 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume_types": [{"name": "iscsi", "extra_specs": {"volume_backend_name":
@@ -16722,7 +16722,7 @@ http_interactions:
         true, "is_public": true, "id": "0d07f8c3-f295-48c7-b632-6b7d8bd860eb", "description":
         null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16740,13 +16740,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:09 GMT
+      - Mon, 04 Mar 2019 20:05:18 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b9d0e1bf-5a94-4988-8315-3cc704aaa865
+      - req-3e445168-897d-4a19-84c2-f7d9259638a5
       Content-Length:
       - '4170'
       Connection:
@@ -16755,10 +16755,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:09.134529", "expires":
-        "2019-01-08T20:18:09Z", "id": "8a1b79b027d4455e8b3764f9f7c22ce1", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:18.958970", "expires":
+        "2019-03-04T21:05:18Z", "id": "38a5c217687444fab341f61701273e00", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hb4F-vAuSLmUDvz1X1uTTg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["IinsSYf8QNmuuaylO9-tXw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16803,7 +16803,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:18 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16821,13 +16821,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:09 GMT
+      - Mon, 04 Mar 2019 20:05:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f90b50e-3e4b-4298-90e8-64636bd4463e
+      - req-75c5f04b-0982-4e94-badf-620289d6ee16
       Content-Length:
       - '4170'
       Connection:
@@ -16836,10 +16836,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:09.333683", "expires":
-        "2019-01-08T20:18:09Z", "id": "39261d32a80a47abb6557ab0ff6e86c6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:19.170282", "expires":
+        "2019-03-04T21:05:19Z", "id": "4184198086624ff8a49797997e5d1f57", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["xVurdv_5QN2qYllFOYod1A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["-mhhdGUXSO6uBDvK9taBYA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -16884,7 +16884,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16902,13 +16902,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:09 GMT
+      - Mon, 04 Mar 2019 20:05:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ed3b244-6d5f-4584-96c1-f21692608439
+      - req-1f478acc-ea57-4f70-84f5-ba7fe5c85c88
       Content-Length:
       - '370'
       Connection:
@@ -16917,13 +16917,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:09.503130", "expires":
-        "2019-01-08T20:18:09Z", "id": "5af7da476b6b4337989c45adc5c602b0", "audit_ids":
-        ["BD-gPgh8SBCcex7rwk-R5g"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:19.333035", "expires":
+        "2019-03-04T21:05:19Z", "id": "fc0541901c3f4fbb94400dfecd5ac1fb", "audit_ids":
+        ["0PeHxE6ZRVmVw3tkATsG7g"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:19 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -16938,20 +16938,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5af7da476b6b4337989c45adc5c602b0
+      - fc0541901c3f4fbb94400dfecd5ac1fb
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:09 GMT
+      - Mon, 04 Mar 2019 20:05:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6b3bd6f9-2c99-45e0-88cf-022ccc300a6d
+      - req-20944437-e50d-480c-8873-6d134c690d93
       Content-Length:
       - '500'
       Connection:
@@ -16968,7 +16968,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -16986,13 +16986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:09 GMT
+      - Mon, 04 Mar 2019 20:05:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-55514a02-843c-4ffc-a97c-c80ed5faea61
+      - req-2642687a-0785-4724-898e-74434f7ea018
       Content-Length:
       - '4117'
       Connection:
@@ -17001,10 +17001,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:09.828550", "expires":
-        "2019-01-08T20:18:09Z", "id": "92b141ff50c94ef597079d90ddbd7351", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:19.669925", "expires":
+        "2019-03-04T21:05:19Z", "id": "c05c40dfd73a4761b23f6a4591e9ece9", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gStAGaVlTE-6c_TLWboYwA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["40DliXWGTIGEGnD4m39SIw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -17048,7 +17048,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17066,13 +17066,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:19 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8c4f0a6c-1fe9-456c-b764-655d887a2353
+      - req-217b5144-f0e1-4062-9ebb-492e250ed96c
       Content-Length:
       - '4131'
       Connection:
@@ -17081,10 +17081,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:10.042659", "expires":
-        "2019-01-08T20:18:10Z", "id": "021e2264f6734c05842d0026166f6246", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:19.871256", "expires":
+        "2019-03-04T21:05:19Z", "id": "61be03d719fd43aba4badd5ab7c64d71", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["_0U-ELleQTe6TVjJtsqCww"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["QL0ik5qDQZCyyX_S4QhKqA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -17128,7 +17128,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:19 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -17146,13 +17146,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-26d70887-5aa4-4480-a1a4-3e14f5f596fe
+      - req-7170cc55-5a38-4199-93d6-71ba50e6503a
       Content-Length:
       - '4118'
       Connection:
@@ -17161,10 +17161,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:10.229992", "expires":
-        "2019-01-08T20:18:10Z", "id": "ec05fb54980f481c9f48f71ed7b43338", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:20.071035", "expires":
+        "2019-03-04T21:05:20Z", "id": "36993b4211f243a98b149147af0e5abd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["vHvWZpQDTl2GttO035hVOg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["l-NRO2gbRn-oeb1AmGaqRQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -17208,7 +17208,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000
@@ -17223,7 +17223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b141ff50c94ef597079d90ddbd7351
+      - c05c40dfd73a4761b23f6a4591e9ece9
   response:
     status:
       code: 200
@@ -17252,15 +17252,15 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txd047342c08134891a1acb-005c34f772
+      - txaa9e0d39f0314d71976d2-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"count": 3, "bytes": 33, "name": "dir_1"}, {"count": 0, "bytes":
         0, "name": "dir_2"}, {"count": 0, "bytes": 0, "name": "dir_3"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/?format=json&limit=1000&marker=dir_3
@@ -17275,7 +17275,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b141ff50c94ef597079d90ddbd7351
+      - c05c40dfd73a4761b23f6a4591e9ece9
   response:
     status:
       code: 200
@@ -17304,14 +17304,14 @@ http_interactions:
       X-Account-Project-Domain-Id:
       - default
       X-Trans-Id:
-      - txfe3165afc5ba484b919a1-005c34f772
+      - tx9a16ac26296d4943b8fa8-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_b458a5c25c3749758f4c0661940b3ba8/?format=json&limit=1000
@@ -17326,7 +17326,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 021e2264f6734c05842d0026166f6246
+      - 61be03d719fd43aba4badd5ab7c64d71
   response:
     status:
       code: 200
@@ -17339,22 +17339,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975090.62747'
+      - '1551729920.48032'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975090.62747'
+      - '1551729920.48032'
       X-Trans-Id:
-      - tx20df3624d79840d4aa99c-005c34f772
+      - txf08987944ce74670b8593-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e54e5c3c19e34720b05661f2ea1ea00a/?format=json&limit=1000
@@ -17369,7 +17369,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 39261d32a80a47abb6557ab0ff6e86c6
+      - 4184198086624ff8a49797997e5d1f57
   response:
     status:
       code: 200
@@ -17382,22 +17382,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975090.76472'
+      - '1551729920.63565'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975090.76472'
+      - '1551729920.63565'
       X-Trans-Id:
-      - txca631dba13644bbab2cf3-005c34f772
+      - txd794c6a99ebe485ab7639-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_e8f744b1fc6a487681d35fb275252608/?format=json&limit=1000
@@ -17412,7 +17412,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec05fb54980f481c9f48f71ed7b43338
+      - 36993b4211f243a98b149147af0e5abd
   response:
     status:
       code: 200
@@ -17425,22 +17425,22 @@ http_interactions:
       X-Account-Object-Count:
       - '0'
       X-Timestamp:
-      - '1546975090.90519'
+      - '1551729920.78801'
       X-Account-Bytes-Used:
       - '0'
       X-Account-Container-Count:
       - '0'
       X-Put-Timestamp:
-      - '1546975090.90519'
+      - '1551729920.78801'
       X-Trans-Id:
-      - tx1b5bfa5d3fbc4e65adeb2-005c34f772
+      - tx6fd3f818e52e4e3cae947-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:10 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_1?format=json
@@ -17455,7 +17455,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b141ff50c94ef597079d90ddbd7351
+      - c05c40dfd73a4761b23f6a4591e9ece9
   response:
     status:
       code: 200
@@ -17476,9 +17476,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx3f74bd154a034dcab2340-005c34f772
+      - txefe165eba51245c680063-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '[{"hash": "61257bf228e2f6802a196c9a460d19a8", "last_modified": "2016-11-11T13:50:03.869630",
@@ -17488,7 +17488,7 @@ http_interactions:
         {"hash": "1727a9b61bddf85bbe7a5710c9f45691", "last_modified": "2016-11-11T13:50:04.495640",
         "bytes": 11, "name": "file_3", "content_type": "application/octet-stream"}]'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:20 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_2?format=json
@@ -17503,7 +17503,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b141ff50c94ef597079d90ddbd7351
+      - c05c40dfd73a4761b23f6a4591e9ece9
   response:
     status:
       code: 200
@@ -17524,14 +17524,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - tx910d104802e641b1b51e1-005c34f773
+      - tx2358204f20b242fcba0be-005c7d8500
       Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
+      - Mon, 04 Mar 2019 20:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8080/v1/AUTH_69f8f7205ade4aa59084c32c83e60b5a/dir_3?format=json
@@ -17546,7 +17546,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b141ff50c94ef597079d90ddbd7351
+      - c05c40dfd73a4761b23f6a4591e9ece9
   response:
     status:
       code: 200
@@ -17567,14 +17567,14 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Trans-Id:
-      - txfd4f1812fd0945d0919b4-005c34f773
+      - txaec042a70a9e4840873a8-005c7d8501
       Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
+      - Mon, 04 Mar 2019 20:05:21 GMT
     body:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -17589,7 +17589,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb2a3185574341419ca1210faf09c28c
+      - bd1927f05fc440b19d7a460c65042a7d
   response:
     status:
       code: 200
@@ -17600,9 +17600,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-d0b18b80-7e49-4624-be2a-050517e9158a
+      - req-cd5fd1bd-28eb-4edd-82e3-3907a946efec
       Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
+      - Mon, 04 Mar 2019 20:05:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -17612,7 +17612,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -17627,7 +17627,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - a39f89acb99d4d72a00b99e12433ba04
   response:
     status:
       code: 200
@@ -17638,183 +17638,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-47f917f1-dd44-41ca-b065-12ee6a82a37c
+      - req-6adc7e45-14f3-49f4-86d3-15f09fde332a
       Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
+      - Mon, 04 Mar 2019 20:05:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-eb355de5-4ba1-4b6b-9d70-6a319f16ff12
-      Date:
-      - Tue, 08 Jan 2019 19:18:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -17863,6 +17725,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -17876,7 +17744,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -17891,7 +17759,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - a39f89acb99d4d72a00b99e12433ba04
   response:
     status:
       code: 200
@@ -17902,46 +17770,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-91fd829b-151e-49be-8ccd-c3d9687688fa
+      - req-5ebc5ab7-1b64-4998-a649-3b17d6b39447
       Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
+      - Mon, 04 Mar 2019 20:05:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -17995,20 +17845,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -18023,7 +17891,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - a39f89acb99d4d72a00b99e12433ba04
   response:
     status:
       code: 200
@@ -18034,16 +17902,39 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e9b9b604-6a7d-4943-a7b2-f049412ba0bd
+      - req-da2ba139-1754-42aa-bee8-7479267efe0e
       Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
+      - Mon, 04 Mar 2019 20:05:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -18052,12 +17943,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -18110,6 +17995,511 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 48d694993cb54e429b26be1a1dd63661
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-aa4b6395-bcef-4d28-a0d3-907845f4437a
+      Date:
+      - Mon, 04 Mar 2019 20:05:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 48d694993cb54e429b26be1a1dd63661
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a4e0aa79-ed93-4ead-b3d8-b1fd70eac2b0
+      Date:
+      - Mon, 04 Mar 2019 20:05:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - bd1927f05fc440b19d7a460c65042a7d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-817507b8-5217-4edb-8fc7-1f0cc7bcfade
+      Date:
+      - Mon, 04 Mar 2019 20:05:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - bd1927f05fc440b19d7a460c65042a7d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ad7c15b1-b6ca-48ef-9ac9-bf8f9ab36d1f
+      Date:
+      - Mon, 04 Mar 2019 20:05:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -18127,6 +18517,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -18140,7 +18536,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -18155,7 +18551,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - bd1927f05fc440b19d7a460c65042a7d
   response:
     status:
       code: 200
@@ -18166,34 +18562,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-311a8f98-8a79-4f62-bfbc-4ffbbec3e193
+      - req-c95512b1-27d3-47e9-9847-7e355f210c4d
       Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
+      - Mon, 04 Mar 2019 20:05:22 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -18259,6 +18649,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -18272,7 +18668,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -18287,7 +18683,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9e016e7082124a47a7b3c172821deca1
+      - bd1927f05fc440b19d7a460c65042a7d
   response:
     status:
       code: 200
@@ -18298,206 +18694,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e5931602-e683-43c0-9dc2-b42530186074
+      - req-26a3e46e-2753-4f21-8ebf-9295baac56ef
       Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
+      - Mon, 04 Mar 2019 20:05:22 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1cf65f95ca414e68a294c3673b951f9f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-10ad34cc-4cfd-4587-bee8-7080f6abf894
-      Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -18523,62 +18758,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1cf65f95ca414e68a294c3673b951f9f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-98e48f7e-143b-4d0a-ae03-646c2eb41af3
-      Date:
-      - Tue, 08 Jan 2019 19:18:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
@@ -18602,191 +18781,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb2a3185574341419ca1210faf09c28c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d15691ce-35a8-4470-9c5a-2fb42b92e5e4
-      Date:
-      - Tue, 08 Jan 2019 19:18:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -18800,7 +18800,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:22 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -18815,7 +18815,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb2a3185574341419ca1210faf09c28c
+      - bd1927f05fc440b19d7a460c65042a7d
   response:
     status:
       code: 200
@@ -18826,166 +18826,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cd16517e-0981-477f-84d8-31dfbdd37eac
+      - req-58fcf18e-1085-491e-979f-dac0928ad880
       Date:
-      - Tue, 08 Jan 2019 19:18:13 GMT
+      - Mon, 04 Mar 2019 20:05:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - eb2a3185574341419ca1210faf09c28c
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-af2ac127-f81a-45c2-a3bc-84eca19130cc
-      Date:
-      - Tue, 08 Jan 2019 19:18:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19051,6 +18913,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -19064,7 +18932,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:23 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - bd1927f05fc440b19d7a460c65042a7d
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-bb3e5338-5bda-46ad-a325-08460baefd9b
+      Date:
+      - Mon, 04 Mar 2019 20:05:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -19079,7 +19079,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f96e69ec3f224fa182bab4e00005737f
+      - ed35474721a2420b96d3dfa3bdf69b97
   response:
     status:
       code: 200
@@ -19090,166 +19090,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-643e9594-1317-4b8f-892c-2c6b78844f81
+      - req-04d4e459-5925-461e-b4b5-c8d3f0d988aa
       Date:
-      - Tue, 08 Jan 2019 19:18:13 GMT
+      - Mon, 04 Mar 2019 20:05:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - f96e69ec3f224fa182bab4e00005737f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a40fd5e2-cdf8-4d2e-a448-734d8f42a2a6
-      Date:
-      - Tue, 08 Jan 2019 19:18:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -19315,6 +19177,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -19328,5 +19196,137 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:24 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ed35474721a2420b96d3dfa3bdf69b97
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3e52b7b9-0924-492d-a7e6-bb15974106cf
+      Date:
+      - Mon, 04 Mar 2019 20:05:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_port_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:55 GMT
+      - Mon, 04 Mar 2019 20:05:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-88df3250-7420-4de3-a1ee-a9c0db2b4547
+      - req-56df9115-fd37-4d0f-aabe-f3943c60e8ae
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:55.393978", "expires":
-        "2019-01-08T20:16:55Z", "id": "225427c03fce4c22a9e3c48d2cd05f7e", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:56.191477", "expires":
+        "2019-03-04T21:05:56Z", "id": "dadecdcc8add45b3a7c7cfc6abe1776c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hkJN0S-oTsKmVdWkwSq80w"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bQMaa8QWSUaMqdRHlwqOHw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:56 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 225427c03fce4c22a9e3c48d2cd05f7e
+      - dadecdcc8add45b3a7c7cfc6abe1776c
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:16:55 GMT
+      - Mon, 04 Mar 2019 20:05:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:55 GMT
+      - Mon, 04 Mar 2019 20:05:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-088958ff-e91a-470a-b1fa-c97fcf4a0283
+      - req-c309194b-7622-47a6-a58a-6b44bed026ee
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:55.684566", "expires":
-        "2019-01-08T20:16:55Z", "id": "710322b61d494da1a69f16359dcc8d4a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:56.473159", "expires":
+        "2019-03-04T21:05:56Z", "id": "7d388f2a21454e078617ad259ea2067b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["fUf6LOUNSgySc9X02m8ZmA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["DLmwSYSBSi6iDH8XMq-djg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:55 GMT
+      - Mon, 04 Mar 2019 20:05:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cac939a3-d9bd-40c5-b42c-f90f601b2887
+      - req-2678f46c-0ff7-4297-ab52-29f7b6aa2cfa
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:55.879491", "expires":
-        "2019-01-08T20:16:55Z", "id": "3a1652228bdd42aea708f3e407d3f38d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:56.665067", "expires":
+        "2019-03-04T21:05:56Z", "id": "b3494efefe1d4804b15e7384dcb7baa2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["NesUQjYkQoSoi02h8d1LBg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PNde4Z3KTUii-vot1b5sGw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:55 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -295,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:56 GMT
+      - Mon, 04 Mar 2019 20:05:56 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-b477cec8-df40-4a4c-9cd1-fbebecef2a20
+      - req-c563bd05-d953-4adb-97cb-ace35a07e814
       Content-Length:
       - '4170'
       Connection:
@@ -310,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:56.065021", "expires":
-        "2019-01-08T20:16:56Z", "id": "b37b77a68a5c4210850c2d7ec6aad884", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:56.866176", "expires":
+        "2019-03-04T21:05:56Z", "id": "bc144e03cece432e828b1c75848527dc", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7LAgzP0uRw60TE8SMYqmxA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["N01eAKJAQhOZ38r6mBdK4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -358,7 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:56 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -376,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:56 GMT
+      - Mon, 04 Mar 2019 20:05:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c10b2938-0b49-4aac-b464-3676bf71e877
+      - req-f7a558f8-b064-4aaa-9fe3-d615a038069b
       Content-Length:
       - '370'
       Connection:
@@ -391,13 +391,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:56.218943", "expires":
-        "2019-01-08T20:16:56Z", "id": "fd98ef2673d04dc5b13bf404e1bccd55", "audit_ids":
-        ["ed2Aa3BCT3OkQ_o3G-LtzA"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:57.028169", "expires":
+        "2019-03-04T21:05:57Z", "id": "d509e14351de497ca34d40d1fc983d8c", "audit_ids":
+        ["a9uwA_GZTqarL95-rsJ__w"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:57 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -412,20 +412,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - fd98ef2673d04dc5b13bf404e1bccd55
+      - d509e14351de497ca34d40d1fc983d8c
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:56 GMT
+      - Mon, 04 Mar 2019 20:05:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6ca65e8f-cb4f-4fc2-9f76-8ceafa861b15
+      - req-57746a0c-b3c2-4c26-a3a9-84c6d8191a46
       Content-Length:
       - '500'
       Connection:
@@ -442,7 +442,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:56 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -460,13 +460,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:01 GMT
+      - Mon, 04 Mar 2019 20:05:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7f7ef4a3-160f-48e8-ab89-e687d6a90ad9
+      - req-b626af00-fe99-444b-9ea1-b35e5a2388c9
       Content-Length:
       - '4117'
       Connection:
@@ -475,10 +475,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:01.660681", "expires":
-        "2019-01-08T20:17:01Z", "id": "a97a3911d5a04404849c0ce70904d55a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:57.395533", "expires":
+        "2019-03-04T21:05:57Z", "id": "8323cd8800f747e1afc7b8b6db7ef82f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["gxfHM6gzTVuPinvW1wIXGw"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["bS7Z6bPzT72qwLUd-j5owQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -522,7 +522,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -540,13 +540,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:01 GMT
+      - Mon, 04 Mar 2019 20:05:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f36180ab-c9c9-405a-89c9-9906a6708960
+      - req-331ea22f-20ef-41cc-8e88-bd23365a15d4
       Content-Length:
       - '4131'
       Connection:
@@ -555,10 +555,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:01.847886", "expires":
-        "2019-01-08T20:17:01Z", "id": "ebcca90d43c94a049f2d67240e029111", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:57.584407", "expires":
+        "2019-03-04T21:05:57Z", "id": "e41aa43ae3f5417eba66dfad2408ff81", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["DvRzepIlRY2dAj3bDIX3Tg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["8nwGJkstSVSiNtj2R3jtvw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -602,7 +602,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:01 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:57 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -620,13 +620,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:01 GMT
+      - Mon, 04 Mar 2019 20:05:57 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-eb3d480b-b0e8-4451-a1d0-d69cdddff19b
+      - req-7a0f8017-3731-4ba9-9669-e3d236e08eea
       Content-Length:
       - '4118'
       Connection:
@@ -635,10 +635,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:02.039193", "expires":
-        "2019-01-08T20:17:02Z", "id": "ff20042c01f444dc83242e39ec74f379", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:57.816498", "expires":
+        "2019-03-04T21:05:57Z", "id": "318cd5cb29d04b0ab7742011bb4163cd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["PrUVCQk1Tr22k1esfE923w"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["l07iOdCNT921ncW89lNBRg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -682,7 +682,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:57 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -697,7 +697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a97a3911d5a04404849c0ce70904d55a
+      - 8323cd8800f747e1afc7b8b6db7ef82f
   response:
     status:
       code: 200
@@ -708,34 +708,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-71c9f3c1-b4d6-4017-8e40-046f4a65624a
+      - req-fe0b7a3c-a4b8-426b-b084-fede44a408d2
       Date:
-      - Tue, 08 Jan 2019 19:17:02 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -801,6 +795,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -814,7 +814,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -829,7 +829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a97a3911d5a04404849c0ce70904d55a
+      - 8323cd8800f747e1afc7b8b6db7ef82f
   response:
     status:
       code: 200
@@ -840,183 +840,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-36c90bf2-bb55-44dd-b14f-71d482ac7b21
+      - req-1d735a88-e144-40c7-afc0-1562db77cc25
       Date:
-      - Tue, 08 Jan 2019 19:17:02 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ebcca90d43c94a049f2d67240e029111
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-8ace505a-13d8-4f7d-aace-19d20bc588fb
-      Date:
-      - Tue, 08 Jan 2019 19:17:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1065,6 +927,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1078,7 +946,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1093,7 +961,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebcca90d43c94a049f2d67240e029111
+      - 8323cd8800f747e1afc7b8b6db7ef82f
   response:
     status:
       code: 200
@@ -1104,298 +972,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-dc5cf5bf-d3d8-443b-a4c0-b4146839f236
+      - req-aedcf13c-1469-43b2-b5ae-5793aeac2f74
       Date:
-      - Tue, 08 Jan 2019 19:17:02 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ebcca90d43c94a049f2d67240e029111
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-62311119-0504-4567-bb07-f5d9c30d4525
-      Date:
-      - Tue, 08 Jan 2019 19:17:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:02 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ebcca90d43c94a049f2d67240e029111
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1892bc2e-7722-47ea-a4af-5999c5521c2b
-      Date:
-      - Tue, 08 Jan 2019 19:17:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1461,6 +1059,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1474,7 +1078,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1489,7 +1093,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ebcca90d43c94a049f2d67240e029111
+      - 8323cd8800f747e1afc7b8b6db7ef82f
   response:
     status:
       code: 200
@@ -1500,46 +1104,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-291b492b-48e2-4cc9-9575-3e4f469c7d02
+      - req-15c0fed3-8715-4f26-9da0-b04a4a5f05d3
       Date:
-      - Tue, 08 Jan 2019 19:17:03 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1593,20 +1179,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1621,7 +1225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b37b77a68a5c4210850c2d7ec6aad884
+      - e41aa43ae3f5417eba66dfad2408ff81
   response:
     status:
       code: 200
@@ -1632,34 +1236,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f746871b-0d6a-46f1-acd6-9c6c42c6b41c
+      - req-987da6ef-9c40-499e-8949-0d1a6c8b675a
       Date:
-      - Tue, 08 Jan 2019 19:17:03 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1725,6 +1323,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1738,7 +1342,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:58 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1753,7 +1357,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b37b77a68a5c4210850c2d7ec6aad884
+      - e41aa43ae3f5417eba66dfad2408ff81
   response:
     status:
       code: 200
@@ -1764,46 +1368,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-08f85206-87e0-493a-b809-b2f08e7dfc26
+      - req-35e4bdae-78db-4766-9c16-d1b5c8c72490
       Date:
-      - Tue, 08 Jan 2019 19:17:03 GMT
+      - Mon, 04 Mar 2019 20:05:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1857,20 +1443,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1885,7 +1489,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff20042c01f444dc83242e39ec74f379
+      - bc144e03cece432e828b1c75848527dc
   response:
     status:
       code: 200
@@ -1896,34 +1500,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f8232cd2-ddd4-4f4a-b546-44e4129cc016
+      - req-9541d709-eb1e-4a1e-9ff0-85c2aaceaab1
       Date:
-      - Tue, 08 Jan 2019 19:17:03 GMT
+      - Mon, 04 Mar 2019 20:05:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1989,6 +1587,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2002,7 +1606,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:03 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2017,7 +1621,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff20042c01f444dc83242e39ec74f379
+      - bc144e03cece432e828b1c75848527dc
   response:
     status:
       code: 200
@@ -2028,46 +1632,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-07ca9c4a-97a5-47dd-b3ed-be08ee352afe
+      - req-b2436740-646b-4470-a055-f9108813949a
       Date:
-      - Tue, 08 Jan 2019 19:17:04 GMT
+      - Mon, 04 Mar 2019 20:05:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2121,20 +1707,302 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 318cd5cb29d04b0ab7742011bb4163cd
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c8145e98-27cc-4ad3-b6ed-2d047b409bd9
+      Date:
+      - Mon, 04 Mar 2019 20:05:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 318cd5cb29d04b0ab7742011bb4163cd
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-db2f1e75-fd86-404c-aa67-0e95e478af84
+      Date:
+      - Mon, 04 Mar 2019 20:05:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/02b5cbb1-6072-429c-b185-89f44b552d40
@@ -2149,7 +2017,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b37b77a68a5c4210850c2d7ec6aad884
+      - bc144e03cece432e828b1c75848527dc
   response:
     status:
       code: 200
@@ -2160,9 +2028,9 @@ http_interactions:
       Content-Length:
       - '888'
       X-Openstack-Request-Id:
-      - req-8e139928-5684-483c-b75c-7f528559a61e
+      - req-bc6a60c7-7d23-4d83-a4d8-144018b0faa0
       Date:
-      - Tue, 08 Jan 2019 19:17:04 GMT
+      - Mon, 04 Mar 2019 20:05:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -2177,7 +2045,7 @@ http_interactions:
         "binding:vif_type": "ovs", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mac_address": "fa:16:3e:b5:f7:9c"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:59 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2195,13 +2063,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:04 GMT
+      - Mon, 04 Mar 2019 20:06:00 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a0dd6bce-0726-4f1e-beb3-c18d8fddc505
+      - req-dd713f0d-9df6-46cb-8204-e529dca664df
       Content-Length:
       - '4170'
       Connection:
@@ -2210,10 +2078,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:04.534725", "expires":
-        "2019-01-08T20:17:04Z", "id": "4ebceb9ad67d4328bcdf47aafb82c8c4", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:00.059340", "expires":
+        "2019-03-04T21:06:00Z", "id": "55a6eb625d2645599e32acad9151c898", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kYTrvjoESy6M45GYen14Sg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["lKjIbaATTTCe0nc08Jy8NA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2258,5 +2126,5 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:04 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_router_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:20 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-06f9e2e5-efdb-44a1-b153-db1815c239d4
+      - req-8b9a0ed9-9087-40a4-9ab8-0d40d738e416
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:20.447340", "expires":
-        "2019-01-08T20:18:20Z", "id": "25db6aa3accd44b2add2f088aa774f75", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:15.088153", "expires":
+        "2019-03-04T21:04:15Z", "id": "15e08d6d75344bf1b5f0391ada5aec95", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qtsFS77uTZiioPwY3gcVow"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["2-UadB-5QKOD_2Js6DYY2w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:15 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 25db6aa3accd44b2add2f088aa774f75
+      - 15e08d6d75344bf1b5f0391ada5aec95
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:20 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:20 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f79d936c-d08a-4ce1-815d-b114d2161718
+      - req-4fc8dad5-dc04-4471-8ca7-bab98562159a
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:20.999481", "expires":
-        "2019-01-08T20:18:20Z", "id": "83b2dff3b289485baea34be9b9893dc2", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:15.383246", "expires":
+        "2019-03-04T21:04:15Z", "id": "3f8008c722ca4d1cb7dc7f3887c68e63", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["WAXc9LJxTUazTY2yksTmew"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["kiidN4rmQtCMg77--x1S3Q"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:21 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-d0c2ef16-88a0-43eb-bea7-4619438c8ce0
+      - req-743b087d-438c-4cf7-a76f-cf45940d0d67
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:21.202157", "expires":
-        "2019-01-08T20:18:21Z", "id": "f8524b001b9c47668989d372eac47631", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:15.635758", "expires":
+        "2019-03-04T21:04:15Z", "id": "884134a834f4479dac7489fdc9ea4530", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1Atqu7B8QYumE4C-BxGAmA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["vu5lXwahTUOSC3GbpeW6Iw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -295,13 +295,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:21 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-72387da6-1c11-45b2-8e26-c7b884a6c5ad
+      - req-51cd588f-a7b6-4c1c-934d-7c56a5e93482
       Content-Length:
       - '4170'
       Connection:
@@ -310,10 +310,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:21.411356", "expires":
-        "2019-01-08T20:18:21Z", "id": "1c152dd85dcb4d7abb5e867973f39706", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:15.835050", "expires":
+        "2019-03-04T21:04:15Z", "id": "4e1bb6171d6548258598e4f4ed3299e2", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["qxM-_kNLTxWAphfnLQu25A"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PUuPVNtBTzi1Nx219mBIFQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -358,7 +358,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:15 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -376,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:21 GMT
+      - Mon, 04 Mar 2019 20:04:15 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-181f43e6-ab45-43c5-b799-c93bd1b890f4
+      - req-f369179e-2ab0-49ed-85b3-463e60bf4576
       Content-Length:
       - '370'
       Connection:
@@ -391,13 +391,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:21.576858", "expires":
-        "2019-01-08T20:18:21Z", "id": "781a361b1caa4f55b50468f7514459e8", "audit_ids":
-        ["018LOGodQkOY57PiP1PANQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:15.995794", "expires":
+        "2019-03-04T21:04:15Z", "id": "d1d78cede8e847c3858d2759e66403d1", "audit_ids":
+        ["WI2AcVh8S4CkpGgYbtRb-g"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -412,20 +412,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 781a361b1caa4f55b50468f7514459e8
+      - d1d78cede8e847c3858d2759e66403d1
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:21 GMT
+      - Mon, 04 Mar 2019 20:04:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-ec7dbc52-c7d1-4a23-affb-81eb58950186
+      - req-0b54a658-6a96-4aa2-b7e2-4ea58bdf85f6
       Content-Length:
       - '500'
       Connection:
@@ -442,7 +442,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -460,13 +460,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:21 GMT
+      - Mon, 04 Mar 2019 20:04:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cff40878-4883-40a5-8a8a-f254902497a2
+      - req-efc7f274-2e5f-46a8-8a01-dc9ba727d894
       Content-Length:
       - '4117'
       Connection:
@@ -475,10 +475,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:21.914880", "expires":
-        "2019-01-08T20:18:21Z", "id": "340fbfeab93647f68cec3d80b5f69e31", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:16.322411", "expires":
+        "2019-03-04T21:04:16Z", "id": "6ebe8e1ce9644b1b81e2858ded22ee39", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["LmVEWLe1TH-O3G9EK8TprA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["ZxwDiIqvQDuzCAmuHNvXdQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -522,7 +522,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -540,13 +540,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:22 GMT
+      - Mon, 04 Mar 2019 20:04:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f172794-98ed-4429-8a57-ab18e571e523
+      - req-f7d5f589-2f64-4a8f-8e3f-3e2a49c744f8
       Content-Length:
       - '4131'
       Connection:
@@ -555,10 +555,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:22.101392", "expires":
-        "2019-01-08T20:18:22Z", "id": "60d28983e9ef4ef291797026150eaf80", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:16.520945", "expires":
+        "2019-03-04T21:04:16Z", "id": "123e01891eb941da9a6b1ac279ea94ed", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["1W-AYO3eTBCwQEj1gF1hCw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["VbT56hY_S76Yy9snuRgNHA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -602,7 +602,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -620,13 +620,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:22 GMT
+      - Mon, 04 Mar 2019 20:04:16 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-76bceb21-c661-478a-b307-5094a41422d0
+      - req-b76c8b7d-2e38-4c4f-bf00-8c59377ccd93
       Content-Length:
       - '4118'
       Connection:
@@ -635,10 +635,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:22.288037", "expires":
-        "2019-01-08T20:18:22Z", "id": "b1b99d9118b745c4a8917b58b198240c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:16.716951", "expires":
+        "2019-03-04T21:04:16Z", "id": "309eb5ba7a504b118223edd39cb3e248", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["napbhexBSGCi7sVQVY4Lqg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["hWRgLg91QCCnLIIoqaXHGA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -682,7 +682,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -697,7 +697,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 340fbfeab93647f68cec3d80b5f69e31
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
   response:
     status:
       code: 200
@@ -708,166 +708,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d20e2332-e364-443f-86b7-9d46f0380170
+      - req-4dfbdeb8-6f1f-412d-acb5-471724659676
       Date:
-      - Tue, 08 Jan 2019 19:18:22 GMT
+      - Mon, 04 Mar 2019 20:04:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 340fbfeab93647f68cec3d80b5f69e31
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-7bb6abc0-8a28-490e-bee3-823a613fb90b
-      Date:
-      - Tue, 08 Jan 2019 19:18:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -933,6 +795,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -946,271 +814,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-4cab8629-48f9-48c0-95ae-49c5219b7384
-      Date:
-      - Tue, 08 Jan 2019 19:18:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a1fca555-fb28-42ff-a498-3e8f5f56f394
-      Date:
-      - Tue, 08 Jan 2019 19:18:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:16 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1225,7 +829,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
   response:
     status:
       code: 200
@@ -1236,51 +840,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-99510a95-b719-49f7-b125-097a686599bb
+      - req-fb526e00-2487-4b35-8add-ba47d6c482b8
       Date:
-      - Tue, 08 Jan 2019 19:18:23 GMT
+      - Mon, 04 Mar 2019 20:04:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1329,6 +927,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1342,7 +946,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:17 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1357,7 +961,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
   response:
     status:
       code: 200
@@ -1368,826 +972,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-44b0c299-d174-41de-bb20-3da3570ff5ea
+      - req-4e2600bb-a3cb-4f71-8c17-a26504c3b47c
       Date:
-      - Tue, 08 Jan 2019 19:18:24 GMT
+      - Mon, 04 Mar 2019 20:04:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:24 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-73e26804-626c-4826-a494-65641264b27e
-      Date:
-      - Tue, 08 Jan 2019 19:18:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:25 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b5ea6c3a-f57a-41b7-8bc0-f5f454a661e7
-      Date:
-      - Tue, 08 Jan 2019 19:18:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 60d28983e9ef4ef291797026150eaf80
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a29cc5cd-8e2b-4e16-9cb9-840c5e4750ff
-      Date:
-      - Tue, 08 Jan 2019 19:18:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c152dd85dcb4d7abb5e867973f39706
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-fb853d71-d8bf-4efd-9dee-97f96346c4bf
-      Date:
-      - Tue, 08 Jan 2019 19:18:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:27 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c152dd85dcb4d7abb5e867973f39706
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-2ea9e8d3-2b7f-43ae-a810-d7c8c4d00fdb
-      Date:
-      - Tue, 08 Jan 2019 19:18:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:28 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 1c152dd85dcb4d7abb5e867973f39706
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6166cb00-ce08-4676-928b-7b829d59d054
-      Date:
-      - Tue, 08 Jan 2019 19:18:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2253,6 +1059,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2266,10 +1078,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:17 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -2281,7 +1093,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1b99d9118b745c4a8917b58b198240c
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
   response:
     status:
       code: 200
@@ -2292,12 +1104,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-09e74141-b779-4658-8733-1bece1fc3af9
+      - req-13e9cc33-b8a5-4911-a6a0-8bc0f7b6dc7a
       Date:
-      - Tue, 08 Jan 2019 19:18:28 GMT
+      - Mon, 04 Mar 2019 20:04:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2332,76 +1191,29 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:17 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -2413,7 +1225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b1b99d9118b745c4a8917b58b198240c
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
   response:
     status:
       code: 200
@@ -2424,34 +1236,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-680abe3b-d8cc-4081-8464-f69bf4e23788
+      - req-11495b0d-efc1-47d1-a75b-52d009434e0a
       Date:
-      - Tue, 08 Jan 2019 19:18:28 GMT
+      - Mon, 04 Mar 2019 20:04:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2517,6 +1323,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2530,7 +1342,2779 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:28 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-434fea51-d7d2-4981-b8d5-23e49bbf404f
+      Date:
+      - Mon, 04 Mar 2019 20:04:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:17 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-51c8024c-e0a8-4920-90f9-ad45770c1972
+      Date:
+      - Mon, 04 Mar 2019 20:04:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b67b1700-5cf6-4119-a112-2c7bbf5ab077
+      Date:
+      - Mon, 04 Mar 2019 20:04:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:18 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-828f4ab8-8b55-472c-9edb-70a967d2f5e1
+      Date:
+      - Mon, 04 Mar 2019 20:04:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-3cbc1cd8-a94a-4c7e-875e-0cfe3098b3f6
+      Date:
+      - Mon, 04 Mar 2019 20:04:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:19 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1f054335-4a3b-420c-bd32-49233ebb36d6
+      Date:
+      - Mon, 04 Mar 2019 20:04:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c1461117-784c-452d-b9fd-3ac414eea298
+      Date:
+      - Mon, 04 Mar 2019 20:04:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-2825528e-2401-4b19-82cd-9c7ef973bff4
+      Date:
+      - Mon, 04 Mar 2019 20:04:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6ebe8e1ce9644b1b81e2858ded22ee39
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e1ca0235-8a7e-4b60-964b-f116d607d68f
+      Date:
+      - Mon, 04 Mar 2019 20:04:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 123e01891eb941da9a6b1ac279ea94ed
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-c1f87185-6f0d-4ac1-9eea-7faff124049a
+      Date:
+      - Mon, 04 Mar 2019 20:04:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:20 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 123e01891eb941da9a6b1ac279ea94ed
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-58d54bb3-dcf1-4a1a-bc5f-1b81a97c4780
+      Date:
+      - Mon, 04 Mar 2019 20:04:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-24c146a7-2f5a-41c5-b6c4-8eeb1154b1b3
+      Date:
+      - Mon, 04 Mar 2019 20:04:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f0852f0b-c37e-4bfb-ae0e-4bef7938d23f
+      Date:
+      - Mon, 04 Mar 2019 20:04:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-86d0d007-c6f2-4f72-a4db-38c66d9b87f9
+      Date:
+      - Mon, 04 Mar 2019 20:04:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-04541b7b-eb47-4c9e-abbf-06f4cccc2d08
+      Date:
+      - Mon, 04 Mar 2019 20:04:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:21 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-99960979-6187-458d-894f-b38a8c658c2a
+      Date:
+      - Mon, 04 Mar 2019 20:04:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4c5613a6-33cc-42f0-9708-ddf2a52583b5
+      Date:
+      - Mon, 04 Mar 2019 20:04:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-28cadbfa-6bd4-4992-8c53-6d2025cd6424
+      Date:
+      - Mon, 04 Mar 2019 20:04:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 4e1bb6171d6548258598e4f4ed3299e2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f8f1e5b4-3dae-4033-8512-6a3892f71d49
+      Date:
+      - Mon, 04 Mar 2019 20:04:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 309eb5ba7a504b118223edd39cb3e248
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-79869498-82da-4d21-84c9-555c09e1af5b
+      Date:
+      - Mon, 04 Mar 2019 20:04:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:22 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 309eb5ba7a504b118223edd39cb3e248
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-34860e81-83c4-4ffe-8d96-1b16d9eecb8a
+      Date:
+      - Mon, 04 Mar 2019 20:04:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:23 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -2545,7 +4129,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 1c152dd85dcb4d7abb5e867973f39706
+      - 4e1bb6171d6548258598e4f4ed3299e2
   response:
     status:
       code: 200
@@ -2556,9 +4140,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-b3aab517-0a7e-4424-a7c8-58cc545d1030
+      - req-1087f370-a600-4848-8fbc-4bb0d5328f0b
       Date:
-      - Tue, 08 Jan 2019 19:18:30 GMT
+      - Mon, 04 Mar 2019 20:04:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -2567,7 +4151,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:23 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2585,13 +4169,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:30 GMT
+      - Mon, 04 Mar 2019 20:04:23 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-559ef28a-8099-4a3a-8aa4-c5316b184601
+      - req-d332f7f9-8caf-47d9-b38e-0ba55b743df9
       Content-Length:
       - '4170'
       Connection:
@@ -2600,10 +4184,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:30.211082", "expires":
-        "2019-01-08T20:18:30Z", "id": "658b369a56d9424698189f155ca7a02f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:23.431158", "expires":
+        "2019-03-04T21:04:23Z", "id": "c1a128eb4f65438ab0123ae1514117a9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["uqZLxIaiTU2kF54eCDssVw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ztF4ympaTo6gz16YQQqEmw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2648,5 +4232,5 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:30 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_stack_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:14 GMT
+      - Mon, 04 Mar 2019 20:05:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cd76b776-de42-4615-a012-041c5686238c
+      - req-6ff1a739-d930-42fe-87ca-d394fc8f485d
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:14.585192", "expires":
-        "2019-01-08T20:18:14Z", "id": "eb05f454973d4cb89de076cdc56b56a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:25.296480", "expires":
+        "2019-03-04T21:05:25Z", "id": "7bf2a5a3f7ec44f89e96a626baa8f658", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["K5i0LgcWTbaf7POY2Blv9g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["c7pAFFzfRgql-TRIA7DyoA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:25 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - eb05f454973d4cb89de076cdc56b56a5
+      - 7bf2a5a3f7ec44f89e96a626baa8f658
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:18:14 GMT
+      - Mon, 04 Mar 2019 20:05:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:14 GMT
+      - Mon, 04 Mar 2019 20:05:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-43c15fe0-e0e8-45c0-b06d-8aacb42ceb9f
+      - req-791d697a-67f4-48e3-b257-8e2fcb1f51ed
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:14.861025", "expires":
-        "2019-01-08T20:18:14Z", "id": "86127885c60e455c9ebd909d61ba0d84", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:25.580417", "expires":
+        "2019-03-04T21:05:25Z", "id": "d4c3bc23cb694c2499b29ef3651cbb02", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["m1oHtLIzT4KFfYto3xaDDA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["FnB2ZijUSAGFvd-zNSMLCw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -214,13 +214,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c92c873a-ceb3-4f94-aff7-5527a7b5c4be
+      - req-570e7d8e-5ec5-4d34-86cb-84d13f95c9be
       Content-Length:
       - '4170'
       Connection:
@@ -229,10 +229,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:15.064974", "expires":
-        "2019-01-08T20:18:15Z", "id": "aded6f5a06fe4904b534bc59cf8fcb67", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:25.775456", "expires":
+        "2019-03-04T21:05:25Z", "id": "79afa25bfe6540c4b0aa4ac872086665", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["3uG_8_HCR1a3qvW3DGhghQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["F2Kh1Nc2T2udO6LggvP9Hg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -277,7 +277,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:25 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -292,20 +292,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - aded6f5a06fe4904b534bc59cf8fcb67
+      - 79afa25bfe6540c4b0aa4ac872086665
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:25 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0a2ed738-2fba-4bf2-a252-4e5012c5dbc2
+      - req-ad3b7585-0ba5-4653-85ea-061a252afc35
       Content-Length:
       - '500'
       Connection:
@@ -322,7 +322,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:25 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -340,13 +340,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-7563b2e4-aea0-4e79-816e-72073332d8b1
+      - req-2f54f127-45d9-4af4-93c1-8c23ee92ddd2
       Content-Length:
       - '4117'
       Connection:
@@ -355,10 +355,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:15.385541", "expires":
-        "2019-01-08T20:18:15Z", "id": "bf8b229b2b7b4eef87a7c45f1be3dc17", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:26.113634", "expires":
+        "2019-03-04T21:05:26Z", "id": "e9eba62d462446358faf5dec5a8a2242", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["7JgRKlmkSJm0Q4RiatN-IQ"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["WSdmww7TT96vHjiHQVkQGQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -402,7 +402,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks
@@ -417,7 +417,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf8b229b2b7b4eef87a7c45f1be3dc17
+      - e9eba62d462446358faf5dec5a8a2242
   response:
     status:
       code: 200
@@ -428,9 +428,9 @@ http_interactions:
       Content-Length:
       - '2559'
       X-Openstack-Request-Id:
-      - req-595a5f8c-d725-4b32-8e2e-eb45a553600a
+      - req-3bdd3d99-5330-465d-91dc-30d9809d8321
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"stacks": [{"description": "Heat WordPress template to support F20,
@@ -464,7 +464,7 @@ http_interactions:
         "rel": "self"}], "updated_time": null, "stack_owner": null, "stack_status":
         "CREATE_COMPLETE", "id": "091e1e54-e01c-4ec5-a0ab-b00bee4d425c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -482,13 +482,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-bdf43ab0-86a3-43fe-888d-9b3116027a29
+      - req-569c8d8e-4b9a-473b-adc2-26e3542b1743
       Content-Length:
       - '4170'
       Connection:
@@ -497,10 +497,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:15.857655", "expires":
-        "2019-01-08T20:18:15Z", "id": "b2a608bce9cc40b99a02580b8af77b7c", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:26.603064", "expires":
+        "2019-03-04T21:05:26Z", "id": "cccfd694d56b4b8bb93d06657383bffd", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["pOrnVDl7R72-LJ9yktzcBw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ResOeAz8TB2ssIcBKPeMAw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -545,7 +545,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/template
@@ -560,7 +560,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf8b229b2b7b4eef87a7c45f1be3dc17
+      - e9eba62d462446358faf5dec5a8a2242
   response:
     status:
       code: 200
@@ -571,9 +571,9 @@ http_interactions:
       Content-Length:
       - '4249'
       X-Openstack-Request-Id:
-      - req-f7bdafa0-1410-445c-bdb4-460e383eae0a
+      - req-10793252-d130-4f9f-8339-ea31d0ac6251
       Date:
-      - Tue, 08 Jan 2019 19:18:15 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"outputs": {"WebsiteURL": {"description": "URL for Wordpress wiki",
@@ -629,7 +629,7 @@ http_interactions:
         /etc/wordpress/wp-config.php\n\nsystemctl start httpd.service\n"}}, "flavor":
         {"get_param": "instance_type"}, "networks": [{"uuid": {"get_param": "network_id"}}]}}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:26 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8004/v1/69f8f7205ade4aa59084c32c83e60b5a/stacks/stack1/091e1e54-e01c-4ec5-a0ab-b00bee4d425c/resources
@@ -644,7 +644,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - bf8b229b2b7b4eef87a7c45f1be3dc17
+      - e9eba62d462446358faf5dec5a8a2242
   response:
     status:
       code: 200
@@ -655,9 +655,9 @@ http_interactions:
       Content-Length:
       - '700'
       X-Openstack-Request-Id:
-      - req-e5a56f49-c16b-4877-9091-92c0c00375ab
+      - req-7455caff-516b-4c16-9f44-871fed0f77cd
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"resources": [{"resource_name": "wordpress_instance", "links": [{"href":
@@ -669,7 +669,7 @@ http_interactions:
         changed", "physical_resource_id": "b686353f-0da0-48bf-bc35-8ea411a67dfd",
         "resource_type": "OS::Nova::Server"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:26 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -687,13 +687,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:26 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2e0cc073-33aa-4412-923e-cc39d78f25a6
+      - req-82f37d86-7b41-465b-8b1d-04d2c6925e00
       Content-Length:
       - '4170'
       Connection:
@@ -702,10 +702,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:16.288636", "expires":
-        "2019-01-08T20:18:16Z", "id": "0b10736435004190a4732c43710cdb93", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:27.074199", "expires":
+        "2019-03-04T21:05:27Z", "id": "9e27cc4ece0a40c6bdbe4c090ed8c146", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["hUCErLJRQ1S-RDkxOF5iww"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["X5J8eJvdRQmreSTBsL9qsw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -750,7 +750,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -768,13 +768,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-c3c13b7c-4c59-4b9b-9ef9-26837a088abf
+      - req-b0ba91b5-1362-47b2-93a4-4ca83b53198e
       Content-Length:
       - '370'
       Connection:
@@ -783,13 +783,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:16.451268", "expires":
-        "2019-01-08T20:18:16Z", "id": "177afa663ba3443394a9bc6f0e0c1218", "audit_ids":
-        ["VyL19oFxTQCx1fepXN4xxQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:27.243809", "expires":
+        "2019-03-04T21:05:27Z", "id": "f0a77e6b0dc44e2b878d386e7f9a74d9", "audit_ids":
+        ["QzALfXWdQpuw5iDugZL8Gg"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -804,20 +804,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 177afa663ba3443394a9bc6f0e0c1218
+      - f0a77e6b0dc44e2b878d386e7f9a74d9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-5c39a437-908c-4743-b8a9-59405b784fd4
+      - req-8a7af30e-5ca7-4f4d-a2e3-5c73fd105414
       Content-Length:
       - '500'
       Connection:
@@ -834,7 +834,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -852,13 +852,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3c3b43c1-2330-48d4-8acf-bd059c20471d
+      - req-aad9f2d0-c353-41e5-baf1-7d65a8dd2729
       Content-Length:
       - '4117'
       Connection:
@@ -867,10 +867,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:16.775928", "expires":
-        "2019-01-08T20:18:16Z", "id": "9d9794da46af425082da4ef980e5d690", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:27.572603", "expires":
+        "2019-03-04T21:05:27Z", "id": "f130e2ce9b284a5386d2630cab2006d6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["4yhNnNYqTimt0VPXv5mhSA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TaBloVhQQkiJHkl_v1Mglw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -914,7 +914,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -932,13 +932,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:16 GMT
+      - Mon, 04 Mar 2019 20:05:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-697a264c-f2a3-4a81-8624-d8f15eb1d595
+      - req-e74ec4f6-e968-44f7-b37b-ece8d8fb799a
       Content-Length:
       - '4131'
       Connection:
@@ -947,10 +947,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:16.975054", "expires":
-        "2019-01-08T20:18:16Z", "id": "6c8c06d6a29a4f9db5724412c9170695", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:27.765468", "expires":
+        "2019-03-04T21:05:27Z", "id": "6f52358425ab442bb006fe7310226656", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["9NEZurQpR5CCM5ByHJyhpg"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["CfTmMhvhSiiQ6HBhrem_Yg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -994,7 +994,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1012,13 +1012,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:17 GMT
+      - Mon, 04 Mar 2019 20:05:27 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2d99cae8-b3c4-49e5-aa07-8ad98a9b3ecc
+      - req-767b4e06-6454-45cb-bf28-5f8c4d489d13
       Content-Length:
       - '4118'
       Connection:
@@ -1027,10 +1027,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:17.162680", "expires":
-        "2019-01-08T20:18:17Z", "id": "61590836742a425fb8963fc5836a8f68", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:27.960035", "expires":
+        "2019-03-04T21:05:27Z", "id": "a8444f7e3a8e40ba84e4691445ac36bd", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["_cCutQjeTKSItGUXCAKewA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["2vUrwCZRSXSUtBMOiEuU0w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1074,7 +1074,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:27 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1089,7 +1089,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9d9794da46af425082da4ef980e5d690
+      - f130e2ce9b284a5386d2630cab2006d6
   response:
     status:
       code: 200
@@ -1100,298 +1100,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-f475c237-d418-415b-b5ae-fbbba155dbe0
+      - req-7e6e5178-7e08-4fef-bc2e-3760a7b68ee8
       Date:
-      - Tue, 08 Jan 2019 19:18:17 GMT
+      - Mon, 04 Mar 2019 20:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 9d9794da46af425082da4ef980e5d690
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-194ed9d7-569c-4838-a67e-b9cbce16f1d0
-      Date:
-      - Tue, 08 Jan 2019 19:18:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:17 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 6c8c06d6a29a4f9db5724412c9170695
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-63050961-4de6-4dfe-9528-4377c67a03f6
-      Date:
-      - Tue, 08 Jan 2019 19:18:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1457,6 +1187,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1470,7 +1206,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1485,7 +1221,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 6c8c06d6a29a4f9db5724412c9170695
+      - f130e2ce9b284a5386d2630cab2006d6
   response:
     status:
       code: 200
@@ -1496,46 +1232,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7706391f-bf7a-4612-9d99-97a688e34c48
+      - req-7c564d8c-e083-41e1-8890-ad2ed0952442
       Date:
-      - Tue, 08 Jan 2019 19:18:18 GMT
+      - Mon, 04 Mar 2019 20:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1589,20 +1307,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1617,7 +1353,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b10736435004190a4732c43710cdb93
+      - 6f52358425ab442bb006fe7310226656
   response:
     status:
       code: 200
@@ -1628,51 +1364,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-317b286b-f761-4d72-a860-719ef611e17a
+      - req-ce1e8e50-aa25-400e-98dd-877046ca5540
       Date:
-      - Tue, 08 Jan 2019 19:18:18 GMT
+      - Mon, 04 Mar 2019 20:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1721,6 +1451,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1734,7 +1470,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1749,7 +1485,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b10736435004190a4732c43710cdb93
+      - 6f52358425ab442bb006fe7310226656
   response:
     status:
       code: 200
@@ -1760,34 +1496,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7fe34568-51f2-4490-b943-88298d1df254
+      - req-c6ff5cf2-56f7-459e-a3af-165252c39969
       Date:
-      - Tue, 08 Jan 2019 19:18:18 GMT
+      - Mon, 04 Mar 2019 20:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1853,6 +1583,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1866,7 +1602,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:28 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1881,7 +1617,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 0b10736435004190a4732c43710cdb93
+      - 6f52358425ab442bb006fe7310226656
   response:
     status:
       code: 200
@@ -1892,12 +1628,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-118eef4a-4e04-4418-bb8f-ee1f945f6f83
+      - req-a56309c3-50db-421a-84bd-bc077f4f36b4
       Date:
-      - Tue, 08 Jan 2019 19:18:18 GMT
+      - Mon, 04 Mar 2019 20:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1932,6 +1715,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:28 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6f52358425ab442bb006fe7310226656
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-98c89edd-0d9e-45c4-832b-fed6e32e0752
+      Date:
+      - Mon, 04 Mar 2019 20:05:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1985,20 +1835,434 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6f52358425ab442bb006fe7310226656
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-f981cbe3-e4e6-4b9f-896f-a81d081d54d6
+      Date:
+      - Mon, 04 Mar 2019 20:05:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6f52358425ab442bb006fe7310226656
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4297e720-f092-47eb-b530-1576dc6950de
+      Date:
+      - Mon, 04 Mar 2019 20:05:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 6f52358425ab442bb006fe7310226656
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a5a8858c-dbb0-46ed-ae1b-90202c0632a7
+      Date:
+      - Mon, 04 Mar 2019 20:05:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:29 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2013,7 +2277,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61590836742a425fb8963fc5836a8f68
+      - 9e27cc4ece0a40c6bdbe4c090ed8c146
   response:
     status:
       code: 200
@@ -2024,13 +2288,72 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-33b8fca8-dee2-4fc9-abdc-7363bc9dd244
+      - req-f8108c9b-afff-4a3b-8a99-29f5155e6642
       Date:
-      - Tue, 08 Jan 2019 19:18:18 GMT
+      - Mon, 04 Mar 2019 20:05:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
@@ -2052,6 +2375,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:29 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 9e27cc4ece0a40c6bdbe4c090ed8c146
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-280098a6-37c8-4a58-964b-9ce82437ffd4
+      Date:
+      - Mon, 04 Mar 2019 20:05:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2117,6 +2507,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2130,7 +2526,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:30 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2145,7 +2541,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 61590836742a425fb8963fc5836a8f68
+      - 9e27cc4ece0a40c6bdbe4c090ed8c146
   response:
     status:
       code: 200
@@ -2156,46 +2552,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7e9ef2a4-870e-4905-9030-2a9892284295
+      - req-3465b554-d608-4eaf-a6eb-81d16690d63c
       Date:
-      - Tue, 08 Jan 2019 19:18:19 GMT
+      - Mon, 04 Mar 2019 20:05:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2249,20 +2627,302 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:30 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a8444f7e3a8e40ba84e4691445ac36bd
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b3bad713-8c1e-4f81-adb6-66c6142d1322
+      Date:
+      - Mon, 04 Mar 2019 20:05:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:30 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - a8444f7e3a8e40ba84e4691445ac36bd
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4b3a1ffa-d90c-4a6a-8d64-641cf4ebcc39
+      Date:
+      - Mon, 04 Mar 2019 20:05:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:30 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2280,13 +2940,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:18:19 GMT
+      - Mon, 04 Mar 2019 20:05:30 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a76eac75-4739-4e74-891b-c777ff88c969
+      - req-28e131bc-9532-4a8e-9d1f-b339da730228
       Content-Length:
       - '4170'
       Connection:
@@ -2295,10 +2955,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:18:19.272290", "expires":
-        "2019-01-08T20:18:19Z", "id": "bb70fa10c24044ad8969c4ee1bc0e4fa", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:30.915241", "expires":
+        "2019-03-04T21:05:30Z", "id": "b552d8c48e844a6191a8f49336673081", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["sh1BIAn-SV2LhiceDaNL5g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ZtCgP8VISCeBuoZC70PoHA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -2343,5 +3003,5 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:18:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:30 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_tenant_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:36 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-517ebb17-c199-4f75-bf51-2e582753df04
+      - req-b1a906f9-2e55-495f-a01b-579ea795907c
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:36.294136", "expires":
-        "2019-01-08T20:16:36Z", "id": "858d8b4fe858475ca70a482e95ff36d5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:01.097828", "expires":
+        "2019-03-04T21:06:01Z", "id": "2c1ca5f0108a46bc96cc6efd14a38844", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["9BhJDsXVSvyYX7lW26TnlA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["gJDkqQatTxKoaaatMJAmaw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:36 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:01 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 858d8b4fe858475ca70a482e95ff36d5
+      - 2c1ca5f0108a46bc96cc6efd14a38844
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:16:37 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:37 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f20e8d8-0c79-48d3-9b3d-5162c47e5589
+      - req-a5d4f6b6-86d5-4750-bbf1-fd1ec41f21da
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:37.602200", "expires":
-        "2019-01-08T20:16:37Z", "id": "53d9e3e1e00249a899a54ae18fcc5748", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:01.377923", "expires":
+        "2019-03-04T21:06:01Z", "id": "b8265e4333d2496e9e37fe665a1407fe", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["q7T7j4wxTcKcxNZ2ha8yiQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["_dgA0cYzTJGqr3ntHqVrLg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:01 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -211,20 +211,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 53d9e3e1e00249a899a54ae18fcc5748
+      - b8265e4333d2496e9e37fe665a1407fe
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:37 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e155561d-648c-4f7d-9378-869d2b59e7a9
+      - req-38849e43-b6ed-4e5d-91b9-d111fb0b1813
       Content-Length:
       - '500'
       Connection:
@@ -241,7 +241,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:37 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -259,13 +259,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:37 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aec97f64-df58-4307-88c1-6745ace68aa7
+      - req-b497f512-ef19-42d4-b9b9-df129eddb00b
       Content-Length:
       - '4170'
       Connection:
@@ -274,10 +274,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:38.024187", "expires":
-        "2019-01-08T20:16:38Z", "id": "edda3158951347578d472387bc1411ed", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:01.800817", "expires":
+        "2019-03-04T21:06:01Z", "id": "b7479b4fa0df4eb4a7e97a5d97ba5901", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["tJqFyl6DSVGI8-XyWP_vqg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fxA9ob_LTgiAWSm9hWM-bA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -322,7 +322,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:01 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -340,13 +340,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:38 GMT
+      - Mon, 04 Mar 2019 20:06:01 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-74e29404-15c2-41dd-89c2-a231ed819cdb
+      - req-78fbb0c8-a419-4be8-a876-fc27f9270288
       Content-Length:
       - '4170'
       Connection:
@@ -355,10 +355,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:38.226740", "expires":
-        "2019-01-08T20:16:38Z", "id": "4d11c89ba8f145b99424aa95db902669", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:02.002763", "expires":
+        "2019-03-04T21:06:01Z", "id": "29aa97ad903c4ef3aba6ddd720a3542a", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["BNfAyDmpT4q81k8Iw6mCug"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["fZnHLhI3QxKy4z5EmFXJyw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -403,7 +403,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -421,13 +421,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:38 GMT
+      - Mon, 04 Mar 2019 20:06:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-538fdd57-a9ef-4884-a61d-b1bdbb5a2b84
+      - req-3b02a189-1723-4f3e-b1e2-10087bc59b67
       Content-Length:
       - '4170'
       Connection:
@@ -436,10 +436,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:38.415586", "expires":
-        "2019-01-08T20:16:38Z", "id": "f9ddff0674eb4f8d81397133c5430b65", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:02.200011", "expires":
+        "2019-03-04T21:06:02Z", "id": "3d23e13cfa304acfb0312d73eab6b347", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7BG85yh7QPqXgg0CXbNpww"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["is7Dl-hzQTWzDpeTOD_NOQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -484,7 +484,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -502,13 +502,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:38 GMT
+      - Mon, 04 Mar 2019 20:06:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cc3bab37-d673-4460-8d19-7650cd706fb4
+      - req-c41003fe-84d3-4343-ba7b-a20a8e539cb6
       Content-Length:
       - '370'
       Connection:
@@ -517,13 +517,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:38.582216", "expires":
-        "2019-01-08T20:16:38Z", "id": "ec7e6a29bbc84e4ca741d5b6283c5e90", "audit_ids":
-        ["THWcNqFvQGaNM3_yiL2VxQ"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:02.370291", "expires":
+        "2019-03-04T21:06:02Z", "id": "3b7915e91d354a21a440946fef2e73a9", "audit_ids":
+        ["cfWU0GXAQ0iy5zPFa3H6AQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -538,20 +538,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ec7e6a29bbc84e4ca741d5b6283c5e90
+      - 3b7915e91d354a21a440946fef2e73a9
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:38 GMT
+      - Mon, 04 Mar 2019 20:06:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a7315eac-333c-4f36-a09e-98e60b3b119c
+      - req-f4142838-8c5b-4694-875d-9e5bbb79391a
       Content-Length:
       - '500'
       Connection:
@@ -568,7 +568,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -586,13 +586,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:38 GMT
+      - Mon, 04 Mar 2019 20:06:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9be51180-bf3f-44b3-8c88-a30acd425d83
+      - req-57c745fa-e1db-479c-b843-d86571d673e6
       Content-Length:
       - '4117'
       Connection:
@@ -601,10 +601,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:38.910198", "expires":
-        "2019-01-08T20:16:38Z", "id": "8da496c59322453b8808ce056b9fcba7", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:02.697954", "expires":
+        "2019-03-04T21:06:02Z", "id": "239906cd50984d449a78f14179c0062f", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["vN6LGoTdQkGsoN5_5WSJkg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["9UKbpLWTR3-QrGJzVsBcUg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -648,7 +648,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:38 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -666,13 +666,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
+      - Mon, 04 Mar 2019 20:06:02 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0eb35cb9-106c-4b0d-ad95-e31710137f74
+      - req-f784e91c-034b-461c-8f35-ff977c620406
       Content-Length:
       - '4131'
       Connection:
@@ -681,10 +681,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:39.108286", "expires":
-        "2019-01-08T20:16:39Z", "id": "58169d3c8cf74c24b3947bf66403f1a6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:02.891103", "expires":
+        "2019-03-04T21:06:02Z", "id": "25799ec7d51c4d449cfd1fea59b5f581", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["aZEFIsVUTqilt3_2k109zw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["Taa2n2jPQWeRk5f4bMHfFw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -728,7 +728,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:02 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -746,13 +746,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
+      - Mon, 04 Mar 2019 20:06:03 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-73375941-a9ec-4362-88bb-2a004024ffbf
+      - req-c748fc6c-4601-462c-b769-ffcedcb10ec9
       Content-Length:
       - '4118'
       Connection:
@@ -761,10 +761,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:39.295426", "expires":
-        "2019-01-08T20:16:39Z", "id": "e50695063e5f40f98e72b6d7a2064664", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:03.094423", "expires":
+        "2019-03-04T21:06:03Z", "id": "85fab73993fc40cea32802ceb2d414fc", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["YGioyh3mS2ua-R5Oy1PoLg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["rnlO3cZoTxmlU6uJE_iqhw"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -808,7 +808,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -823,7 +823,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
+      - 239906cd50984d449a78f14179c0062f
   response:
     status:
       code: 200
@@ -834,1750 +834,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-fbdcb8ca-f4f9-4430-a2c9-1654aeb540f2
+      - req-c1b45258-c354-4a4b-be99-a8dffb2662b3
       Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
+      - Mon, 04 Mar 2019 20:06:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-913c972c-9de4-47ae-9800-746e845b9d66
-      Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c1737fcc-0956-4853-862d-49c55e17838d
-      Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-eb0b327b-7194-4ca3-a323-3ac59e42c48c
-      Date:
-      - Tue, 08 Jan 2019 19:16:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:39 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-557704d1-c165-42f8-9cdb-eefb304a8536
-      Date:
-      - Tue, 08 Jan 2019 19:16:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8da496c59322453b8808ce056b9fcba7
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d99709fc-8d15-40f2-84d3-db98a103f2b3
-      Date:
-      - Tue, 08 Jan 2019 19:16:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-975bcab8-7386-4a5a-9b62-6e4e5419d6be
-      Date:
-      - Tue, 08 Jan 2019 19:16:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-502113a5-2d0d-48c3-a294-2e3fa70c754c
-      Date:
-      - Tue, 08 Jan 2019 19:16:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-47bf5dc3-23bd-4fe7-83d4-432907d3d162
-      Date:
-      - Tue, 08 Jan 2019 19:16:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:40 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-d01351bf-8db8-44eb-b24d-8077eb8afd18
-      Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-98bfcd5b-742b-43df-a258-8436d544097b
-      Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-ff808af1-45d7-43d3-98ff-65349083c633
-      Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b1cd57aa-eee6-4a84-9c4d-66f4bdf80e60
-      Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-6f7cbd40-a6f9-43e3-8e23-47f15c4c4fbf
-      Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2643,6 +921,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2656,7 +940,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2671,7 +955,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 58169d3c8cf74c24b3947bf66403f1a6
+      - 239906cd50984d449a78f14179c0062f
   response:
     status:
       code: 200
@@ -2682,12 +966,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ad55ab0c-6686-4505-a97b-19d65d628323
+      - req-e45879ca-3a1e-4f43-98eb-dd3268339a95
       Date:
-      - Tue, 08 Jan 2019 19:16:41 GMT
+      - Mon, 04 Mar 2019 20:06:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2722,76 +1053,29 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:41 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:03 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -2803,7 +1087,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f9ddff0674eb4f8d81397133c5430b65
+      - 239906cd50984d449a78f14179c0062f
   response:
     status:
       code: 200
@@ -2814,34 +1098,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-ea29425f-7988-402c-82cd-15356cf6a1e4
+      - req-b8b04954-17b3-4c2b-bf34-0876b489e2e0
       Date:
-      - Tue, 08 Jan 2019 19:16:42 GMT
+      - Mon, 04 Mar 2019 20:06:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2907,6 +1185,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2920,7 +1204,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:03 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2935,7 +1219,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - f9ddff0674eb4f8d81397133c5430b65
+      - 239906cd50984d449a78f14179c0062f
   response:
     status:
       code: 200
@@ -2946,298 +1230,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-603203bf-44a6-4b36-90b9-e13ae98127db
+      - req-8cee129c-f1ee-4c81-9552-fe21d093f45c
       Date:
-      - Tue, 08 Jan 2019 19:16:42 GMT
+      - Mon, 04 Mar 2019 20:06:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e50695063e5f40f98e72b6d7a2064664
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-104eb95c-f971-4856-af31-86ff1d2b5736
-      Date:
-      - Tue, 08 Jan 2019 19:16:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:42 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e50695063e5f40f98e72b6d7a2064664
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-f10a38dd-849f-45b4-8478-73b67be046d1
-      Date:
-      - Tue, 08 Jan 2019 19:16:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3303,6 +1317,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -3316,7 +1336,1195 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:42 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:03 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 25799ec7d51c4d449cfd1fea59b5f581
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-686456d1-1a0b-4e70-b61f-c151e348c9da
+      Date:
+      - Mon, 04 Mar 2019 20:06:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 25799ec7d51c4d449cfd1fea59b5f581
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7c47fedc-e421-47aa-beeb-2f2533284610
+      Date:
+      - Mon, 04 Mar 2019 20:06:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3d23e13cfa304acfb0312d73eab6b347
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-48866f56-0158-4882-b87a-c03364d338c1
+      Date:
+      - Mon, 04 Mar 2019 20:06:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3d23e13cfa304acfb0312d73eab6b347
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-2dd42c5f-3ed7-445a-8566-42c3dd4811d4
+      Date:
+      - Mon, 04 Mar 2019 20:06:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 3d23e13cfa304acfb0312d73eab6b347
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-1c1998cb-1747-423c-90e7-0da0e4b2adb4
+      Date:
+      - Mon, 04 Mar 2019 20:06:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:04 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85fab73993fc40cea32802ceb2d414fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-15920588-27cc-444e-bf5e-f34912e56fda
+      Date:
+      - Mon, 04 Mar 2019 20:06:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85fab73993fc40cea32802ceb2d414fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-db547443-8a71-4932-abb2-b0aa5035e3dc
+      Date:
+      - Mon, 04 Mar 2019 20:06:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85fab73993fc40cea32802ceb2d414fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4249159f-511c-4e04-96cf-51ad4ae24623
+      Date:
+      - Mon, 04 Mar 2019 20:06:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:05 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 85fab73993fc40cea32802ceb2d414fc
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6ed8d001-1593-4e93-85ed-18dfc09719eb
+      Date:
+      - Mon, 04 Mar 2019 20:06:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:06:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -3334,13 +2542,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:42 GMT
+      - Mon, 04 Mar 2019 20:06:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-9d82e3bc-87dc-4113-baa5-d5ae14125e00
+      - req-69f4ca23-fd92-414b-88bf-74841c470fe4
       Content-Length:
       - '4170'
       Connection:
@@ -3349,10 +2557,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:43.039186", "expires":
-        "2019-01-08T20:16:43Z", "id": "3e25a4b289374986a3c8216d3101dec6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:06:06.000676", "expires":
+        "2019-03-04T21:06:05Z", "id": "4aceb0f64a77442fb0a00f59968375b0", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["__EjM35mQvGgdCMnBELIhQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["PspbBK7sSRGEbSd9s06L4w"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -3397,5 +2605,5 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:43 GMT
+  recorded_at: Mon, 04 Mar 2019 20:06:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_vm_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:05 GMT
+      - Mon, 04 Mar 2019 20:05:32 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2dce929d-3104-499b-9c0e-48fdda556f1a
+      - req-0268df8f-1241-4a4a-91a1-c92be39084a6
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:05.628404", "expires":
-        "2019-01-08T20:17:05Z", "id": "ff09ba440f2748d394cdb51f1b81e954", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:32.141957", "expires":
+        "2019-03-04T21:05:32Z", "id": "ecddce91e4fd4451b42b44b900a8e16e", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["1Sy0jZ5RR1qdE27djCE2RQ"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["bdnlEv76SFWmOFpBS5orJA"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:05 GMT
+      - Mon, 04 Mar 2019 20:05:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:05 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -130,7 +130,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -143,9 +143,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-d619fdb4-ce91-4bba-bb10-a2f003513165
+      - req-ed4a6a28-ffd7-4e8e-a4ae-fcb1aacc49b5
       Date:
-      - Tue, 08 Jan 2019 19:17:06 GMT
+      - Mon, 04 Mar 2019 20:05:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -172,7 +172,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -187,7 +187,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -200,9 +200,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-6d55e22f-5288-48f4-a8eb-49ea39e37049
+      - req-100c745e-acf0-4289-8836-b41eccfa0a62
       Date:
-      - Tue, 08 Jan 2019 19:17:06 GMT
+      - Mon, 04 Mar 2019 20:05:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -210,7 +210,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:32 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -225,7 +225,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -238,9 +238,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-472e6be5-5d6a-4e51-a4da-02068e5e6bc8
+      - req-1be46ef6-1c1f-4c12-8962-9dc1b25eb2a4
       Date:
-      - Tue, 08 Jan 2019 19:17:06 GMT
+      - Mon, 04 Mar 2019 20:05:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -292,7 +292,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -307,7 +307,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -320,14 +320,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-91e74d17-a4d3-4cdf-8ab0-a0c181259250
+      - req-533c9adc-d951-4baa-a70c-67c70d81d1b9
       Date:
-      - Tue, 08 Jan 2019 19:17:06 GMT
+      - Mon, 04 Mar 2019 20:05:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:06 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -345,13 +345,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:06 GMT
+      - Mon, 04 Mar 2019 20:05:33 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-fa7939a6-a949-4886-8b47-609570ab2dc3
+      - req-375d0775-a271-46f7-a8fd-2d6c2392a2bf
       Content-Length:
       - '4170'
       Connection:
@@ -360,10 +360,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:07.039999", "expires":
-        "2019-01-08T20:17:07Z", "id": "92b2900a008d4685ba39d3f4675a4ab6", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:33.719386", "expires":
+        "2019-03-04T21:05:33Z", "id": "d6862fbac8aa46019709a4caed2e9b25", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["QCPjEdlrROC3F4SoKVyUpg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["v2KpUT4ST_axNaAQhWfwnw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -408,7 +408,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:33 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -423,7 +423,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -434,9 +434,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-4ce5ed37-1df0-412c-9fa3-ce535c97cc62
+      - req-b55c991e-4b68-4251-987d-2013751d7437
       Date:
-      - Tue, 08 Jan 2019 19:17:07 GMT
+      - Mon, 04 Mar 2019 20:05:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -445,7 +445,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:33 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -463,13 +463,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:07 GMT
+      - Mon, 04 Mar 2019 20:05:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-6f26be33-c763-419f-bfda-021a08c90cfc
+      - req-fdd3c7cc-19dc-4e77-b6f9-736a34849a6b
       Content-Length:
       - '4170'
       Connection:
@@ -478,10 +478,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:07.406250", "expires":
-        "2019-01-08T20:17:07Z", "id": "78aa8798583b48f69aeba79d919fe460", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:34.116381", "expires":
+        "2019-03-04T21:05:34Z", "id": "b4a6acf05a4c4ababb88ba0c3531302d", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Ms6CYBLaQn2bbZ4LCIqOEg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["dYCeoFnITdGNbGtMZXs4rQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -526,7 +526,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -544,13 +544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:07 GMT
+      - Mon, 04 Mar 2019 20:05:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2f4c6916-9c84-4e80-a9f8-25056a865535
+      - req-74fa0c4f-5b75-4e74-a57a-b6b3ec3d8ab2
       Content-Length:
       - '4170'
       Connection:
@@ -559,10 +559,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:07.593253", "expires":
-        "2019-01-08T20:17:07Z", "id": "7460e5b6eb174f639a35349a5be0a964", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:34.309787", "expires":
+        "2019-03-04T21:05:34Z", "id": "faa076e452b34e688a6b65a539151a3b", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["Bu-6y9MKQgCBKgzcTaU6hg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["g3vCycr3SSu4W03GLSIEJg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -607,7 +607,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:34 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -622,20 +622,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7460e5b6eb174f639a35349a5be0a964
+      - faa076e452b34e688a6b65a539151a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:07 GMT
+      - Mon, 04 Mar 2019 20:05:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-3147383a-91fb-4d6f-af6b-47a6bfefd946
+      - req-36f9251d-be86-4153-82e9-0f1495a44c65
       Content-Length:
       - '500'
       Connection:
@@ -652,7 +652,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:34 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -670,13 +670,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:07 GMT
+      - Mon, 04 Mar 2019 20:05:34 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-aa7bdf59-b9a0-4d32-895b-421bcca4f5c1
+      - req-2b3312da-42f6-4dc2-9bad-eff6c1377fc2
       Content-Length:
       - '4117'
       Connection:
@@ -685,10 +685,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:07.923391", "expires":
-        "2019-01-08T20:17:07Z", "id": "9bb87a6b602544658d159dc1edbb4c3b", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:34.644417", "expires":
+        "2019-03-04T21:05:34Z", "id": "d3cb3d2ed6534cf6972d4953ac3df668", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["KBoPv0x7SjmQ1LiqaE9r9A"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["_SDEhuLNT_iHvN1dzPTVUQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -732,7 +732,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:07 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -747,22 +747,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bb87a6b602544658d159dc1edbb4c3b
+      - d3cb3d2ed6534cf6972d4953ac3df668
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-fae0ed6c-f19c-4ef3-8004-424a74a792d1
+      - req-ebb22548-4b7c-4b4f-94e5-9a16e1f2f171
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-fae0ed6c-f19c-4ef3-8004-424a74a792d1
+      - req-ebb22548-4b7c-4b4f-94e5-9a16e1f2f171
       Date:
-      - Tue, 08 Jan 2019 19:17:08 GMT
+      - Mon, 04 Mar 2019 20:05:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -783,7 +783,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:34 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -798,22 +798,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bb87a6b602544658d159dc1edbb4c3b
+      - d3cb3d2ed6534cf6972d4953ac3df668
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-54ba5f09-3eed-43ed-a9eb-b788d7b148c6
+      - req-73a5ad64-d034-4c79-bf49-2b6de97bf313
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-54ba5f09-3eed-43ed-a9eb-b788d7b148c6
+      - req-73a5ad64-d034-4c79-bf49-2b6de97bf313
       Date:
-      - Tue, 08 Jan 2019 19:17:08 GMT
+      - Mon, 04 Mar 2019 20:05:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -834,7 +834,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -849,7 +849,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -862,9 +862,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-421a5a00-d526-48b4-93f1-213d73f0a63f
+      - req-5419bf39-2a24-4400-8886-dec437108cd1
       Date:
-      - Tue, 08 Jan 2019 19:17:08 GMT
+      - Mon, 04 Mar 2019 20:05:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -873,7 +873,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -891,13 +891,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:08 GMT
+      - Mon, 04 Mar 2019 20:05:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4740c7c6-0e10-4cd5-b5e1-2eb2b1984a21
+      - req-61696798-d386-43af-adcc-cab85f3770d7
       Content-Length:
       - '4170'
       Connection:
@@ -906,10 +906,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:08.809658", "expires":
-        "2019-01-08T20:17:08Z", "id": "26292298a6684dda8c18031e0b5c9921", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:35.571042", "expires":
+        "2019-03-04T21:05:35Z", "id": "55db4a94a1d14c37958c574f42678a47", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ivU2XnT4SiOyc-8Jls6STA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["cVoBl5r0RdmBR20YLs1Zcw"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -954,7 +954,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:08 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:35 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -969,7 +969,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26292298a6684dda8c18031e0b5c9921
+      - 55db4a94a1d14c37958c574f42678a47
   response:
     status:
       code: 200
@@ -980,9 +980,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-cbca8f75-3eba-401c-95a0-6baa8f1e240a
+      - req-f3473d37-b152-41cb-bd32-6f033fc97d90
       Date:
-      - Tue, 08 Jan 2019 19:17:08 GMT
+      - Mon, 04 Mar 2019 20:05:35 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -993,7 +993,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:35 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1011,13 +1011,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:35 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-0ff4a697-3fd0-4ddb-89ba-3beb69250f4e
+      - req-21a20422-41c8-47d4-86d1-56b2d177e8a4
       Content-Length:
       - '370'
       Connection:
@@ -1026,13 +1026,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:09.139378", "expires":
-        "2019-01-08T20:17:09Z", "id": "96b4f1363d2845a68f717becc88df576", "audit_ids":
-        ["KnAW91YhR66axmP0KE6F5A"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:35.902693", "expires":
+        "2019-03-04T21:05:35Z", "id": "8cccfbac60b74b3a94fafa6a2b8e3b71", "audit_ids":
+        ["Z-EMXd4CQoy0fAYzEbnS4A"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:35 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -1047,20 +1047,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 96b4f1363d2845a68f717becc88df576
+      - 8cccfbac60b74b3a94fafa6a2b8e3b71
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-a19efd30-a6d9-4014-8b79-f2ab24773dd6
+      - req-a21bfc16-89c9-4de3-8930-5cefbd21311b
       Content-Length:
       - '500'
       Connection:
@@ -1077,7 +1077,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1095,13 +1095,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e73588bc-6f4d-4057-b232-36454eb97c42
+      - req-31b50de7-9eb1-4204-9983-35fb061e7833
       Content-Length:
       - '4117'
       Connection:
@@ -1110,10 +1110,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:09.480976", "expires":
-        "2019-01-08T20:17:09Z", "id": "b8c836ecba0a4220ad21adf1ab515910", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:36.228938", "expires":
+        "2019-03-04T21:05:36Z", "id": "6aa304a4700b4164a7de1bebbf0afd06", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["eoPg_lbeQz2ATzt8lweYMg"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["zlyDAEPZTOWj3753EoJS0g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -1157,7 +1157,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1172,7 +1172,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8c836ecba0a4220ad21adf1ab515910
+      - 6aa304a4700b4164a7de1bebbf0afd06
   response:
     status:
       code: 200
@@ -1183,7 +1183,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1192,7 +1192,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1210,13 +1210,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-099482ec-b09f-4bf3-a7fb-fd96ddf3bfdc
+      - req-fc18e55b-f6d4-45e2-9249-3443c886beca
       Content-Length:
       - '4131'
       Connection:
@@ -1225,10 +1225,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:09.753419", "expires":
-        "2019-01-08T20:17:09Z", "id": "2ff8597be88a4da29433363f1bffe759", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:36.515758", "expires":
+        "2019-03-04T21:05:36Z", "id": "2cb582ad79d84a308c1ed47a7a4372f4", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["4yZaixzoRwyYFchpQ028SA"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["O44vIN5CSviRXyrwt3cU7g"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -1272,7 +1272,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1287,7 +1287,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff8597be88a4da29433363f1bffe759
+      - 2cb582ad79d84a308c1ed47a7a4372f4
   response:
     status:
       code: 200
@@ -1298,7 +1298,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1307,7 +1307,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:09 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1325,13 +1325,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:09 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-65ed5816-be04-442c-a8cf-42bd0b6ddb51
+      - req-1fb9a87b-66e6-4796-bba5-d98be0746e26
       Content-Length:
       - '4118'
       Connection:
@@ -1340,10 +1340,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:10.023482", "expires":
-        "2019-01-08T20:17:10Z", "id": "321f978a59554cc681f19043d8d37a00", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:36.792658", "expires":
+        "2019-03-04T21:05:36Z", "id": "9b032a7073334855ae042b26828f24b9", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["CVvnlWS7RMWawdol3qoeJA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["ZX-7HLv9THmB850a5zpYnQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1387,7 +1387,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -1402,7 +1402,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321f978a59554cc681f19043d8d37a00
+      - 9b032a7073334855ae042b26828f24b9
   response:
     status:
       code: 200
@@ -1413,7 +1413,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:36 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -1422,7 +1422,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:36 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -1437,7 +1437,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8c836ecba0a4220ad21adf1ab515910
+      - 6aa304a4700b4164a7de1bebbf0afd06
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1450,9 +1450,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-61ac2207-b2b2-4d16-ab9d-141bfcf661ba
+      - req-272c3292-5255-445f-8d29-516bd42b2067
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1462,7 +1462,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1477,7 +1477,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8c836ecba0a4220ad21adf1ab515910
+      - 6aa304a4700b4164a7de1bebbf0afd06
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1490,9 +1490,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-169a84e5-5b1a-4fcc-b70c-58d208a2b172
+      - req-031772a8-dd43-44a1-891a-a793936730f7
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1502,7 +1502,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -1517,7 +1517,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff8597be88a4da29433363f1bffe759
+      - 2cb582ad79d84a308c1ed47a7a4372f4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1530,9 +1530,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-2685f601-8676-436f-b68f-bb9db2935be6
+      - req-3bae0a9a-8916-4da8-bb0b-789b93ab01cc
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1542,7 +1542,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1557,7 +1557,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff8597be88a4da29433363f1bffe759
+      - 2cb582ad79d84a308c1ed47a7a4372f4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1570,9 +1570,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5d0efc39-cba2-4437-bfa4-3e2ac218bf59
+      - req-04926ebf-3297-4006-9b27-cfd698360d59
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1582,7 +1582,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -1597,7 +1597,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1610,9 +1610,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-d5612b86-5810-4752-a201-4e8db2e2aaf9
+      - req-9b6be08b-92cf-4504-be15-d281d6af3210
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1622,7 +1622,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1637,7 +1637,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1650,9 +1650,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7fc93154-e6fe-4c44-9d26-9e9cd1f68c48
+      - req-70397645-39e4-41d4-8ac9-f186e06cfe4d
       Date:
-      - Tue, 08 Jan 2019 19:17:10 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1662,7 +1662,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:10 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -1677,7 +1677,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321f978a59554cc681f19043d8d37a00
+      - 9b032a7073334855ae042b26828f24b9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1690,9 +1690,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-7d40c2e5-c7ce-4932-b898-26789a7d646d
+      - req-38a2cfc0-c3bf-47f9-8215-a800d86bd002
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1702,7 +1702,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -1717,7 +1717,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321f978a59554cc681f19043d8d37a00
+      - 9b032a7073334855ae042b26828f24b9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1730,9 +1730,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-5536c249-13df-42e7-8cd0-6323b7e72c8d
+      - req-0d3263d8-3be5-4769-ba3c-7b5de744a9b2
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -1742,7 +1742,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:37 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1760,13 +1760,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-cdb10bec-a2a3-4569-9b67-c40285de0373
+      - req-597d2f89-2352-474c-9c81-1a576bb00373
       Content-Length:
       - '4170'
       Connection:
@@ -1775,10 +1775,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:11.446533", "expires":
-        "2019-01-08T20:17:11Z", "id": "a8fa2b83035a4cc58459d249b6ad285f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:38.167221", "expires":
+        "2019-03-04T21:05:38Z", "id": "3465fc4f897e44c48daa0d030461661c", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["v6OJR4aGQ9u-vV7QgN4aIg"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["SyyhrmMmRIGYmCEQ8EhX_g"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -1823,7 +1823,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -1838,7 +1838,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1851,9 +1851,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-aaeb72b2-819b-4636-bf78-582a60d153a7
+      - req-8cce9fd7-36f7-4ca5-988c-5e9aa2ae8dd7
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -1862,7 +1862,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -1877,7 +1877,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -1890,15 +1890,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-c1e4383f-611d-4478-8d80-4369b8b59c15
+      - req-71de19e2-2162-4664-aaf8-df2e4840d4e7
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -1913,7 +1913,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -1924,19 +1924,19 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-1519e687-23f9-4c18-9490-29b38e3708c5
+      - req-231970dc-e5d6-463f-a54a-5f58e66dc64c
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"network": {"status": "ACTIVE", "subnets": ["104c081f-97dd-42b7-8930-98abbd015c74",
-        "d53802a5-f0f6-48ba-9207-dbd9b13acac3"], "name": "EmsRefreshSpec-NetworkPrivate",
+      string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "104c081f-97dd-42b7-8930-98abbd015c74"], "name": "EmsRefreshSpec-NetworkPrivate",
         "provider:physical_network": null, "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "mtu": 0, "router:external": false, "shared": false, "provider:network_type":
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -1951,7 +1951,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -1962,9 +1962,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-a45f36a0-58fe-4fb5-992b-2e06ef2db9d7
+      - req-21c97929-aedd-46a7-8a1d-bcd9ef906982
       Date:
-      - Tue, 08 Jan 2019 19:17:11 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -1974,7 +1974,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:11 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1992,13 +1992,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:12 GMT
+      - Mon, 04 Mar 2019 20:05:38 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-2a8a87de-e308-45e4-a87f-0b75d7ed623a
+      - req-1beccf04-3a78-4a30-b913-3013491b20d2
       Content-Length:
       - '4117'
       Connection:
@@ -2007,10 +2007,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:12.145752", "expires":
-        "2019-01-08T20:17:12Z", "id": "5b6895d7af754946a1ae56d13bc2d9fe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:38.874721", "expires":
+        "2019-03-04T21:05:38Z", "id": "93db77e32b1946d48f6269cbd9a36558", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["BGV9xwVQQMCNDq0RtbrL0w"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["TgzCFzNbSyqH7cq8eseK9w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -2054,7 +2054,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:38 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2072,13 +2072,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:12 GMT
+      - Mon, 04 Mar 2019 20:05:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8470a0be-3178-4f11-b49a-d1d58d1ae4cf
+      - req-e1eb4846-4cff-4f33-9a99-b51eb5c63f32
       Content-Length:
       - '4131'
       Connection:
@@ -2087,10 +2087,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:12.342599", "expires":
-        "2019-01-08T20:17:12Z", "id": "68c85da4c6004e9ca96056a9d36e8e29", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:39.081704", "expires":
+        "2019-03-04T21:05:39Z", "id": "ec10b6bcc70549b7a0dc26cfd134d7cf", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["nrowLBUYRVGGXg2jdiJpMw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["-RyE885BRayDoNi2oMso3w"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -2134,7 +2134,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:39 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -2152,13 +2152,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:12 GMT
+      - Mon, 04 Mar 2019 20:05:39 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f546abce-0587-4a7a-8e9b-0bacb37eca8a
+      - req-d9fb91f7-4c58-408d-a0cd-b566ac7e4d76
       Content-Length:
       - '4118'
       Connection:
@@ -2167,10 +2167,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:17:12.524165", "expires":
-        "2019-01-08T20:17:12Z", "id": "547271dd7d8744bfa0e54a8eb6fbe8a5", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:05:39.274793", "expires":
+        "2019-03-04T21:05:39Z", "id": "71c9a47264b94006811c44ffd31f62a1", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["SnhtTCZWR6SRFlr-wyoqQg"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["kc7-rxlZRWCwF0U2yogHOg"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -2214,7 +2214,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:12 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -2229,7 +2229,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -2240,338 +2240,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-e1f2a7a7-b9f7-425b-8f76-56f1c38f1578
+      - req-c1401fb7-558b-4557-8a0a-dc2ba3b959fd
       Date:
-      - Tue, 08 Jan 2019 19:17:12 GMT
+      - Mon, 04 Mar 2019 20:05:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-10ff096d-e6e5-47da-a281-119672e83604
-      Date:
-      - Tue, 08 Jan 2019 19:17:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:12 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-54c3681c-f776-4807-a035-c7d852bd898e
-      Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2597,62 +2304,6 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
-        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
-        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
-        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
-        "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-31911edf-82d7-4f46-b97e-62fe688993e7
-      Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
         "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
@@ -2676,191 +2327,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:13 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-c78c27ca-a8c4-4ac3-a009-3c97b98a3d38
-      Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2874,7 +2346,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2889,7 +2361,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -2900,34 +2372,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7022d5ad-0648-41e4-829b-e3b502cb72d8
+      - req-ddddeb1e-9af7-4021-bfae-a6cd6c478286
       Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
+      - Mon, 04 Mar 2019 20:05:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2993,6 +2459,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -3006,7 +2478,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3021,7 +2493,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -3032,46 +2504,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-706c076d-a54a-42f4-9708-e46ac4b8c029
+      - req-8c3a7b3d-c4e0-457b-b4a3-395e5d7460ce
       Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
+      - Mon, 04 Mar 2019 20:05:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3125,20 +2579,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:13 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:39 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -3153,7 +2625,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -3164,46 +2636,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-c89c5804-b6b4-4c42-897a-ac721a40a16d
+      - req-7e47440b-5896-4eb6-bb94-390892534ceb
       Date:
-      - Tue, 08 Jan 2019 19:17:13 GMT
+      - Mon, 04 Mar 2019 20:05:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3257,20 +2711,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -3285,7 +2757,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -3296,51 +2768,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-de5c4838-7745-4f44-8870-1779f125f60d
+      - req-6c51d4f8-d4b8-41d9-870a-16f453ed983f
       Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
+      - Mon, 04 Mar 2019 20:05:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -3389,6 +2855,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -3402,7 +2874,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:40 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -3417,7 +2889,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -3428,166 +2900,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-00a321d5-5bb3-43ce-be8a-9c20660290bf
+      - req-bd6e3edb-9b38-41bf-a24a-7fd2460d8590
       Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
+      - Mon, 04 Mar 2019 20:05:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-b93b7479-4327-4bbf-87f4-159e4cd8a4ae
-      Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -3653,6 +2987,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -3666,7 +3006,1591 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d56ed81d-b159-4199-87b1-065fdb24bab6
+      Date:
+      - Mon, 04 Mar 2019 20:05:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d6862fbac8aa46019709a4caed2e9b25
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-11b9e163-2d45-44dd-a7d9-ad7a23ad4246
+      Date:
+      - Mon, 04 Mar 2019 20:05:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:40 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d6862fbac8aa46019709a4caed2e9b25
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fda020d6-f2f8-42ac-8dab-0882dc2df8b8
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d6862fbac8aa46019709a4caed2e9b25
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-b001b9a1-c7a5-43f4-b492-49eb62dde7a0
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-81240118-45a0-46d4-9a53-da1342a489d0
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e291bc27-a7cc-4103-bb4b-d2ecf7794347
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-61d0c20c-4d23-43ba-9b23-baa88f01faf2
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-292c4fda-79e4-4f5b-b36b-51664aab0380
+      Date:
+      - Mon, 04 Mar 2019 20:05:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:41 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-7ee9694b-655d-42d1-acd9-e26531a6de8d
+      Date:
+      - Mon, 04 Mar 2019 20:05:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-594ae4b9-f85f-4650-87ac-022b0abb7921
+      Date:
+      - Mon, 04 Mar 2019 20:05:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-85f04252-1306-4144-b3ee-1aa3090d17ce
+      Date:
+      - Mon, 04 Mar 2019 20:05:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-fda37cb4-3a7b-47cf-8711-1e9f75aafc74
+      Date:
+      - Mon, 04 Mar 2019 20:05:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -3681,7 +4605,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -3692,9 +4616,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-665436f6-7437-4cd8-ae68-9b69067bdff5
+      - req-34917839-cf59-4243-817f-e921e2aa35b7
       Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
+      - Mon, 04 Mar 2019 20:05:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3709,7 +4633,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3724,7 +4648,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -3735,9 +4659,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-178bf7e9-b1ed-4ae4-9c28-da63d5abfb9a
+      - req-43625154-b631-42b1-83c9-43a7c5d35bb7
       Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
+      - Mon, 04 Mar 2019 20:05:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3773,7 +4697,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:42 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3788,7 +4712,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -3799,9 +4723,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-93e3254f-1f60-48be-a752-ec519f9395f2
+      - req-d1e1ac6e-c625-4dea-863c-2d7ad83e68d7
       Date:
-      - Tue, 08 Jan 2019 19:17:14 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3837,7 +4761,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:14 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3852,7 +4776,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -3863,9 +4787,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-f2d432f9-dc4c-42e4-9c0a-ffe48e01218c
+      - req-645f0ea8-f25c-4500-a4ac-70503c90647d
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3901,7 +4825,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -3916,7 +4840,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -3927,9 +4851,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-daf636fc-a59b-43be-8e1d-8c1e18406b32
+      - req-2da16e46-42ef-4a3e-96eb-650edcaec098
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -3965,7 +4889,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -3980,7 +4904,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -3991,9 +4915,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-90a3388f-35a0-47d0-9474-8f9e4cd1f258
+      - req-83b0e3fd-f9c4-4821-98c0-d85460f45867
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4029,7 +4953,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4044,7 +4968,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4055,9 +4979,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-7c5e6f41-b7fd-4fb4-be82-965aaf7c9079
+      - req-ec83ee48-dab8-45ff-9fc0-e909d7c8b277
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4093,7 +5017,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -4108,7 +5032,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -4119,9 +5043,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-779dfb63-954a-4284-b05f-814de96f06fc
+      - req-e39db5a9-53fb-49fb-9475-3381f6d7f1c3
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4157,7 +5081,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -4172,7 +5096,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -4183,9 +5107,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-00bf258b-bc4c-43a7-aa90-038a32ae0068
+      - req-17cae6f8-8761-4db8-8de1-39c0a790e8d2
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -4221,7 +5145,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -4236,7 +5160,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4247,9 +5171,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-0a6da7c9-3f1c-4e62-9695-e04985a7bd66
+      - req-70d11d52-8264-4bfd-9df1-bf2e35c56daa
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -4258,7 +5182,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:43 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -4273,7 +5197,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4284,9 +5208,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-cd308c71-e7c6-4e0e-89b4-794a77f62e73
+      - req-6b196e61-9146-4d6d-accb-6e7f48b173cf
       Date:
-      - Tue, 08 Jan 2019 19:17:15 GMT
+      - Mon, 04 Mar 2019 20:05:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -4372,7 +5296,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:15 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:44 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -4387,7 +5311,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4398,9 +5322,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-e3544edf-e771-4d3d-b8a8-9ce3db2d081b
+      - req-1d007e1a-7bc7-4981-a9a8-5065f868a699
       Date:
-      - Tue, 08 Jan 2019 19:17:16 GMT
+      - Mon, 04 Mar 2019 20:05:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -4414,7 +5338,7 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:16 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -4429,7 +5353,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4442,9 +5366,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-d1047343-0c74-4037-8989-2865e5447887
+      - req-48319b27-3c7b-412b-a9e3-e26cd1f9cf40
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -4471,7 +5395,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-interface
@@ -4486,7 +5410,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4499,9 +5423,9 @@ http_interactions:
       Content-Length:
       - '285'
       X-Compute-Request-Id:
-      - req-b6b1dc2e-e9cc-4c98-b6d9-8167bdb49fe7
+      - req-5bb7f613-3a88-4c8f-a904-9889bdb1ace0
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"interfaceAttachments": [{"port_state": "ACTIVE", "fixed_ips": [{"subnet_id":
@@ -4509,7 +5433,7 @@ http_interactions:
         "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "net_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "mac_addr": "fa:16:3e:e1:0b:2c"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:45 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-security-groups
@@ -4524,7 +5448,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4537,9 +5461,9 @@ http_interactions:
       Content-Length:
       - '3931'
       X-Compute-Request-Id:
-      - req-33331a3c-fb20-4319-b711-b0a5d94851eb
+      - req-2a7e49e0-babb-4100-8a08-5daf6d637146
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_groups": [{"rules": [{"from_port": 3, "group": {"tenant_id":
@@ -4591,7 +5515,7 @@ http_interactions:
         "name": "EmsRefreshSpec-SecurityGroup2", "description": "EmsRefreshSpec-SecurityGroup2
         description"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-floating-ips
@@ -4606,7 +5530,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4619,14 +5543,14 @@ http_interactions:
       Content-Length:
       - '20'
       X-Compute-Request-Id:
-      - req-6e3ab456-5c82-4828-b049-ad99ff967bc6
+      - req-84a7abe4-5c42-482c-87b8-1aded1cb1093
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floating_ips": []}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips?floating_ip_address=172.16.17.4
@@ -4641,7 +5565,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4652,9 +5576,9 @@ http_interactions:
       Content-Length:
       - '374'
       X-Openstack-Request-Id:
-      - req-b944cfb6-b089-41a0-8cfb-0e335d1363ee
+      - req-62053e30-c9cb-4744-8664-70678fb278be
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingips": [{"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -4663,7 +5587,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/floatingips/855b23e7-1ace-4c22-8c02-2160d3cde900
@@ -4678,7 +5602,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -4689,9 +5613,9 @@ http_interactions:
       Content-Length:
       - '371'
       X-Openstack-Request-Id:
-      - req-5f677614-a53e-4740-9d39-70515aafa370
+      - req-4d82e596-c270-4aa5-8d67-ba12eb9d9e8d
       Date:
-      - Tue, 08 Jan 2019 19:17:17 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"floatingip": {"floating_network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
@@ -4700,7 +5624,7 @@ http_interactions:
         "status": "ACTIVE", "port_id": "dda2ebad-f144-4f63-9a75-cbd4fe25e3e9", "id":
         "855b23e7-1ace-4c22-8c02-2160d3cde900"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:17 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -4715,20 +5639,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 7460e5b6eb174f639a35349a5be0a964
+      - faa076e452b34e688a6b65a539151a3b
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:17:18 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-8a945b2a-70ff-4393-b640-cacb93e6591d
+      - req-9a51a883-8a4f-442f-ac7a-9e30f6edf52b
       Content-Length:
       - '500'
       Connection:
@@ -4745,7 +5669,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -4760,22 +5684,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bb87a6b602544658d159dc1edbb4c3b
+      - d3cb3d2ed6534cf6972d4953ac3df668
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-e5f59f6a-bad8-4f63-b18a-2178dd8fbd11
+      - req-ea34b358-7a65-43aa-8e04-fee86781cfb8
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-e5f59f6a-bad8-4f63-b18a-2178dd8fbd11
+      - req-ea34b358-7a65-43aa-8e04-fee86781cfb8
       Date:
-      - Tue, 08 Jan 2019 19:17:18 GMT
+      - Mon, 04 Mar 2019 20:05:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -4796,7 +5720,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:46 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/69f8f7205ade4aa59084c32c83e60b5a/volumes/2c774148-c11a-434c-aabb-7fa9c82c37ce
@@ -4811,22 +5735,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 9bb87a6b602544658d159dc1edbb4c3b
+      - d3cb3d2ed6534cf6972d4953ac3df668
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-d41a0584-ce84-455c-8400-a43cbf6764e5
+      - req-2d43c216-d1ea-487e-922f-b89c52f95a0b
       Content-Type:
       - application/json
       Content-Length:
       - '1408'
       X-Openstack-Request-Id:
-      - req-d41a0584-ce84-455c-8400-a43cbf6764e5
+      - req-2d43c216-d1ea-487e-922f-b89c52f95a0b
       Date:
-      - Tue, 08 Jan 2019 19:17:18 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -4847,7 +5771,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:43.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -4862,7 +5786,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4875,9 +5799,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-4bd56566-0ada-4563-955a-349a3142b9e0
+      - req-dac42639-94cf-43bc-be79-d376d93eac98
       Date:
-      - Tue, 08 Jan 2019 19:17:18 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -4886,7 +5810,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9292/v2/images/bb799f70-5e02-461b-8324-17ee88259c7b
@@ -4901,7 +5825,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 26292298a6684dda8c18031e0b5c9921
+      - 55db4a94a1d14c37958c574f42678a47
   response:
     status:
       code: 200
@@ -4912,9 +5836,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       X-Openstack-Request-Id:
-      - req-7ebba738-224e-433f-a824-b7cfbd45b28f
+      - req-fcb06e3a-660c-4f60-86c3-ba99a08d1d4b
       Date:
-      - Tue, 08 Jan 2019 19:17:18 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"status": "active", "name": "EmsRefreshSpec-Image", "tags": [], "container_format":
@@ -4925,7 +5849,7 @@ http_interactions:
         "checksum": "ee1eca47dc88f4879d8a229cc70a07c6", "owner": "69f8f7205ade4aa59084c32c83e60b5a",
         "virtual_size": null, "min_ram": 0, "schema": "/v2/schemas/image"}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:18 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000
@@ -4940,7 +5864,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8c836ecba0a4220ad21adf1ab515910
+      - 6aa304a4700b4164a7de1bebbf0afd06
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4953,9 +5877,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-c52047ec-f72c-4958-9ea9-85ce17535156
+      - req-027b3846-90c4-40c5-9110-e3d8c6d42b56
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -4965,7 +5889,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -4980,7 +5904,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b8c836ecba0a4220ad21adf1ab515910
+      - 6aa304a4700b4164a7de1bebbf0afd06
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -4993,9 +5917,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e16b0eb7-522c-44a7-a4fd-55df5d452af2
+      - req-d4759843-b5ee-4ef9-a4d3-d9dcc4ffad10
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5005,7 +5929,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000
@@ -5020,7 +5944,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff8597be88a4da29433363f1bffe759
+      - 2cb582ad79d84a308c1ed47a7a4372f4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5033,9 +5957,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-3eb7dad5-17de-4695-b0a9-8c3d13ff02a5
+      - req-395621ed-54d5-432d-bc72-ae2c87d62056
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5045,7 +5969,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5060,7 +5984,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 2ff8597be88a4da29433363f1bffe759
+      - 2cb582ad79d84a308c1ed47a7a4372f4
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5073,9 +5997,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-75182848-e005-4cea-b304-594d5424a12c
+      - req-4b064b6a-26d7-4706-aa2d-5c320024b961
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5085,7 +6009,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:47 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000
@@ -5100,7 +6024,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5113,9 +6037,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-8211a1b2-023c-43c1-a818-16215519b986
+      - req-35221613-d30a-4ba2-b678-7c2728909607
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5125,7 +6049,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5140,7 +6064,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5153,9 +6077,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-e1a2eb52-cf37-4c21-9cbe-458061ef5cb1
+      - req-90d286e3-79fd-4e3e-9e01-7c91c32a25d3
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5165,7 +6089,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000
@@ -5180,7 +6104,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321f978a59554cc681f19043d8d37a00
+      - 9b032a7073334855ae042b26828f24b9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5193,9 +6117,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-0b4ba035-da30-48e9-adec-84aabf63e0c9
+      - req-df5c223f-1c8c-4087-aa4a-140884175272
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5205,7 +6129,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608/os-keypairs?limit=1000&marker=EmsRefreshSpec-KeyPair-3
@@ -5220,7 +6144,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 321f978a59554cc681f19043d8d37a00
+      - 9b032a7073334855ae042b26828f24b9
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5233,9 +6157,9 @@ http_interactions:
       Content-Length:
       - '1617'
       X-Compute-Request-Id:
-      - req-51702c34-8784-486e-bbe6-31ad62d4aea1
+      - req-51de62e5-6ec7-4ce5-909a-498b01b07890
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keypairs": [{"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn6mhl9SBfXCBF8wcPeaNLi/0ZTbkOZb+3S4m1lEcfT6JVr1+Y9Pr91Kp228HrjFvVUGIMIgPytuK1rc6ytXqfzuar7fPZTxXSmUb0f+zz+eWRvbkvd9RgP4pqsENL3cPyjyTi/iE7GhpX7prItSA0HJOxDDFmeKupBudh4p2UpC5mwHyE0NonkjHfRQAnJNUz6wCcZbobTRXS+PVVZ0t9kQH6iG58iPQeXUzupZVjsPStksLA2Gtu5wUXewuIM1QbBB+GtGKUBZ7UKESO4oueKIH0Lu3z5SWA9MfGd2oyTPL0pbBKaCRMpzhKvIbaDIGoDu1h7kOFBcJQwPOLRkI/
@@ -5245,7 +6169,7 @@ http_interactions:
         {"keypair": {"public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwcaKcZZF6YrVWjgItxRWZyClehIYKU7tIQS3f1AbUzf/RBc3SrsZFtfPgzMXiX+YFxoxWUf6WCH7dJPZsmEaUJ21GbZ8s29ohCg67n9PL+kezdq9Ukm6CdojX0rsZfU/EKMhObvEmAzJ1ue0A2KQCrdSM92iO3BWcWFVjmxCZRB40eZvcvEbZc32s1MdxOk5cDrA0AsmFVyas3UeqWCE7U6SRWJIa3bjV34qeJWELZ6L7/XzdKYkiBpS0rjHuIejI73VSq082vyph8f8TE4bc3g57Sn4O1AbV7/9aIW+lA+7qw+MJ/7aVWRAtil0OQkhLc0mXmFXmUGMJkUHLFkUj
         Generated-by-Nova\n", "name": "EmsRefreshSpec-KeyPair-3", "fingerprint": "5f:98:28:4d:f4:f1:0d:0e:51:07:b4:7b:d7:f4:e6:cd"}}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -5260,7 +6184,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5273,9 +6197,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-af0d1110-a951-427a-8fd1-096b8038e49c
+      - req-72514fac-d9f0-4726-afbb-ecb100493319
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -5284,7 +6208,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -5299,7 +6223,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - ff09ba440f2748d394cdb51f1b81e954
+      - ecddce91e4fd4451b42b44b900a8e16e
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -5312,15 +6236,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-299af2d6-8dec-4952-b73a-5e95e4f15363
+      - req-0628bbbd-c990-4186-be1b-f9debd6ecae9
       Date:
-      - Tue, 08 Jan 2019 19:17:19 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:19 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/c0e8e42b-005e-4183-8f25-fa91b3e441c1
@@ -5335,7 +6259,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -5346,9 +6270,9 @@ http_interactions:
       Content-Length:
       - '440'
       X-Openstack-Request-Id:
-      - req-ea574fbd-df3d-43d0-8d9e-55361e3e8add
+      - req-66c694fa-08c2-4c6a-b38f-b69c9416a838
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["d53802a5-f0f6-48ba-9207-dbd9b13acac3",
@@ -5358,7 +6282,7 @@ http_interactions:
         "vxlan", "id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "provider:segmentation_id":
         14}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/networks/20af6027-7aeb-432a-ab3b-d7217faa2f1c
@@ -5373,7 +6297,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -5384,9 +6308,9 @@ http_interactions:
       Content-Length:
       - '409'
       X-Openstack-Request-Id:
-      - req-7952c332-2499-49b0-b3e0-b55d680007f2
+      - req-22c4348a-8d3e-41df-b823-b54d362b1c66
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"network": {"status": "ACTIVE", "subnets": ["33da95a6-bded-44d8-be36-6cc97f3d72bd"],
@@ -5396,7 +6320,7 @@ http_interactions:
         "id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "provider:segmentation_id":
         null}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -5411,7 +6335,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -5422,51 +6346,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-95b3e8f9-bb7e-425e-8526-c75bc91feb3f
+      - req-3600d67c-58a7-473d-989c-629ea669da35
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -5515,6 +6433,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -5528,7 +6452,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:48 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -5543,7 +6467,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -5554,34 +6478,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cde36dac-f37c-40dc-ace5-b7229a17feda
+      - req-2c794333-2e16-4594-b1da-1332a64c141b
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5647,6 +6565,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -5660,7 +6584,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -5675,7 +6599,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -5686,46 +6610,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-33691669-dc6f-4b54-8cd6-5c0c56351d0f
+      - req-b5fef78f-5832-4b9a-ba50-f20ac5e4038d
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5779,20 +6685,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -5807,7 +6731,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -5818,46 +6742,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-82579bda-8a8e-4014-b26e-73d52d143ce4
+      - req-30d029ad-4101-480b-add7-9c9cbe1c4dcc
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -5911,20 +6817,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:49 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -5939,7 +6863,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -5950,16 +6874,39 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d4291e64-c840-4110-98a5-7433916e7523
+      - req-020b3047-ab64-4b31-b8da-cbb1dd3ea813
       Date:
-      - Tue, 08 Jan 2019 19:17:20 GMT
+      - Mon, 04 Mar 2019 20:05:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
@@ -5968,12 +6915,6 @@ http_interactions:
         "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
@@ -6026,6 +6967,511 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
         "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:50 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d6862fbac8aa46019709a4caed2e9b25
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5315c812-5c6b-40ef-9e8d-cb241987f87f
+      Date:
+      - Mon, 04 Mar 2019 20:05:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:50 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - d6862fbac8aa46019709a4caed2e9b25
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-ad3583d0-9f10-4762-8b58-537dbd770535
+      Date:
+      - Mon, 04 Mar 2019 20:05:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:50 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-a3ada6c8-12ca-487f-9c44-f89e088d8293
+      Date:
+      - Mon, 04 Mar 2019 20:05:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-cb5089e4-8d56-4244-aadf-0209844a1454
+      Date:
+      - Mon, 04 Mar 2019 20:05:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
@@ -6043,6 +7489,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -6056,7 +7508,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:20 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -6071,7 +7523,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -6082,34 +7534,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-4f70f1b8-9429-4600-953a-e9d06b0a5df0
+      - req-a8cbfe73-16e5-4459-afba-b33ba4d310b0
       Date:
-      - Tue, 08 Jan 2019 19:17:21 GMT
+      - Mon, 04 Mar 2019 20:05:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -6175,6 +7621,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -6188,7 +7640,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -6203,7 +7655,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -6214,12 +7666,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-a574da46-7df2-43d0-8c35-39f279fd343a
+      - req-ef3791fb-2a4a-48fa-b4bc-f8251751dfce
       Date:
-      - Tue, 08 Jan 2019 19:17:21 GMT
+      - Mon, 04 Mar 2019 20:05:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -6254,76 +7753,29 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:21 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -6335,7 +7787,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -6346,166 +7798,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-29c671fb-90e4-4039-b572-32d3de6c91dc
+      - req-266c7cf2-aeb4-4e66-9a48-cfcfed75f0b0
       Date:
-      - Tue, 08 Jan 2019 19:17:21 GMT
+      - Mon, 04 Mar 2019 20:05:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1303e59f-f8fa-4049-8744-c45d92e7939a
-      Date:
-      - Tue, 08 Jan 2019 19:17:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -6571,6 +7885,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -6584,10 +7904,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
     body:
       encoding: US-ASCII
       string: ''
@@ -6599,7 +7919,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -6610,12 +7930,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-62e6c14e-0ec2-4bf6-8595-a4eb96408629
+      - req-35a959cc-bc3d-4ad8-bf75-741057375ba3
       Date:
-      - Tue, 08 Jan 2019 19:17:22 GMT
+      - Mon, 04 Mar 2019 20:05:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -6650,76 +8017,29 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:51 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
     body:
       encoding: US-ASCII
       string: ''
@@ -6731,7 +8051,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -6742,34 +8062,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-b5a44a92-0272-4c77-8f27-0ef5ae9ab17b
+      - req-e7b73582-f9da-4b7c-a308-718fb0ff6663
       Date:
-      - Tue, 08 Jan 2019 19:17:22 GMT
+      - Mon, 04 Mar 2019 20:05:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -6835,6 +8149,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -6848,7 +8168,139 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 71c9a47264b94006811c44ffd31f62a1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-caa3c43f-f090-4ee7-bcaa-5f5424c5ffe1
+      Date:
+      - Mon, 04 Mar 2019 20:05:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports/dda2ebad-f144-4f63-9a75-cbd4fe25e3e9
@@ -6863,7 +8315,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -6874,9 +8326,9 @@ http_interactions:
       Content-Length:
       - '954'
       X-Openstack-Request-Id:
-      - req-483710e0-4a43-4a66-b146-d2ab8237d02b
+      - req-467502ca-ebd8-4b82-bfa4-89fbf2e2856a
       Date:
-      - Tue, 08 Jan 2019 19:17:22 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"port": {"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6891,7 +8343,7 @@ http_interactions:
         true}, "binding:vnic_type": "normal", "binding:vif_type": "ovs", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "mac_address": "fa:16:3e:e1:0b:2c"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -6906,7 +8358,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -6917,9 +8369,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-b6b843e0-1c87-4825-8bb3-c3d3e3ecb64e
+      - req-e5e327d9-1f82-4e68-a9fd-e1a037e06a3d
       Date:
-      - Tue, 08 Jan 2019 19:17:22 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -6955,7 +8407,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:22 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -6970,7 +8422,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 5b6895d7af754946a1ae56d13bc2d9fe
+      - 93db77e32b1946d48f6269cbd9a36558
   response:
     status:
       code: 200
@@ -6981,9 +8433,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-c0a0bef3-f098-4be0-84c7-c6cbcb1fab77
+      - req-e0ea1131-1f02-4e04-8d49-97edba75f8e6
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7019,7 +8471,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -7034,7 +8486,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -7045,9 +8497,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-a7198c7b-d8ff-499f-b1bd-7a947fb523e3
+      - req-8874b39e-3d93-4a49-bc92-2a27ed9103e5
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7083,7 +8535,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -7098,7 +8550,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 68c85da4c6004e9ca96056a9d36e8e29
+      - ec10b6bcc70549b7a0dc26cfd134d7cf
   response:
     status:
       code: 200
@@ -7109,9 +8561,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-62963ebe-5257-4654-95ea-9d92964e0831
+      - req-f4a2bb9a-8156-4501-8e34-236305882d68
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7147,7 +8599,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -7162,7 +8614,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -7173,9 +8625,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-ab866e47-a334-4fb6-8079-b9bedeccb967
+      - req-92e1b91d-eb9d-49e5-8971-413af1c384ac
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7211,7 +8663,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -7226,7 +8678,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -7237,9 +8689,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-63ccc7dc-9993-44da-b8ad-d96e259a554c
+      - req-2af43850-6bda-4510-91fb-e73720933a18
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7275,7 +8727,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:52 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000
@@ -7290,7 +8742,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -7301,9 +8753,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-57ba4419-c2eb-4d86-81fc-3f3667360ce7
+      - req-bd540ac9-0b2b-45dd-aecf-5c4427519646
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7339,7 +8791,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/ports?device_id=57e17608-8ac6-44a6-803e-f42ec15e9d1e&limit=1000&marker=9330caba-d3ec-4675-b68a-b80fffae6365
@@ -7354,7 +8806,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 547271dd7d8744bfa0e54a8eb6fbe8a5
+      - 71c9a47264b94006811c44ffd31f62a1
   response:
     status:
       code: 200
@@ -7365,9 +8817,9 @@ http_interactions:
       Content-Length:
       - '2617'
       X-Openstack-Request-Id:
-      - req-d4806055-fdb5-4adc-a2d7-4700a89a6893
+      - req-66e39491-5661-4b45-8f9d-3ece3dd200ed
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"ports": [{"status": "ACTIVE", "binding:host_id": "11.22.33.44",
@@ -7403,7 +8855,7 @@ http_interactions:
         {"port_filter": true, "ovs_hybrid_plug": true}, "binding:vnic_type": "normal",
         "binding:vif_type": "ovs", "tenant_id": "", "mac_address": "fa:16:3e:2e:66:be"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/routers/57e17608-8ac6-44a6-803e-f42ec15e9d1e
@@ -7418,7 +8870,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -7429,9 +8881,9 @@ http_interactions:
       Content-Length:
       - '443'
       X-Openstack-Request-Id:
-      - req-6119a0ca-d411-4d8d-abc8-fef9ca4049b6
+      - req-04198931-d7d3-42f1-9bd5-16b74207ffc1
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"router": {"status": "ACTIVE", "external_gateway_info": {"network_id":
@@ -7440,7 +8892,7 @@ http_interactions:
         "name": "EmsRefreshSpec-Router", "admin_state_up": true, "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "distributed": false, "routes": [], "ha": false, "id": "57e17608-8ac6-44a6-803e-f42ec15e9d1e"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/fd147cb7-7456-43d9-a01f-c06e21b4e6fb
@@ -7455,7 +8907,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -7466,9 +8918,9 @@ http_interactions:
       Content-Length:
       - '6900'
       X-Openstack-Request-Id:
-      - req-446f0c14-8f50-465b-b362-8ad147f6ce6e
+      - req-d9b461ff-997c-4876-9a61-8b6ecc33bc88
       Date:
-      - Tue, 08 Jan 2019 19:17:23 GMT
+      - Mon, 04 Mar 2019 20:05:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -7554,7 +9006,7 @@ http_interactions:
         "port_range_max": 80, "port_range_min": 80, "id": "f79f0e32-b186-4778-952e-20827a60ef73",
         "security_group_id": "fd147cb7-7456-43d9-a01f-c06e21b4e6fb"}], "name": "EmsRefreshSpec-SecurityGroup"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:23 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:53 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/security-groups/e4836528-d0df-425e-a117-ae8ec6f356d4
@@ -7569,7 +9021,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 92b2900a008d4685ba39d3f4675a4ab6
+      - d6862fbac8aa46019709a4caed2e9b25
   response:
     status:
       code: 200
@@ -7580,9 +9032,9 @@ http_interactions:
       Content-Length:
       - '880'
       X-Openstack-Request-Id:
-      - req-0f19520b-c116-466f-8981-e4e2a7914419
+      - req-2441176c-685b-4a20-a0bc-dcfad898ef94
       Date:
-      - Tue, 08 Jan 2019 19:17:24 GMT
+      - Mon, 04 Mar 2019 20:05:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"security_group": {"tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
@@ -7596,5 +9048,5 @@ http_interactions:
         "port_range_max": null, "port_range_min": null, "id": "75924ebc-4758-4042-ad04-4ef3c9189098",
         "security_group_id": "e4836528-d0df-425e-a117-ae8ec6f356d4"}], "name": "EmsRefreshSpec-SecurityGroup2"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:17:24 GMT
+  recorded_at: Mon, 04 Mar 2019 20:05:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_volume_targeted_refresh.yml
@@ -17,13 +17,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:44 GMT
+      - Mon, 04 Mar 2019 20:04:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-93dc84fe-c20e-4261-a7e0-4fa654b523d7
+      - req-a55be9b2-76e3-4f93-98b9-3795bf64743e
       Content-Length:
       - '4170'
       Connection:
@@ -32,10 +32,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:44.221401", "expires":
-        "2019-01-08T20:16:44Z", "id": "b02fa910ee054002bb8429ea5a3d3c17", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:04.533848", "expires":
+        "2019-03-04T21:04:04Z", "id": "7f07357507454adfad50edec2c52e8a1", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["DgdUSCJJR4S00iYKt8egnw"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["yD1ySNxSSPWqFev6E09Fgg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -80,7 +80,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/
@@ -95,7 +95,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02fa910ee054002bb8429ea5a3d3c17
+      - 7f07357507454adfad50edec2c52e8a1
   response:
     status:
       code: 200
@@ -106,7 +106,7 @@ http_interactions:
       Content-Length:
       - '371'
       Date:
-      - Tue, 08 Jan 2019 19:16:44 GMT
+      - Mon, 04 Mar 2019 20:04:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"versions": [{"status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z",
@@ -115,7 +115,7 @@ http_interactions:
         "links": [{"href": "http://10.8.99.233:8774/v2.1/", "rel": "self"}], "min_version":
         "2.1", "version": "2.12", "id": "v2.1"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:44 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:04 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -133,13 +133,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:46 GMT
+      - Mon, 04 Mar 2019 20:04:04 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4c203f44-e471-4460-aefa-835ee8f3eb86
+      - req-5f94f150-fa7f-41c7-9a9a-3d3c97abb9f5
       Content-Length:
       - '4170'
       Connection:
@@ -148,10 +148,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:46.525383", "expires":
-        "2019-01-08T20:16:46Z", "id": "d9508b9a8aa14ffc894c702d79004adc", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:04.883104", "expires":
+        "2019-03-04T21:04:04Z", "id": "841d9abfd7f14262bfdcf7284202402f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["yEbGKig2RxO3rwsl7Nuk5g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["mSFqYYWHS4yQK-Mlz-5MEQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -196,7 +196,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:04 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8776/v2/e54e5c3c19e34720b05661f2ea1ea00a/volumes/0a55c0d5-c780-4e7d-9d09-47f5520c7448
@@ -211,22 +211,22 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - d9508b9a8aa14ffc894c702d79004adc
+      - 841d9abfd7f14262bfdcf7284202402f
   response:
     status:
       code: 200
       message: OK
     headers:
       X-Compute-Request-Id:
-      - req-dfb96de1-4033-487a-8b15-c4164e9fb49b
+      - req-d56cab58-07da-4099-a796-e6c821997687
       Content-Type:
       - application/json
       Content-Length:
       - '1406'
       X-Openstack-Request-Id:
-      - req-dfb96de1-4033-487a-8b15-c4164e9fb49b
+      - req-d56cab58-07da-4099-a796-e6c821997687
       Date:
-      - Tue, 08 Jan 2019 19:16:46 GMT
+      - Mon, 04 Mar 2019 20:04:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volume": {"migration_status": null, "attachments": [{"server_id":
@@ -247,7 +247,7 @@ http_interactions:
         "bootable": "false", "created_at": "2016-11-11T13:49:20.000000", "volume_type":
         "iscsi"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:46 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -265,13 +265,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:47 GMT
+      - Mon, 04 Mar 2019 20:04:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-64ae3416-fb16-4a42-95aa-13d16a3944d5
+      - req-8533030b-85dc-4c5e-9039-e9189581f874
       Content-Length:
       - '4170'
       Connection:
@@ -280,10 +280,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:47.089393", "expires":
-        "2019-01-08T20:16:47Z", "id": "cd0705b0f11b455bbc3b96d8c2539e9d", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:05.543817", "expires":
+        "2019-03-04T21:04:05Z", "id": "5d61db6843f74d89a935dd6980d3c4f9", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["I18iyzx_Rda-BIhYY8_lzA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["YpTK-vXwQ7iAd35iWgNJqQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -328,7 +328,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:05 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -346,13 +346,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:47 GMT
+      - Mon, 04 Mar 2019 20:04:05 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-628af34a-82fc-4240-9584-bc476d65a272
+      - req-109834de-399c-465e-b298-b74a8d810595
       Content-Length:
       - '4170'
       Connection:
@@ -361,10 +361,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:47.295016", "expires":
-        "2019-01-08T20:16:47Z", "id": "a7d99643e145404ba8d798c56cfe535a", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:05.738489", "expires":
+        "2019-03-04T21:04:05Z", "id": "ccf2e54a77b7434a9440889b008a7fc4", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["kPwE9EIaTZGh7TEuc_b7nA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["NN3jb8DqTdGaNt7t5cJPpg"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -409,7 +409,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:05 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b
@@ -424,7 +424,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02fa910ee054002bb8429ea5a3d3c17
+      - 7f07357507454adfad50edec2c52e8a1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -437,9 +437,9 @@ http_interactions:
       Content-Length:
       - '2088'
       X-Compute-Request-Id:
-      - req-56214e4c-a38c-4ca6-8633-1496641ab85c
+      - req-73a6eb76-d447-4fec-978d-3ad0b1b78614
       Date:
-      - Tue, 08 Jan 2019 19:16:47 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"server": {"status": "ACTIVE", "updated": "2018-10-09T18:40:19Z",
@@ -466,7 +466,7 @@ http_interactions:
         "", "progress": 0, "OS-EXT-STS:power_state": 1, "config_drive": "", "metadata":
         {}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6
@@ -481,7 +481,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02fa910ee054002bb8429ea5a3d3c17
+      - 7f07357507454adfad50edec2c52e8a1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -494,9 +494,9 @@ http_interactions:
       Content-Length:
       - '433'
       X-Compute-Request-Id:
-      - req-a6b9cb76-fdd2-4788-96da-0dd58700b7c5
+      - req-06f709e8-c8c7-4964-a92b-150ac513eb39
       Date:
-      - Tue, 08 Jan 2019 19:16:47 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"flavor": {"name": "m1.ems_refresh_spec", "links": [{"href": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/flavors/6",
@@ -505,7 +505,7 @@ http_interactions:
         1, "swap": 512, "os-flavor-access:is_public": true, "rxtx_factor": 1.0, "OS-FLV-EXT-DATA:ephemeral":
         1, "disk": 1, "id": "6"}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:47 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -523,13 +523,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:47 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-f293365b-ebd3-43fe-970e-06d73082feae
+      - req-0ab060a0-e312-4113-9dbd-4e5bc848fd93
       Content-Length:
       - '4170'
       Connection:
@@ -538,10 +538,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:47.981297", "expires":
-        "2019-01-08T20:16:47Z", "id": "915356c012a1477382fd12901a14a971", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:06.440798", "expires":
+        "2019-03-04T21:04:06Z", "id": "03633661f09a4736b60bfe06e0e75d9f", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["7UcUzK8lR6-MU9BC_ua43g"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["ibEggoy9QPKfD6qO7UQITQ"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -586,7 +586,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -601,20 +601,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 915356c012a1477382fd12901a14a971
+      - 03633661f09a4736b60bfe06e0e75d9f
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-e99fcdb5-9d43-42e1-8b49-625c88de92f4
+      - req-7dab4b73-695b-4056-b9ca-fa65de529054
       Content-Length:
       - '500'
       Connection:
@@ -631,7 +631,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: get
     uri: http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a/servers/ca4f3a16-bae3-4407-83e9-f77b28af0f2b/os-volume_attachments
@@ -646,7 +646,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - b02fa910ee054002bb8429ea5a3d3c17
+      - 7f07357507454adfad50edec2c52e8a1
       X-Openstack-Nova-Api-Version:
       - '2.12'
   response:
@@ -659,15 +659,15 @@ http_interactions:
       Content-Length:
       - '197'
       X-Compute-Request-Id:
-      - req-07dbedb3-a338-4acf-95b2-d1a13657e97b
+      - req-435677f3-6562-4837-be6c-b4b098386b83
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"volumeAttachments": [{"device": "/dev/vdd", "serverId": "ca4f3a16-bae3-4407-83e9-f77b28af0f2b",
         "id": "0a55c0d5-c780-4e7d-9d09-47f5520c7448", "volumeId": "0a55c0d5-c780-4e7d-9d09-47f5520c7448"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -685,13 +685,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:06 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-221bca2e-c0d7-48dd-ad69-8f97cde57dd9
+      - req-1fdfb0f5-99c4-4d29-b744-15f66a6d9fe7
       Content-Length:
       - '4170'
       Connection:
@@ -700,10 +700,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:48.452307", "expires":
-        "2019-01-08T20:16:48Z", "id": "8c0e59f8556f4506b4d69b4bfa5f3afe", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:06.955551", "expires":
+        "2019-03-04T21:04:06Z", "id": "124d599a9c654a7fb631a870c0c7ec22", "tenant":
         {"description": "admin tenant", "enabled": true, "id": "e54e5c3c19e34720b05661f2ea1ea00a",
-        "name": "admin"}, "audit_ids": ["ZONOjTFXRbG79iTl6yFZqA"]}, "serviceCatalog":
+        "name": "admin"}, "audit_ids": ["tP6pwn3gTxuQWxBR6W118A"]}, "serviceCatalog":
         [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e54e5c3c19e34720b05661f2ea1ea00a"}],
@@ -748,7 +748,7 @@ http_interactions:
         {"is_admin": 0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "9fe2ff9ee4384b1894a90878d3e92bab",
         "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:06 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -766,13 +766,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-28e41396-0696-4053-886c-77b38f67e17a
+      - req-b3649ffd-5021-483e-b7a5-fcf4b61e4e2b
       Content-Length:
       - '370'
       Connection:
@@ -781,13 +781,13 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:48.615797", "expires":
-        "2019-01-08T20:16:48Z", "id": "a920989a723e41a3a8d0280477453871", "audit_ids":
-        ["t85-n54ySdCw3poeWYQdZw"]}, "serviceCatalog": [], "user": {"username": "admin",
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:07.130395", "expires":
+        "2019-03-04T21:04:07Z", "id": "104468f292804b5c8a80cfe4bc5b0aa2", "audit_ids":
+        ["GqYmAVdgToC3HwxZAvx4LQ"]}, "serviceCatalog": [], "user": {"username": "admin",
         "roles_links": [], "id": "80ea157498b44d08aa6d6f54b8a7c3e7", "roles": [],
         "name": "admin"}, "metadata": {"is_admin": 0, "roles": []}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:07 GMT
 - request:
     method: get
     uri: http://11.22.33.44:5000/v2.0/tenants
@@ -802,20 +802,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a920989a723e41a3a8d0280477453871
+      - 104468f292804b5c8a80cfe4bc5b0aa2
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-4ff2774f-f785-4d13-99f1-d8e8f32e006e
+      - req-d5af45a1-a853-450a-90c8-85249d4e47de
       Content-Length:
       - '500'
       Connection:
@@ -832,7 +832,7 @@ http_interactions:
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
         "name": "EmsRefreshSpec-Project2"}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -850,13 +850,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:48 GMT
+      - Mon, 04 Mar 2019 20:04:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-83e3e5c6-9c0f-4de3-a908-530c153e44c2
+      - req-923ef286-142f-490f-90cb-0d858813d235
       Content-Length:
       - '4117'
       Connection:
@@ -865,10 +865,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:48.948537", "expires":
-        "2019-01-08T20:16:48Z", "id": "cc2af7e909f54aa78474cf13a0588e30", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:07.466347", "expires":
+        "2019-03-04T21:04:07Z", "id": "3c0647cddb1a4f5cbe64211dc6a725a6", "tenant":
         {"description": "", "enabled": true, "id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["HoqJVPwtQqKacGrLhZSUzA"]},
+        "name": "EmsRefreshSpec-Project"}, "audit_ids": ["jREgNJ7iQKOkbaP__of3iQ"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/69f8f7205ade4aa59084c32c83e60b5a"}],
@@ -912,7 +912,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:48 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -930,13 +930,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:49 GMT
+      - Mon, 04 Mar 2019 20:04:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-65898a6c-1d0b-40e6-b431-f44525122dba
+      - req-ec9839d5-3de3-439e-9444-d01fa0e3edb6
       Content-Length:
       - '4131'
       Connection:
@@ -945,10 +945,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:49.144000", "expires":
-        "2019-01-08T20:16:49Z", "id": "a9ef531d7d68414ea32b2f8b019ae94f", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:07.662436", "expires":
+        "2019-03-04T21:04:07Z", "id": "fc72e48944da4182b223b45f72338b2c", "tenant":
         {"description": "", "enabled": true, "id": "b458a5c25c3749758f4c0661940b3ba8",
-        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["tJxcE0GnR2a4HXbH661VIw"]},
+        "name": "EmsRefreshSpec-Project-No-Admin-Role"}, "audit_ids": ["ta5IG2IbT42dteskhCiKbA"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/b458a5c25c3749758f4c0661940b3ba8"}],
@@ -992,7 +992,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:07 GMT
 - request:
     method: post
     uri: http://11.22.33.44:5000/v2.0/tokens
@@ -1010,13 +1010,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 08 Jan 2019 19:16:49 GMT
+      - Mon, 04 Mar 2019 20:04:07 GMT
       Server:
       - Apache/2.4.6 (Red Hat Enterprise Linux)
       Vary:
       - X-Auth-Token,Accept-Encoding
       X-Openstack-Request-Id:
-      - req-265c865e-5b6c-4770-b7de-2b25f7be4fd7
+      - req-b06ce1a0-c993-4845-bfa1-3f6729b70151
       Content-Length:
       - '4118'
       Connection:
@@ -1025,10 +1025,10 @@ http_interactions:
       - application/json
     body:
       encoding: ASCII-8BIT
-      string: '{"access": {"token": {"issued_at": "2019-01-08T19:16:49.333671", "expires":
-        "2019-01-08T20:16:49Z", "id": "e4bfc71dfab0418bb50a2441caae33ca", "tenant":
+      string: '{"access": {"token": {"issued_at": "2019-03-04T20:04:07.864444", "expires":
+        "2019-03-04T21:04:07Z", "id": "fa87434be6c54cbc8be675ed3413cc3e", "tenant":
         {"description": "", "enabled": true, "id": "e8f744b1fc6a487681d35fb275252608",
-        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["NrTJEGgtSPa0ZSaiW3q0uA"]},
+        "name": "EmsRefreshSpec-Project2"}, "audit_ids": ["62VIdoYZS5KN3eYRKr8H-Q"]},
         "serviceCatalog": [{"endpoints": [{"adminURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "region": "RegionOne", "internalURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608",
         "id": "33f58c6950134a2381bb3668fae5a325", "publicURL": "http://10.8.99.233:8774/v2/e8f744b1fc6a487681d35fb275252608"}],
@@ -1072,7 +1072,7 @@ http_interactions:
         {"name": "heat_stack_owner"}], "name": "admin"}, "metadata": {"is_admin":
         0, "roles": ["bafabff3f3174e6ab41388bde984e1e5", "725d26e4ae494cc689c60f857e347267"]}}}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:07 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
@@ -1087,7 +1087,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc2af7e909f54aa78474cf13a0588e30
+      - 3c0647cddb1a4f5cbe64211dc6a725a6
   response:
     status:
       code: 200
@@ -1098,183 +1098,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-81cdc753-f0e1-4987-9655-e785f1dd3e78
+      - req-901f2ccc-7a66-4706-9563-34caa1b67208
       Date:
-      - Tue, 08 Jan 2019 19:16:49 GMT
+      - Mon, 04 Mar 2019 20:04:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
         [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:49 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - cc2af7e909f54aa78474cf13a0588e30
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-5492c552-937a-4ffa-a5d4-8869f6a9f7b7
-      Date:
-      - Tue, 08 Jan 2019 19:16:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
         "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
         "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -1323,6 +1185,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1336,7 +1204,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -1351,7 +1219,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc2af7e909f54aa78474cf13a0588e30
+      - 3c0647cddb1a4f5cbe64211dc6a725a6
   response:
     status:
       code: 200
@@ -1362,34 +1230,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7e427f4d-5fd9-49fa-a047-11a15f160421
+      - req-83640111-29f5-4cf9-9b09-c881065ba8fa
       Date:
-      - Tue, 08 Jan 2019 19:16:49 GMT
+      - Mon, 04 Mar 2019 20:04:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1455,6 +1317,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1468,7 +1336,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:49 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -1483,7 +1351,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - cc2af7e909f54aa78474cf13a0588e30
+      - 3c0647cddb1a4f5cbe64211dc6a725a6
   response:
     status:
       code: 200
@@ -1494,166 +1362,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-40a0defd-1e51-47e6-a817-53d4d1ec9c48
+      - req-c7295a08-153e-4983-91fc-fc1050c7ff08
       Date:
-      - Tue, 08 Jan 2019 19:16:50 GMT
+      - Mon, 04 Mar 2019 20:04:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:50 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - a9ef531d7d68414ea32b2f8b019ae94f
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-a4ae7a37-f283-4610-970c-e207be39c4cd
-      Date:
-      - Tue, 08 Jan 2019 19:16:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -1719,6 +1449,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -1732,10 +1468,10 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:50 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:08 GMT
 - request:
     method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -1747,7 +1483,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - a9ef531d7d68414ea32b2f8b019ae94f
+      - fc72e48944da4182b223b45f72338b2c
   response:
     status:
       code: 200
@@ -1758,12 +1494,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-6f49d726-52ea-4bb2-8e34-85715a9115d4
+      - req-677b5f36-e958-4511-89e9-f6fd0359ea09
       Date:
-      - Tue, 08 Jan 2019 19:16:51 GMT
+      - Mon, 04 Mar 2019 20:04:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -1798,191 +1581,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8c0e59f8556f4506b4d69b4bfa5f3afe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-1162e524-d805-46a5-a75e-3628611663b3
-      Date:
-      - Tue, 08 Jan 2019 19:16:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
         false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
         "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -1996,7 +1600,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2011,7 +1615,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 8c0e59f8556f4506b4d69b4bfa5f3afe
+      - fc72e48944da4182b223b45f72338b2c
   response:
     status:
       code: 200
@@ -2022,298 +1626,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-1ed65bac-bdfa-42dd-9710-946a8e294dce
+      - req-aa13e57b-f107-4bb8-a5ba-a3d81ec7f9d9
       Date:
-      - Tue, 08 Jan 2019 19:16:51 GMT
+      - Mon, 04 Mar 2019 20:04:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 8c0e59f8556f4506b4d69b4bfa5f3afe
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-864231b0-934d-492b-9459-c4f8695f7894
-      Date:
-      - Tue, 08 Jan 2019 19:16:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
-        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
-        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
-        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
-        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
-        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
-        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
-        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
-        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
-        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
-        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
-    http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:51 GMT
-- request:
-    method: get
-    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.45.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - e4bfc71dfab0418bb50a2441caae33ca
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '8299'
-      X-Openstack-Request-Id:
-      - req-3e3aae76-9c18-4603-8daa-532d25eb11cd
-      Date:
-      - Tue, 08 Jan 2019 19:16:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp":
-        true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2379,6 +1713,12 @@ http_interactions:
         "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
         "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
         "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
@@ -2392,7 +1732,7 @@ http_interactions:
         4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
         "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:51 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:08 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2407,7 +1747,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e4bfc71dfab0418bb50a2441caae33ca
+      - fc72e48944da4182b223b45f72338b2c
   response:
     status:
       code: 200
@@ -2418,51 +1758,45 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-cf275091-9f4a-4c10-95b1-aeb6ca372813
+      - req-191f6d9f-3d33-48fb-bb59-7a34d0bd3d2a
       Date:
-      - Tue, 08 Jan 2019 19:16:52 GMT
+      - Mon, 04 Mar 2019 20:04:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
-        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
-        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
-        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
-        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
-        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPublic", "enable_dhcp": false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "172.16.17.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2",
-        "end": "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
         "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
         "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
         "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
         "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
-        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
-        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
-        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
-        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
         false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
@@ -2511,6 +1845,12 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
@@ -2524,7 +1864,7 @@ http_interactions:
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
         "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
@@ -2539,7 +1879,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e4bfc71dfab0418bb50a2441caae33ca
+      - fc72e48944da4182b223b45f72338b2c
   response:
     status:
       code: 200
@@ -2550,46 +1890,28 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-7b6372a4-1436-46bd-bc08-de04d636967a
+      - req-cefcf946-1b5b-4c6f-b9c4-7703b3e4ead3
       Date:
-      - Tue, 08 Jan 2019 19:16:52 GMT
+      - Mon, 04 Mar 2019 20:04:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
-        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
-        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
-        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
-        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
-        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
-        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
         "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
-        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
-        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
-        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
-        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
-        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
-        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
-        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
-        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
-        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
-        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
-        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
-        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2643,20 +1965,38 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
-        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:10 GMT
 - request:
     method: get
     uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
@@ -2671,7 +2011,7 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - e4bfc71dfab0418bb50a2441caae33ca
+      - fc72e48944da4182b223b45f72338b2c
   response:
     status:
       code: 200
@@ -2682,12 +2022,59 @@ http_interactions:
       Content-Length:
       - '8299'
       X-Openstack-Request-Id:
-      - req-d72cc7b1-75ce-4932-ba9a-687ed71a3fd8
+      - req-d150012e-198b-4f00-b5e5-5c3e310a3c63
       Date:
-      - Tue, 08 Jan 2019 19:16:52 GMT
+      - Mon, 04 Mar 2019 20:04:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
         true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
         "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
@@ -2722,6 +2109,73 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
         "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:10 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-9d7f34b3-0924-4dc4-8abc-bd12811915e1
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
         false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
         "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
@@ -2775,18 +2229,1620 @@ http_interactions:
         "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
         "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
         null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
-        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate", "enable_dhcp":
-        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
-        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.0.1", "ipv6_ra_mode":
-        null, "allocation_pools": [{"start": "192.168.0.3", "end": "192.168.0.5"},
-        {"start": "192.168.0.8", "end": "192.168.0.8"}], "host_routes": [], "ip_version":
-        4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24", "id": "104c081f-97dd-42b7-8930-98abbd015c74",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-602c21ff-e52e-4278-a398-4e431e6f06f1
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
         "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
         true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
         "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
         null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
         "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
-        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}]}'
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
     http_version: 
-  recorded_at: Tue, 08 Jan 2019 19:16:52 GMT
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6f440113-13f9-4c53-9d64-c8eaf001b3ea
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4adadfe3-193e-4d57-9239-59a2e7d43233
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5bb53d19-0a10-40d0-90ff-038e44b5faf6
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-0aaad4f0-43ff-4182-af1c-9450f50bd402
+      Date:
+      - Mon, 04 Mar 2019 20:04:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:11 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fc72e48944da4182b223b45f72338b2c
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-d7cfb158-2f41-464c-a933-f7ea75c76cd6
+      Date:
+      - Mon, 04 Mar 2019 20:04:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 124d599a9c654a7fb631a870c0c7ec22
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-6abfcf1e-f526-4c23-8604-2f4589da7877
+      Date:
+      - Mon, 04 Mar 2019 20:04:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 124d599a9c654a7fb631a870c0c7ec22
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-4938f7b8-b216-406c-aec9-1e180a40b74e
+      Date:
+      - Mon, 04 Mar 2019 20:04:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fa87434be6c54cbc8be675ed3413cc3e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-bfc8d76f-21db-4db1-8dd1-7450b827626b
+      Date:
+      - Mon, 04 Mar 2019 20:04:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:12 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fa87434be6c54cbc8be675ed3413cc3e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-e62f2e1b-2af6-48bd-9138-7a6cf62b1bb3
+      Date:
+      - Mon, 04 Mar 2019 20:04:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.30.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.30.2", "end": "192.168.30.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.30.0/24",
+        "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2",
+        "end": "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp":
+        true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.3.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.3.8", "end": "192.168.3.10"}, {"start":
+        "192.168.3.2", "end": "192.168.3.6"}], "host_routes": [], "ip_version": 4,
+        "ipv6_address_mode": null, "cidr": "192.168.3.0/24", "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.11", "end":
+        "172.16.17.19"}, {"start": "172.16.17.2", "end": "172.16.17.9"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp": false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.21.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2",
+        "end": "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.2",
+        "end": "192.168.50.2"}, {"start": "192.168.50.4", "end": "192.168.50.4"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp":
+        true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.20.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.20.2", "end": "192.168.20.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.20.0/24",
+        "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp": true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.2.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.2.2",
+        "end": "192.168.2.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.2.0/24", "id": "bb23bb48-804d-4416-bac3-231db23841e8",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.51.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2", "end":
+        "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.8", "end": "192.168.0.8"}, {"start": "192.168.0.3", "end": "192.168.0.5"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.1.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.1.2", "end": "192.168.1.254"}], "host_routes": [], "ip_version":
+        4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24", "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3",
+        "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=d53802a5-f0f6-48ba-9207-dbd9b13acac3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fa87434be6c54cbc8be675ed3413cc3e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-8b5e13f1-acaa-41a0-9cb9-2d9bf6f053d9
+      Date:
+      - Mon, 04 Mar 2019 20:04:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:13 GMT
+- request:
+    method: get
+    uri: http://10.8.99.233:9696/v2.0/subnets?limit=1000&marker=104c081f-97dd-42b7-8930-98abbd015c74
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - fa87434be6c54cbc8be675ed3413cc3e
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '8299'
+      X-Openstack-Request-Id:
+      - req-5c6a9527-6d8a-4429-a8f2-63fe0ac07850
+      Date:
+      - Mon, 04 Mar 2019 20:04:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"subnets": [{"name": "EmsRefreshSpec-SubnetPublic", "enable_dhcp":
+        false, "network_id": "20af6027-7aeb-432a-ab3b-d7217faa2f1c", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.17.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.17.2", "end":
+        "172.16.17.9"}, {"start": "172.16.17.11", "end": "172.16.17.19"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "172.16.17.0/24",
+        "id": "33da95a6-bded-44d8-be36-6cc97f3d72bd", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_20", "enable_dhcp": false, "network_id": "8da920f8-705d-4777-a938-e081b01ad41c",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.19.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.19.21",
+        "end": "172.16.19.23"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.19.0/24", "id": "c68ac5c0-9d9e-438b-a10f-6d0faeee0790",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-IsolatedSubnetPrivate_2",
+        "enable_dhcp": true, "network_id": "6ad8942f-11ef-4419-bdf5-9ba3561b6281",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.50.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.50.4",
+        "end": "192.168.50.4"}, {"start": "192.168.50.2", "end": "192.168.50.2"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.50.0/24",
+        "id": "826fd5a9-7a7a-4c40-a9b1-bd69041bbad4", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_20", "enable_dhcp": true, "network_id": "9e63fc1a-c0d4-4a1d-b91c-07e6c9c85076",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.20.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.20.2",
+        "end": "192.168.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.20.0/24", "id": "2092b802-1034-4fb8-9c5e-1ec61d1e463f",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_2", "enable_dhcp":
+        true, "network_id": "4fadcfb0-493b-4a00-a2a8-e357f8115d96", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.2.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.2.2", "end": "192.168.2.254"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.2.0/24",
+        "id": "bb23bb48-804d-4416-bac3-231db23841e8", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPublic_51", "enable_dhcp": false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "172.16.51.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.51.2",
+        "end": "172.16.51.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.51.0/24", "id": "68682f0f-b0e4-4f6d-9f96-d1dfb6a6c2b2",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_10", "enable_dhcp":
+        false, "network_id": "83e63648-5a43-4db0-907c-cf9ca0150336", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.18.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.18.2", "end":
+        "172.16.18.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.18.0/24", "id": "93c2f53c-df39-491e-b45b-ce8b36b29437",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_30", "enable_dhcp":
+        false, "network_id": "64bf0546-b600-4bd7-a519-9353bde2e235", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.20.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.20.2", "end":
+        "172.16.20.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.20.0/24", "id": "4d8b0801-addf-4ad4-8f46-e5bffa6a1002",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_31", "enable_dhcp":
+        true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.31.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.31.2", "end": "192.168.31.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.31.0/24",
+        "id": "841b5584-f86f-4abd-9bc2-f445b8bc860b", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_1", "enable_dhcp": true, "network_id":
+        "560b4210-2b5a-4439-8d24-203e09478f48", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.40.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.40.2", "end": "192.168.40.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.40.0/24",
+        "id": "448a986a-19a9-4684-ab6e-25cbf19ae30d", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-IsolatedSubnetPrivate_21", "enable_dhcp": true, "network_id":
+        "6ad8942f-11ef-4419-bdf5-9ba3561b6281", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": [], "gateway_ip": "192.168.51.1", "ipv6_ra_mode": null,
+        "allocation_pools": [{"start": "192.168.51.2", "end": "192.168.51.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.51.0/24",
+        "id": "edfcb49b-e917-4897-b8ae-859ef3dae2de", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_3", "enable_dhcp": true, "network_id": "1c785619-a768-4788-b3b5-ac39ebc2cea1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.3.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.3.2",
+        "end": "192.168.3.6"}, {"start": "192.168.3.8", "end": "192.168.3.10"}], "host_routes":
+        [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.3.0/24",
+        "id": "82ca5926-43cb-4312-a23f-727d5c0f5bae", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate_30", "enable_dhcp": true, "network_id": "c82b70e9-0847-43e9-9bde-b98b1ae445e9",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip":
+        "192.168.30.1", "ipv6_ra_mode": null, "allocation_pools": [{"start": "192.168.30.2",
+        "end": "192.168.30.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "192.168.30.0/24", "id": "39628ee0-d5ff-4a88-ae66-80442e5feefd",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_50", "enable_dhcp":
+        false, "network_id": "6b46d522-85a1-4ce2-a276-2fab7cde0946", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.50.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.50.2", "end":
+        "172.16.50.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.50.0/24", "id": "d71653c5-34d2-47bd-9cd2-d93330a34d44",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPublic_40", "enable_dhcp":
+        false, "network_id": "68259081-a5ca-425f-9d9b-816eb62148a3", "tenant_id":
+        "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": [], "gateway_ip": "172.16.21.1",
+        "ipv6_ra_mode": null, "allocation_pools": [{"start": "172.16.21.2", "end":
+        "172.16.21.254"}], "host_routes": [], "ip_version": 4, "ipv6_address_mode":
+        null, "cidr": "172.16.21.0/24", "id": "d0065ae4-dffb-4dcc-9e44-a0b1166337f3",
+        "subnetpool_id": null}, {"name": "EmsRefreshSpec-SubnetPrivate_12", "enable_dhcp":
+        true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1", "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a",
+        "dns_nameservers": ["8.8.8.8"], "gateway_ip": "192.168.1.1", "ipv6_ra_mode":
+        null, "allocation_pools": [{"start": "192.168.1.2", "end": "192.168.1.254"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.1.0/24",
+        "id": "d53802a5-f0f6-48ba-9207-dbd9b13acac3", "subnetpool_id": null}, {"name":
+        "EmsRefreshSpec-SubnetPrivate", "enable_dhcp": true, "network_id": "c0e8e42b-005e-4183-8f25-fa91b3e441c1",
+        "tenant_id": "69f8f7205ade4aa59084c32c83e60b5a", "dns_nameservers": ["8.8.8.8"],
+        "gateway_ip": "192.168.0.1", "ipv6_ra_mode": null, "allocation_pools": [{"start":
+        "192.168.0.3", "end": "192.168.0.5"}, {"start": "192.168.0.8", "end": "192.168.0.8"}],
+        "host_routes": [], "ip_version": 4, "ipv6_address_mode": null, "cidr": "192.168.0.0/24",
+        "id": "104c081f-97dd-42b7-8930-98abbd015c74", "subnetpool_id": null}]}'
+    http_version: 
+  recorded_at: Mon, 04 Mar 2019 20:04:13 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR would cause Cinder availability zones to be split from Nova availability zones when using the modern inventory collection system. Currently both kinds of AZs are collected together and then merged under the CloudManager, which works when the AZs coincidentally share names but is broken the rest of the time, since they are not interchangeable. Splitting up the two kinds of AZs would allow the Create Volume form to list only the Cinder AZs instead of having to list a mix of valid and invalid options.

@Ladas or @aufi, do you have any thoughts about how I'm going about this, or know anything about why these were originally merged in the first place?