### PR TITLE
 Create instance snapshots with the owner's project scope

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -282,16 +282,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'create'})
     snapshot_id = snapshot["id"]
 
-    # Add new snapshot to the snapshots table.
-    vm.snapshots.create!(
-      :name        => options[:name],
-      :description => options[:desc],
-      :uid         => snapshot_id,
-      :uid_ems     => snapshot_id,
-      :ems_ref     => snapshot_id,
-      :create_time => snapshot["created"]
-    )
-
     return snapshot_id
   rescue => err
     _log.error "#{log_prefix}, error: #{err}"

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -276,8 +276,9 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   def vm_create_snapshot(vm, options = {})
     log_prefix = "vm=[#{vm.name}]"
 
-    miq_openstack_instance = MiqOpenStackInstance.new(vm.ems_ref, openstack_handle)
-    snapshot = miq_openstack_instance.create_snapshot(options)
+    compute_service = openstack_handle.compute_service(vm.cloud_tenant.name)
+    snapshot = compute_service.create_image(vm.ems_ref, options[:name], :description => options[:desc]).body["image"]
+
     Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'create'})
     snapshot_id = snapshot["id"]
 


### PR DESCRIPTION
This PR causes `vm_create_snapshot` (used by the snapshot creation UI) to create snapshots in the instance's tenant's scope rather than the admin tenant's scope. It also stops `vm_create_snapshot` from creating a MIQ Snapshot which is not used in the Openstack CloudManager and which isn't cleaned up by the refresh process. 

https://bugzilla.redhat.com/show_bug.cgi?id=1685300

This PR does not change `vm_create_evm_snapshot` which appears only to be used by the SmartState vm scan.
