### PR TITLE
Fix Image targeted refresh

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
@@ -52,11 +52,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::EventTargetParser do
     it "parses image events" do
       ems_event = create_ems_event("image.create.end", "resource_id" => "image_id_test")
       parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
+      expect(parsed_targets.size).to eq(2)
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:images, {:ems_ref => "image_id_test"}]
+            [:images, {:ems_ref=>"image_id_test"}], [:miq_templates, {:ems_ref=>"image_id_test"}]
           ]
         )
       )


### PR DESCRIPTION
Targeted refresh for Image is triggered but didn't update database with up-to-date Images status.

Updated Image ID parsing to use oslo.message as a fallback and added target association miq_templates which represents Images in MIQ.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1762866