### PR TITLE
Skip Volumes without mountpoint in VM refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -413,6 +413,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       # will take care of that.
       if s.attributes.fetch("os-extended-volumes:volumes_attached", []).length > 0
         s.volume_attachments.each do |attachment|
+          # Skip Volume mounts without mount point
+          next if attachment['device'].blank?
+
           dev = File.basename(attachment['device'])
           persister.disks.find_or_build_by(
             :hardware    => hardware,


### PR DESCRIPTION
If volume is mounted to a VM, but it doesn't have mountpoint to the VM, something
is wrong in OpenStack (e.g. failures with limits in migration), but our code should not fail
the refresh.

Adding skip volumes without mountpoint to VM parsing refresh code.