### PR TITLE
Tag AvailabilityZones with the service(s) they belong to so that Cinder and Nova AZs can be identified

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -215,6 +215,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     authentication_for_providers.collect(&:authentication_type) - [:ssh_keypair]
   end
 
+  def volume_availability_zones
+    availability_zones.where("'volume' = ANY(provider_services_supported)")
+  end
+
   #
   # Operations
   #

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -104,6 +104,12 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     end
   end
 
+  def allowed_availability_zones(_options = {})
+    source = load_ar_obj(get_source_vm)
+    targets = get_targets_for_ems(source, :cloud_filter, AvailabilityZone, 'availability_zones.available')
+    targets.each_with_object({}) { |az, h| h[az.id] = az.name if az.provider_services_supported.include?("compute") }
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -39,32 +39,33 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
 
   def initialize_inventory_sources
     # cloud
-    @availability_zones        = []
-    @cloud_services            = []
-    @tenants                   = []
-    @flavors                   = []
-    @host_aggregates           = []
-    @key_pairs                 = []
-    @images                    = []
-    @orchestration_stacks      = nil
-    @quotas                    = []
-    @vms                       = []
-    @vnfs                      = []
-    @vnfds                     = []
-    @volume_templates          = []
-    @volume_snapshot_templates = []
+    @availability_zones_compute = []
+    @availability_zones_volume  = []
+    @cloud_services             = []
+    @tenants                    = []
+    @flavors                    = []
+    @host_aggregates            = []
+    @key_pairs                  = []
+    @images                     = []
+    @orchestration_stacks       = nil
+    @quotas                     = []
+    @vms                        = []
+    @vnfs                       = []
+    @vnfds                      = []
+    @volume_templates           = []
+    @volume_snapshot_templates  = []
     # network
-    @cloud_networks            = []
-    @cloud_subnets             = []
-    @floating_ips              = []
-    @network_ports             = []
-    @network_routers           = []
-    @security_groups           = []
+    @cloud_networks             = []
+    @cloud_subnets              = []
+    @floating_ips               = []
+    @network_ports              = []
+    @network_routers            = []
+    @security_groups            = []
     # cinder
-    @cloud_volumes             = []
-    @cloud_volume_snapshots    = []
-    @cloud_volume_backups      = []
-    @cloud_volume_types        = []
+    @cloud_volumes              = []
+    @cloud_volume_snapshots     = []
+    @cloud_volume_backups       = []
+    @cloud_volume_types         = []
   end
 
   def connection

--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -2,16 +2,20 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
 
   def availability_zones_compute
-    @availability_zones_compute ||= safe_list { compute_service.availability_zones.summary }
+    return @availability_zones_compute if @availability_zones_compute.any?
+    @availability_zones_compute = safe_list { compute_service.availability_zones.summary }
+    @availability_zones_compute = @availability_zones_compute.collect(&:zoneName).to_set
   end
 
   def availability_zones_volume
     return [] unless volume_service
-    @availability_zones_volume ||= safe_list { volume_service.availability_zones.summary }
+    return @availability_zones_volume if @availability_zones_volume.any?
+    @availability_zones_volume = safe_list { volume_service.availability_zones.summary }
+    @availability_zones_volume = @availability_zones_volume.collect(&:zoneName).to_set
   end
 
   def availability_zones
-    (availability_zones_compute + availability_zones_volume).uniq(&:zoneName)
+    @availability_zones ||= (availability_zones_compute + availability_zones_volume).to_set
   end
 
   def cloud_services

--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -24,10 +24,16 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
   end
 
   def availability_zones
+    availability_zones_compute
+  end
+
+  def availability_zones_compute
     return [] if references(:availability_zones).blank?
-    @availability_zones = references(:availability_zones).collect do |az|
-      OpenStruct.new(:zoneName => az)
-    end
+    @availability_zones_compute = references(:availability_zones)
+  end
+
+  def availability_zones_volume
+    []
   end
 
   def cloud_networks

