### PR TITLE
Raise notifications when creating, restoring, and deleting backups

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -78,9 +78,15 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
 
   def backup_create(options)
     options[:volume_id] = ems_ref
-    with_provider_connection do |service|
-      backup = service.backups.new(options)
-      backup.save
+    with_notification(:cloud_volume_backup_create,
+                      :options => {
+                        :subject     => self,
+                        :backup_name => options[:name]
+                      }) do
+      with_provider_connection do |service|
+        backup = service.backups.new(options)
+        backup.save
+      end
     end
   rescue => e
     _log.error "backup=[#{name}], error: #{e}"

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup.rb
@@ -6,8 +6,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup < ::CloudV
   supports :backup_restore
 
   def raw_restore(volumeid = nil, name = nil)
-    with_provider_object do |backup|
-      backup.restore(volumeid, name)
+    with_notification(:cloud_volume_backup_restore,
+                      :options => {
+                        :subject     => self,
+                        :volume_name => cloud_volume.name
+                      }) do
+      with_provider_object do |backup|
+        backup.restore(volumeid, name)
+      end
     end
   rescue => e
     _log.error("backup=[#{name}], error: #{e}")
@@ -15,8 +21,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup < ::CloudV
   end
 
   def raw_delete
-    with_provider_object do |backup|
-      backup.destroy if backup
+    with_notification(:cloud_volume_backup_delete,
+                      :options => {
+                        :subject     => self,
+                        :volume_name => cloud_volume.name
+                      }) do
+      with_provider_object do |backup|
+        backup&.destroy
+      end
     end
   rescue => e
     _log.error("volume backup=[#{name}], error: #{e}")

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
@@ -35,12 +35,48 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
       expect(raw_cloud_volume_backup).to receive(:restore)
       cloud_volume_backup.raw_restore(cloud_volume)
     end
+
+    it "raises a success notification when raw_backup_restore succeeds" do
+      NotificationType.seed
+
+      expect(raw_cloud_volume_backup).to receive(:restore)
+      cloud_volume_backup.raw_restore(cloud_volume)
+      note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_restore_success").id)
+      expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name)
+    end
+
+    it "raises an error notification when raw_backup_restore fails" do
+      NotificationType.seed
+      error_message = "restore failed"
+      expect(raw_cloud_volume_backup).to receive(:restore).and_raise(error_message)
+      expect { cloud_volume_backup.raw_restore(cloud_volume) }.to raise_error
+      note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_restore_error").id)
+      expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name, :error_message => error_message)
+    end
   end
 
   context 'raw_delete_backup' do
     it 'deletes backup' do
       expect(raw_cloud_volume_backup).to receive(:destroy)
       cloud_volume_backup.raw_delete
+    end
+
+    it "raises a success notification when raw_delete_backup succeeds" do
+      NotificationType.seed
+
+      expect(raw_cloud_volume_backup).to receive(:destroy)
+      cloud_volume_backup.raw_delete
+      note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_delete_success").id)
+      expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name)
+    end
+
+    it "raises an error notification when raw_delete_backup fails" do
+      NotificationType.seed
+      error_message = "backup failed"
+      expect(raw_cloud_volume_backup).to receive(:destroy).and_raise(error_message)
+      expect { cloud_volume_backup.raw_delete }.to raise_error
+      note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_delete_error").id)
+      expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name, :error_message => error_message)
     end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
@@ -49,7 +49,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
       NotificationType.seed
       error_message = "restore failed"
       expect(raw_cloud_volume_backup).to receive(:restore).and_raise(error_message)
-      expect { cloud_volume_backup.raw_restore(cloud_volume) }.to raise_error
+      expect { cloud_volume_backup.raw_restore(cloud_volume) }.to raise_error(error_message)
       note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_restore_error").id)
       expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name, :error_message => error_message)
     end
@@ -74,7 +74,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
       NotificationType.seed
       error_message = "backup failed"
       expect(raw_cloud_volume_backup).to receive(:destroy).and_raise(error_message)
-      expect { cloud_volume_backup.raw_delete }.to raise_error
+      expect { cloud_volume_backup.raw_delete }.to raise_error(error_message)
       note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "cloud_volume_backup_delete_error").id)
       expect(note.options).to eq(:subject => cloud_volume_backup.name, :volume_name => cloud_volume.name, :error_message => error_message)
     end


### PR DESCRIPTION
I expect this to be a partial fix (along with associated core PR) for https://bugzilla.redhat.com/show_bug.cgi?id=1748918, where a lack of notifications around Volume Backup actions is obscuring the reason for backup deletion failing.

Depends on https://github.com/ManageIQ/manageiq/pull/19357