### PR TITLE
Add case for 404 error to ManagerMixin:translate_exception

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -61,6 +61,8 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     def translate_exception(err)
       require 'excon'
       case err
+      when Excon::Errors::NotFound
+        MiqException::MiqHostError.new("Endpoint not found.")
       when Excon::Errors::Unauthorized
         MiqException::MiqInvalidCredentialsError.new("Login failed due to a bad username or password.")
       when Excon::Errors::Timeout


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/628956/55027049-b5055080-4fda-11e9-86ba-445f64e624fa.png)

Fixes the ugly 404 error demonstrated in https://github.com/ManageIQ/manageiq-providers-openstack/issues/455