### PR TITLE
Fix 5.1 deprecation on attribute_was, not 5.0 compatible

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -63,7 +63,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   def refresh_parent_infra_manager
     # If the cloud manager had a new/different infra manager attached to it
     # during this save, refresh the infra manager.
-    if provider_id && (provider_id_was != provider_id) && provider.infra_ems
+    if provider_id && (attribute_before_last_save(:provider_id) != provider_id) && provider.infra_ems
       EmsRefresh.queue_refresh(provider.infra_ems)
       _log.info("EMS: [#{name}] refreshing attached infra manager [#{provider.infra_ems.name}]")
     end


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: The behavior of `attribute_was` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `attribute_before_last_save` instead. (called from refresh_parent_infra_manager at /Users/joerafaniello/Code/manageiq-providers-openstack/app/models/manageiq/providers/openstack/cloud_manager.rb:66)
```