### PR TITLE
Fix block_device_mapping in Snapshots Refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -232,7 +232,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
     return true if image.image_type == 'snapshot'
 
     block_device_mapping = image.attributes[:block_device_mapping]
-    source_type = JSON.parse(block_device_mapping)&.dig('source_type') if block_device_mapping
+    block_device_data    = JSON.parse(block_device_mapping) if block_device_mapping
+    block_device_data    = block_device_data.first if block_device_data.kind_of?(Array)
+    source_type          = block_device_data&.dig('source_type')
 
     source_type == 'snapshot'
   rescue JSON::ParserError


### PR DESCRIPTION
OpenStack can return an Array for block_device_mapping on a VM,
updating code to use first element if an Array is provided.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1727275