### PR TITLE
Fix Snapshot create error message

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -298,7 +298,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   rescue => err
     _log.error "#{log_prefix}, error: #{err}"
     _log.debug { err.backtrace.join("\n") }
-    raise
+    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err)
   end
 
   def vm_remove_snapshot(vm, options = {})


### PR DESCRIPTION
Error passed to UI by failed Snapshot create call was not displayed by UI correctly.
Updating error message with information parsed from original fog error.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1750558