### PR TITLE
Support Cinder's volume-extend action

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -44,8 +44,10 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
                         :subject => self,
                       }) do
       with_provider_object do |volume|
+        size = options.delete(:size)
         volume.attributes.merge!(options)
         volume.save
+        volume.extend(size) if size.to_i != volume.size.to_i
       end
     end
   rescue => e

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -8,6 +8,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
 
   supports :cinder_volume_types
   supports :volume_multiattachment
+  supports :volume_resizing
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -78,6 +78,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
     context "#update_volume" do
       it 'updates the volume' do
         expect(the_raw_volume).to receive(:save)
+        expect(the_raw_volume).to receive(:size)
         cloud_volume.update_volume({})
       end
 


### PR DESCRIPTION
There's an RFE for supporting Cinder's volume extend action. I don't know if it'll be accepted, but I had time so why not be proactive about it. https://bugzilla.redhat.com/show_bug.cgi?id=1685063

Volume extension has to be done via a separate request from updating other fields. I've added it as part of `raw_update_volume` since the alternative would be having to add a new UI just for this purpose. The way this is set up, if updating the volume's attributes fail, the whole thing will fail. But if only extending fails, the rest of the update will succeed but you'll still get a message in the UI about the resize having failed. If that seems odd, we could probably set up unique notifications and exceptions for volume-extend so that you get a notification for the attribute update and a separate notification for the results of the extend.

@aufi, what do you think about that?