### PR TITLE
Set :complete=>false when doing targeted snapshot refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -150,6 +150,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
     add_collection(cloud, :snapshots) do |builder|
       builder.add_properties(:model_class => ::Snapshot)
       builder.add_properties(:parent_inventory_collections => %i[vms miq_templates])
+      builder.add_properties(:complete => !targeted?)
     end
   end
 


### PR DESCRIPTION
I noticed that targeted refresh of snapshots seems to wipe out all the snapshots except for the target, suggesting that the inventory system is treating this as a complete refresh. Manually setting the :complete flag in the collection definition solves the problem, but I'm puzzled why this is necessary here but not for other collections.

@agrare @Ladas any thoughts on why this would be needed for just this collection? I hunted around through the inventory_refresh repo but didn't discover any clues.