### PR TITLE
update_attributes deprecation

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
@@ -14,6 +14,6 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations
                       }) do
       with_provider_object(&:destroy)
     end
-    self.update_attributes!(:raw_power_state => "DELETED")
+    self.update!(:raw_power_state => "DELETED")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/guest.rb
@@ -16,12 +16,12 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Guest
   def raw_reboot_guest
     with_provider_object(&:reboot)
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "REBOOT")
+    self.update!(:raw_power_state => "REBOOT")
   end
 
   def raw_reset
     with_provider_object { |instance| instance.reboot("HARD") }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "HARD_REBOOT")
+    self.update!(:raw_power_state => "HARD_REBOOT")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/power.rb
@@ -16,36 +16,36 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Power
       when "SHELVED", "SHELVED_OFFLOADED" then connection.unshelve_server(ems_ref)
       end
     end
-    self.update_attributes!(:raw_power_state => "ACTIVE")
+    self.update!(:raw_power_state => "ACTIVE")
   end
 
   def raw_stop
     with_provider_connection { |connection| connection.stop_server(ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "SHUTOFF")
+    self.update!(:raw_power_state => "SHUTOFF")
   end
 
   def raw_pause
     with_provider_connection { |connection| connection.pause_server(ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "PAUSED")
+    self.update!(:raw_power_state => "PAUSED")
   end
 
   def raw_suspend
     with_provider_connection { |connection| connection.suspend_server(ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "SUSPENDED")
+    self.update!(:raw_power_state => "SUSPENDED")
   end
 
   def raw_shelve
     with_provider_connection { |connection| connection.shelve_server(ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "SHELVED")
+    self.update!(:raw_power_state => "SHELVED")
   end
 
   def raw_shelve_offload
     with_provider_connection { |connection| connection.shelve_offload_server(ems_ref) }
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "SHELVED_OFFLOADED")
+    self.update!(:raw_power_state => "SHELVED_OFFLOADED")
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations/relocation.rb
@@ -29,7 +29,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
       end
     end
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "MIGRATING")
+    self.update!(:raw_power_state => "MIGRATING")
   end
 
   def raw_evacuate(options = {})
@@ -50,6 +50,6 @@ module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations::Relocation
       end
     end
     # Temporarily update state for quick UI response until refresh comes along
-    self.update_attributes!(:raw_power_state => "MIGRATING")
+    self.update!(:raw_power_state => "MIGRATING")
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -48,7 +48,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
 
     attributes = {:name => name, :zone => zone}
     if provider
-      provider.update_attributes!(attributes)
+      provider.update!(attributes)
     else
       self.provider = ManageIQ::Providers::Openstack::Provider.create!(attributes)
     end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -447,7 +447,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       elsif existing_network_port.name.blank?
         # Just updating a names of network_ports refreshed from Neutron, rest of attributes
         # is handled in refresh section.
-        existing_network_port.update_attributes(:name => network_port[:name])
+        existing_network_port.update(:name => network_port[:name])
       end
     end
     unless hashes.blank?
@@ -485,6 +485,6 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
     create_event = ext_management_system.ems_events.find_by(:host_id    => nil,
                                                             :event_type => "compute.instance.create.end",
                                                             :host_name  => parsed_ems_ref_obj)
-    create_event&.update_attributes!(:host_id => id)
+    create_event&.update!(:host_id => id)
   end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresh_worker_spec.rb
@@ -4,8 +4,8 @@ describe ManageIQ::Providers::Openstack::InfraManager::RefreshWorker do
     let!(:storage_manager) { FactoryBot.create(:ems_storage) }
     let(:ems) do
       FactoryBot.create(:ems_infra).tap do |ems|
-        network_manager.update_attributes(:parent_ems_id => ems.id)
-        storage_manager.update_attributes(:parent_ems_id => ems.id)
+        network_manager.update(:parent_ems_id => ems.id)
+        storage_manager.update(:parent_ems_id => ems.id)
       end
     end
 


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links.