### PR TITLE
Fix tests broken by #18633 changing the base class of AuthKeyPair

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -242,7 +242,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
         end
 
         it "#allowed_guest_access_key_pairs" do
-          kp = AuthPrivateKey.create(:name => "auth_1")
+          kp = ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.create(:name => "auth_1")
           provider.key_pairs << kp
           expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
         end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -62,8 +62,8 @@ module Openstack
       expect(CloudObjectStoreContainer.count).to   eq storage_data.directories.count
       expect(CloudObjectStoreObject.count).to      eq 0
       expect(CloudResourceQuota.count).to          eq 0
-      expect(AuthPrivateKey.count).to              eq 0
       expect(AvailabilityZone.count).to            eq 1 # just NoZone
+      expect(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.count).to eq 0
 
       # We have broken flavor list, but there is fallback for private flavors using get, which will collect used flavors
       expect(Flavor.count).to eq 2
@@ -245,7 +245,7 @@ module Openstack
       expect(Flavor.count).to                            eq compute_data.flavors.count
       expect(AvailabilityZone.count).to                  eq availability_zones_count
       expect(FloatingIp.count).to                        eq network_data.floating_ips.sum
-      expect(AuthPrivateKey.count).to                    eq compute_data.key_pairs.count
+      expect(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.count).to eq compute_data.key_pairs.count
       expect(security_groups_without_defaults.count).to  eq security_groups_count
       expect(firewall_without_defaults.count).to         eq firewall_rules_count
       expect(CloudNetwork.count).to                      eq network_data.networks.count

--- a/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/stubbed_refresher_spec.rb
@@ -88,7 +88,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
           EmsRefresh.refresh(keypair_target)
           assert_do_not_delete
           expect(@ems.key_pairs.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
-          expect(AuthPrivateKey.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
+          expect(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
         end
       end
 
@@ -101,7 +101,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
                                                       :manager_ref => {:ems_ref => nil})
           EmsRefresh.refresh(keypair_target)
           expect(@ems.key_pairs.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
-          expect(AuthPrivateKey.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
+          expect(ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.count).to eq(test_counts(@data_scaling)[:key_pairs_count])
           @data_scaling -= 1
         end
       end
@@ -133,7 +133,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
       image_count_plus_disconnect_inv           = image_count + test_counts(disconnect)[:miq_templates_count]
       volumes_and_snapshots_plus_disconnect_inv = volumes_and_snapshots_count + test_counts(disconnect)[:volume_templates_count] + test_counts(disconnect)[:volume_snapshot_templates_count]
       {
-        :auth_private_key              => test_counts(@data_scaling)[:key_pairs_count],
+        :auth_key_pair                 => test_counts(@data_scaling)[:key_pairs_count],
         :ext_management_system         => 4,
         :flavor                        => test_counts(@data_scaling)[:flavors_count],
         :host_aggregate                => test_counts(@data_scaling)[:host_aggregates_count],
@@ -153,7 +153,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
 
     def assert_table_counts
       actual = {
-        :auth_private_key              => AuthPrivateKey.count,
+        :auth_key_pair                 => ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair.count,
         :ext_management_system         => ExtManagementSystem.count,
         :flavor                        => Flavor.count,
         :host_aggregate                => HostAggregate.count,


### PR DESCRIPTION
Fixes broken tests caused by https://github.com/ManageIQ/manageiq/pull/18633 changing CloudManager::AuthKeyPair to inherit from Authentication instead of AuthPrivateKey.