### PR TITLE
Specify CloudManager::Template in Cloud persister definition

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/base_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/base_template.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::CloudManager::BaseTemplate < ManageIQ::Providers::CloudManager::Template
+end

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
+class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Providers::Openstack::CloudManager::BaseTemplate
   include ManageIQ::Providers::Openstack::HelperMethods
   belongs_to :cloud_tenant
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/volume_snapshot_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/volume_snapshot_template.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate < ManageIQ::Providers::CloudManager::Template
+class ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate < ManageIQ::Providers::Openstack::CloudManager::BaseTemplate
   # VolumeSnapshotTemplates are proxies to allow provisioning instances from volumes
   # without having to refactor the entire provisioning workflow to support types
   # other than VmOrTemplate subtypes. VolumeSnapshotTemplates are created 1-to-1 during

--- a/app/models/manageiq/providers/openstack/cloud_manager/volume_template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/volume_template.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate < ManageIQ::Providers::CloudManager::Template
+class ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate < ManageIQ::Providers::Openstack::CloudManager::BaseTemplate
   # VolumeTemplates are proxies to allow provisioning instances from volumes
   # without having to refactor the entire provisioning workflow to support types
   # other than VmOrTemplate subtypes. VolumeTemplates are created 1-to-1 during

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -62,8 +62,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   def add_miq_templates
     add_collection(cloud, :miq_templates) do |builder|
-      builder.add_properties(:model_class => ::MiqTemplate)
-
+      builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Template)
       builder.add_default_values(:ems_id => manager.id)
 
       # Extra added to automatic attributes

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -62,7 +62,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   def add_miq_templates
     add_collection(cloud, :miq_templates) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::Template)
+      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::BaseTemplate)
       builder.add_default_values(:ems_id => manager.id)
 
       # Extra added to automatic attributes


### PR DESCRIPTION
Since the Cloud persister miq_template collection definition was using the 'MiqTemplate' model, all MiqTemplates were getting scooped up when attempting to reconnect archived templates. This PR specifies that only objects of the CloudManager's own Template type should be included.