### PR TITLE
Raise error for numeric-only passwords

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -60,6 +60,13 @@ module OpenstackHandle
       opts[:openstack_service_type] = ["nfv-orchestration"] if service == "NFV"
       opts[:openstack_service_type] = ["workflowv2"] if service == "Workflow"
 
+      # Fog handles just numeric fields as integer which fails for password, making check here until
+      # it get resolved in fog.
+      if password == password.to_i.to_s
+        $log.error("Wrong password format, just numeric passwords are not accepted.")
+        raise MiqException::MiqOpenstackApiRequestError, _("Numeric-only passwords are not accepted")
+      end
+
       if service == "Planning"
         # Special behaviour for Planning service Tuskar, since it is OpenStack specific service, there is no
         # Fog::Planning module, only Fog::OpenStack::Planning

--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -42,6 +42,14 @@ describe OpenstackHandle::Handle do
     end
   end
 
+  context "errors from connection" do
+    it "raises error for numeric-only password" do
+      handle = OpenstackHandle::Handle.new("dummy", "123456", "dummy")
+      expect { handle.connect } .to raise_error MiqException::MiqOpenstackApiRequestError, \
+                                                "Numeric-only passwords are not accepted"
+    end
+  end
+
   context "supports ssl" do
     it "handles default ssl type connections just fine" do
       fog      = double('fog')


### PR DESCRIPTION
When OpenStack User's password was a Number, fog-core coerced it to Numeric type, which caused
HTTP 400 failure leading to print request malformed error message including the password.

This is a temporary solution before fog-side fix https://github.com/fog/fog-openstack/pull/493
gets released and properly tested.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1723180