### PR TITLE
Revert "Don't create a MIQ Snapshot record when creating an OSP Snapshot"

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -282,6 +282,16 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     Notification.create(:type => :vm_snapshot_success, :subject => vm, :options => {:snapshot_op => 'create'})
     snapshot_id = snapshot["id"]
 
+    # Add new snapshot to the snapshots table.
+    vm.snapshots.create!(
+      :name        => options[:name],
+      :description => options[:desc],
+      :uid         => snapshot_id,
+      :uid_ems     => snapshot_id,
+      :ems_ref     => snapshot_id,
+      :create_time => snapshot["created"]
+    )
+
     return snapshot_id
   rescue => err
     _log.error "#{log_prefix}, error: #{err}"


### PR DESCRIPTION
This reverts commit 35cb19d5cb8c812ee67474fbcf45f15ca72276fe, which was mistakenly included in #462 and backported to gaprindashvili and hammer.