### PR TITLE
Fix invalid field user_id on Miqtask

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
@@ -56,7 +56,7 @@ module ManageIQ::Providers::Openstack::InfraManager::Host::Operations
                                    power_state = "power off")
     task_opts = {
       :action  => "Set Ironic Node Power State",
-      :user_id => userid
+      :userid  => userid
     }
 
     queue_opts = {


### PR DESCRIPTION
Host's unset_node_maintenance_queue method used user_id field on MiqTask which doesn't exist, changed to userid.

This should this failing CI.