### PR TITLE
[WIP] Upgrade fog-openstack to 1.0.9

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
-  s.add_runtime_dependency "excon",                "~> 0.40"
-  s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"
+  s.add_runtime_dependency "excon",                "~> 0.58"
+  s.add_runtime_dependency "fog-openstack",        "= 1.0.9"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
   s.add_runtime_dependency "parallel",             "~> 1.12.0"
 


### PR DESCRIPTION
Dependency upgrade fog-openstack and excon gems.

fog-openstack to latest released version
excon to version matching to fog-core requirement