### PR TITLE
Manage snapshots as part of the inventory refresh process

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
            :foreign_key => :parent_ems_id,
            :class_name  => "ManageIQ::Providers::StorageManager",
            :autosave    => true
-
+  has_many :snapshots, :through => :vms_and_templates
   include ManageIQ::Providers::Openstack::CinderManagerMixin
   include SwiftManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
@@ -277,20 +277,11 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     log_prefix = "vm=[#{vm.name}]"
 
     compute_service = openstack_handle.compute_service(vm.cloud_tenant.name)
-    snapshot = compute_service.create_image(vm.ems_ref, options[:name], :description => options[:desc]).body["image"]
+    snapshot = compute_service.create_image(vm.ems_ref, options[:name], :description   => options[:desc],
+                                                                        :instance_uuid => vm.ems_ref).body["image"]
 
     Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'create'})
     snapshot_id = snapshot["id"]
-
-    # Add new snapshot to the snapshots table.
-    vm.snapshots.create!(
-      :name        => options[:name],
-      :description => options[:desc],
-      :uid         => snapshot_id,
-      :uid_ems     => snapshot_id,
-      :ems_ref     => snapshot_id,
-      :create_time => snapshot["created"]
-    )
 
     return snapshot_id
   rescue => err

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -45,6 +45,8 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
     add_orchestration_stack_ancestry
 
+    add_snapshots
+
     add_vm_and_template_labels
     add_vm_and_template_taggings
   end
@@ -141,6 +143,13 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
   def add_orchestration_stack_ancestry
     add_collection(cloud, :orchestration_stack_ancestry) do |builder|
       builder.remove_dependency_attributes(:orchestration_stacks_resources) unless targeted?
+    end
+  end
+
+  def add_snapshots
+    add_collection(cloud, :snapshots) do |builder|
+      builder.add_properties(:model_class => ::Snapshot)
+      builder.add_properties(:parent_inventory_collections => %i[vms miq_templates])
     end
   end
 


### PR DESCRIPTION
Instance "snapshots" in Openstack are a collection of an image
and a set of volume snapshots. In Horizon these are managed
individually, but ManageIQ abstracts them into a "snapshot"
object with its own UI. These snapshots were not part of the
inventory refresh process and could get out of sync with
the Glance images they represented. This patch causes these
helper objects to be managed by the inventory refresh process.