### PR TITLE
Set panko flag when using settings.yml to define event service

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
@@ -84,6 +84,7 @@ class OpenstackCeilometerEventMonitor < OpenstackEventMonitor
 
   def self.connect_service_from_settings(ems)
     $log.debug "#{_log.prefix} Using events provided by \"#{event_service_settings}\" service, which was set in settings.yml."
+    @panko = (event_service_settings == "panko")
     ems.connect(:service => event_services[event_service_settings])
   end
 


### PR DESCRIPTION
@aufi I missed this while working on the previous PR, but it's part of the same fix.