### PR TITLE
Fix Volume Template nil name refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -36,7 +36,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       # next if vt["attributes"].["bootable"].to_s != "true"
       volume_template = persister.miq_templates.find_or_build(vt["id"])
       volume_template.type = "ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate"
-      volume_template.name = (vt['display_name'] || vt['name']).blank? ? vt.id : (vt['display_name'] || vt['name'])
+      volume_template.name = (vt['display_name'] || vt['name']).blank? ? vt["id"] : (vt['display_name'] || vt['name'])
       volume_template.cloud_tenant = persister.cloud_tenants.lazy_find(vt["os-extended-snapshot-attributes:project_id"])
       volume_template.location = "N/A"
       volume_template.vendor = "openstack"


### PR DESCRIPTION
In Volume Template refresh, there is fallback for filling name attribute by ID
in case OpenStack name is nil. This was failing for undefined :id method.

Hash-like access was used in same way as primary identification of
Volume Template object few lines before.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1767423