### PR TITLE
The leaf class should be tested

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_worker_spec.rb
@@ -1,28 +1,11 @@
 describe ManageIQ::Providers::Openstack::CloudManager::RefreshWorker do
   context "EMS with children" do
-    let!(:network_manager) { FactoryBot.create(:ems_network) }
-    let!(:storage_manager) { FactoryBot.create(:ems_storage) }
-    let(:ems) do
-      FactoryBot.create(:ems_cloud).tap do |ems|
-        network_manager.update_attributes(:parent_ems_id => ems.id)
-        storage_manager.update_attributes(:parent_ems_id => ems.id)
-      end
-    end
+    let(:ems) { FactoryBot.create(:ems_openstack) }
 
     it ".queue_name_for_ems" do
       queue_name = described_class.queue_name_for_ems(ems)
-      expect(queue_name.count).to eq(3)
+      expect(queue_name.count).to eq(4)
       expect(queue_name.sort).to  eq(queue_name)
-    end
-  end
-
-  context "EMS with no children" do
-    let(:ems) { FactoryBot.create(:ems_cloud) }
-
-    it ".queue_name_for_ems" do
-      queue_name = described_class.queue_name_for_ems(ems)
-      expect(queue_name.count).to eq(1)
-      expect(queue_name.first).to eq(ems.queue_name)
     end
   end
 end


### PR DESCRIPTION
Found here: https://github.com/ManageIQ/manageiq-providers-amazon/pull/542

One of these specs is pointless now since the leaf will always create three. Unless Adam disagrees. I'm sure I'll hear about it if he does. 

Broken originally by https://github.com/ManageIQ/manageiq/pull/18842