### PR TITLE
Allow skip historical Events from OpenStack

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,8 @@
       :read_timeout: 60
     :blacklisted_event_names: []
     :event_handling:
-      :event_backread_seconds: 15
+      :event_backread_seconds: 5
+      :event_skip_history: false
       :event_groups:
         :addition:
           :critical:

--- a/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
@@ -140,7 +140,13 @@ class OpenstackCeilometerEventMonitor < OpenstackEventMonitor
     end
   end
 
+  def skip_history?
+    Settings.fetch_path(:ems, :ems_openstack, :event_handling, :event_skip_history) || false
+  end
+
   def latest_event_timestamp
-    @since ||= @ems.ems_events.maximum(:timestamp)
+    return @since if @since.present?
+
+    @since = @ems.ems_events.maximum(:timestamp) || skip_history? ? @ems.created_on.iso8601 : nil
   end
 end


### PR DESCRIPTION
Multiple issues related to not processing new events appeared, partially
caused by slow processing of historical Events from OpenStack. Adding settings option
:event_skip_history to allow skip all events generated in OpenStack before OpenStack
was added as provider to ManageIQ.

Also, event backread was decreased from 15 to 5 seconds to speedup catchup with OpenStack Events.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1692892