### PR TITLE
Add an exception handler to event monitoring

### DIFF
--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -44,7 +44,7 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
       end
       sleep_poll_normal
     end
-  rescue Exception => err
+  rescue Fog::Metering::OpenStack::NotFound => err
     _log.warn("#{log_prefix} Failed to monitor events because [#{err.message}]")
   ensure
     reset_event_monitor_handle

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -44,6 +44,8 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
       end
       sleep_poll_normal
     end
+  rescue Exception => err
+    _log.warn("#{log_prefix} Failed to monitor events because [#{err.message}]")
   ensure
     reset_event_monitor_handle
   end


### PR DESCRIPTION
This adds an exception handler to the `EventCatcherMixin#monitor_events` method. If it fails, it will properly log the issue instead of spewing a backtrace into the log. This occurred recently when connecting to an Openstack instance where Panko was missing.

Should it also call `stop_event_monitor` on an exception there? If you think so I can update the PR.