### PR TITLE
[WIP] Fixing targeted refresh for nested stacks and their resources

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
@@ -63,7 +63,7 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
   end
 
   def collect_orchestration_stack_references!(target_collection, ems_event)
-    stack_id = ems_event.full_data.fetch_path(:content, 'payload', 'stack_id')
+    stack_id = ems_event.full_data.fetch_path(:content, 'payload', 'stack_id') || ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
     tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'tenant_id')
     target_collection.add_target(:association => :orchestration_stacks, :manager_ref => {:ems_ref => stack_id}, :options => {:tenant_id => tenant_id})
   end

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -100,4 +100,21 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   def orchestration_service
     @orchestration_service ||= manager.openstack_handle.detect_orchestration_service
   end
+
+  def all_orchestration_stacks
+    return [] unless orchestration_service
+    # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
+    # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
+    # can't get list of detailed stacks in one API call.
+    return @all_orchestration_stacks unless @all_orchestration_stacks.nil?
+    @all_orchestration_stacks = if openstack_heat_global_admin?
+                                  orchestration_service.handled_list(:stacks, {:show_nested => true, :global_tenant => true}, true).collect(&:details)
+                                else
+                                  orchestration_service.handled_list(:stacks, :show_nested => true).collect(&:details)
+                                end
+  rescue Excon::Errors::Forbidden
+    # Orchestration service is detected but not open to the user
+    $log.warn("Skip refreshing stacks because the user cannot access the orchestration service")
+    []
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -111,20 +111,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
   end
 
   def orchestration_stacks
-    return [] unless orchestration_service
-    # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
-    # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
-    # can't get list of detailed stacks in one API call.
-    return @orchestration_stacks unless @orchestration_stacks.nil?
-    @orchestration_stacks = if openstack_heat_global_admin?
-                                orchestration_service.handled_list(:stacks, {:show_nested => true, :global_tenant => true}, true).collect(&:details)
-                              else
-                                orchestration_service.handled_list(:stacks, :show_nested => true).collect(&:details)
-                              end
-  rescue Excon::Errors::Forbidden
-    # Orchestration service is detected but not open to the user
-    $log.warn("Skip refreshing stacks because the user cannot access the orchestration service")
-    []
+    all_orchestration_stacks
   end
 
   def orchestration_outputs(stack)

--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -94,8 +94,9 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
   def orchestration_stacks
     return [] unless orchestration_service
     return [] if targets_by_association(:orchestration_stacks).blank?
-    return @orchestration_stacks unless @orchestration_stacks.nil?
-    @orchestration_stacks = targets_by_association(:orchestration_stacks).collect do |target|
+    # Cache of this call is done on individual API results, because we call this method multiple times while chenging
+    # the targets_by_association(:orchestration_stacks). The list of targets grows after scanning.
+    targets_by_association(:orchestration_stacks).collect do |target|
       get_orchestration_stack(target.manager_ref[:ems_ref], target.options[:tenant_id])
     end.compact
   rescue Excon::Errors::Forbidden
@@ -104,9 +105,15 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
     []
   end
 
-  def get_orchestration_stack(stack_id, tenant_id)
-    tenant = memoized_get_tenant(tenant_id)
-    safe_get { @os_handle.detect_orchestration_service(tenant.try(:name)).stacks.get(stack_id) }
+  def indexed_all_orchestration_stacks
+    @indexed_all_orchestration_stacks ||= all_orchestration_stacks.index_by(&:id)
+  end
+
+  def get_orchestration_stack(stack_id, _tenant_id = nil)
+    # TODO fog needs to implement /v1/{tenant_id}/stacks/{stack_identity} call, right now the only supported call
+    # excepts get(name, id). And when we do just get(id) it degrades to fetching all stacks and O(n) search in them.
+    # But the method for fetching all stack doesn't include nested stacks, so we were missing those.
+    indexed_all_orchestration_stacks[stack_id]
   end
 
   def vms
@@ -307,7 +314,26 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
 
   def infer_related_orchestration_stacks_ems_refs_api!
     orchestration_stacks.each do |stack|
-      add_simple_target!(:orchestration_stacks, stack.parent, :tenant_id => stack.service.current_tenant["id"]) unless stack.parent.blank?
+      # Scan resources for VMs and add them as target, so the stack connects to vm, otherwise they don't connect on
+      # targeted refresh
+      orchestration_resources(stack).each do |resource|
+        case resource.resource_type
+        when "OS::Nova::Server"
+          # TODO(lsmola) we need to cache vms also on individual level, so the calling vms again has also these vms
+          add_simple_target!(:vms, resource.physical_resource_id)
+        end
+      end
+
+      # Load all parent stacks as targets (with max_depth)
+      max_depth     = 5
+      counter       = 0
+      current_stack = stack
+      while counter < max_depth && current_stack && current_stack.parent
+        add_simple_target!(:orchestration_stacks, current_stack.parent, :tenant_id => current_stack.service.current_tenant["id"])
+        counter       += 1
+        current_stack = get_orchestration_stack(current_stack.parent)
+      end
+
       add_simple_target!(:cloud_tenants, stack.service.current_tenant["id"]) unless stack.service.current_tenant["id"].blank?
     end
   end


### PR DESCRIPTION
First the stack target was not extracted from the event, because
it goes as resource_id, not stack_id.

Second we need to always add all parent stacks as targets (so the
chain of relations gets connected) and we need to scan resources
to connect all instances to the stack.

(Issue found and fixed as part of hackaton)

WIP: 
- have to add other resources tied to stack (networks, security_groups, ...)

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1732861