### PR TITLE
Fix rails 5-1 errors

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -8,10 +8,11 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     :class_name => 'ManageIQ::Providers::Openstack::InfraManager::HostServiceGroup'
 
   has_many :network_ports, :as => :device
+  has_many :cloud_subnets,   :through => :network_ports
   has_many :network_routers, :through => :cloud_subnets
-  has_many :cloud_networks, :through => :cloud_subnets
+  has_many :cloud_networks,  :through => :cloud_subnets
   alias_method :private_networks, :cloud_networks
-  has_many :cloud_subnets, :through    => :network_ports
+
   has_many :public_networks, :through => :cloud_subnets
 
   has_many :floating_ips, :through => :network_ports

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -239,7 +239,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       expect(vm.validate_resize_confirm).to be false
       expect(service).to receive(:resize_server).with(vm.ems_ref, flavor.ems_ref)
       expect(MiqQueue).to receive(:put)
-      vm.resize(flavor)
+      vm.resize(flavor.id)
     end
 
     it 'confirm resize' do

--- a/spec/models/manageiq/providers/openstack/identity_sync_mixin_spec.rb
+++ b/spec/models/manageiq/providers/openstack/identity_sync_mixin_spec.rb
@@ -117,7 +117,7 @@ describe ManageIQ::Providers::Openstack::IdentitySyncMixin do
 
       expect(miq_group.tenant).to eq(tenant)
       expect(miq_group.entitlement.miq_user_role).to eq(admin_role)
-      expect(miq_group.users.exists?(user)).to be true
+      expect(miq_group.users.exists?(user.id)).to be true
 
       # member
       miq_group = MiqGroup.joins(:entitlement).where(:tenant_id => tenant.id).where('entitlements.miq_user_role_id' => member_role.id).take
@@ -126,7 +126,7 @@ describe ManageIQ::Providers::Openstack::IdentitySyncMixin do
 
       expect(miq_group.tenant).to eq(tenant)
       expect(miq_group.entitlement.miq_user_role).to eq(member_role)
-      expect(miq_group.users.exists?(user)).to be true
+      expect(miq_group.users.exists?(user.id)).to be true
     end
 
     it "group should be named <provider>-<domainID>-<tenant>-<role> for keystone v3" do


### PR DESCRIPTION
The below changes are rails 5.0 and 5.1 compatible.

* Define through association before trying to use it 
* Pass id to AR::Base exists?/find, not AR::Base objs