--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -45,14 +45,23 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
 
   def availability_zones
     collector.availability_zones.each do |az|
-      availability_zone = persister.availability_zones.find_or_build(az.zoneName)
-      availability_zone.ems_ref = az.zoneName
-      availability_zone.name = az.zoneName
+      availability_zone = persister.availability_zones.find_or_build(az)
+      availability_zone.ems_ref = az
+      availability_zone.name = az
+      availability_zone.provider_services_supported = []
+      if collector.availability_zones_compute.include?(az)
+        availability_zone.provider_services_supported.append("compute")
+      end
+      if collector.availability_zones_volume.include?(az)
+        availability_zone.provider_services_supported.append("volume")
+      end
     end
+
     # ensure the null az exists
     null_az = persister.availability_zones.find_or_build("null_az")
     null_az.type = "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull"
     null_az.ems_ref = "null_az"
+    null_az.provider_services_supported = ["compute"]
   end
 
   def cloud_services

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
       volume.multi_attachment = v.attributes['multiattach']
       volume.base_snapshot = persister.cloud_volume_snapshots.lazy_find(v.snapshot_id)
       volume.cloud_tenant = persister.cloud_tenants.lazy_find(v.tenant_id)
-      volume.availability_zone = persister.availability_zones.lazy_find(v.availability_zone || "null_az")
+      volume.availability_zone = persister.availability_zones.lazy_find(v.availability_zone)
 
       volume_attachments(volume, v.attachments)
     end
@@ -56,7 +56,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
       backup.name = b['display_name'] || b['name']
       backup.description = b['display_description'] || b['description']
       backup.cloud_volume = persister.cloud_volumes.lazy_find(b['volume_id'])
-      backup.availability_zone = persister.availability_zones.lazy_find(b['availability_zone'] || "null_az")
+      backup.availability_zone = persister.availability_zones.lazy_find(b['availability_zone'])
     end
   end
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -9,6 +9,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
   supports :cinder_volume_types
   supports :volume_multiattachment
   supports :volume_resizing
+  supports :volume_availability_zones
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -228,12 +228,17 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       context "with valid relationships" do
         it "#allowed_availability_zones" do
           az = FactoryBot.create(:availability_zone_openstack)
+          az.provider_services_supported = ["compute"]
+          excluded_az = FactoryBot.create(:availability_zone_openstack)
+          excluded_az.provider_services_supported = ["volume"]
           provider.availability_zones << az
           expect(workflow.allowed_availability_zones).to eq(az.id => az.name)
         end
 
         it "#allowed_availability_zones with NULL AZ" do
-          provider.availability_zones << az = FactoryBot.create(:availability_zone_openstack)
+          az = FactoryBot.create(:availability_zone_openstack)
+          az.provider_services_supported = ["compute"]
+          provider.availability_zones << az
           provider.availability_zones << FactoryBot.create(:availability_zone_openstack_null, :ems_ref => "null_az")
 
           azs = workflow.allowed_availability_zones

--- a/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
@@ -175,6 +175,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
     def setup_mocked_collector
       allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:image_service).and_return(double(:name => "not-glance"))
       allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:availability_zones).and_return(mocked_availability_zones)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:availability_zones_compute).and_return(mocked_availability_zones)
+      allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:availability_zones_volume).and_return(mocked_availability_zones)
       allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:cloud_services).and_return(mocked_cloud_services)
       allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:flavors).and_return(mocked_flavors)
       allow_any_instance_of(ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager).to receive(:host_aggregates).and_return(mocked_host_aggregates)


### PR DESCRIPTION
@Ladas @aufi Based on our previous conversation, this PR uses a `services` column to indicate which Openstack services know about an AZ with that name. This seems like a much simpler way to go, and if this looks good I'll put up the other PRs it depends on.

https://bugzilla.redhat.com/show_bug.cgi?id=1549128