### PR TITLE
Add proxy support to Openstack

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -171,16 +171,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def nova_connection_options
     connection_options = {:service => "Compute"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    proxy = openstack_proxy
-    connection_options[:proxy] = proxy.to_s if proxy
+    connection_options[:proxy] = openstack_proxy
     connection_options
   end
 
   def self.cinder_connection_options(cloud_tenant = nil)
     connection_options = {:service => "Volume"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    proxy = openstack_proxy
-    connection_options[:proxy] = proxy.to_s if proxy
+    connection_options[:proxy] = openstack_proxy
     connection_options
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -171,12 +171,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def nova_connection_options
     connection_options = {:service => "Compute"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
+    connection_options[:proxy] = openstack_proxy if openstack_proxy
     connection_options
   end
 
   def self.cinder_connection_options(cloud_tenant = nil)
     connection_options = {:service => "Volume"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
+    connection_options[:proxy] = openstack_proxy if openstack_proxy
     connection_options
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -171,14 +171,16 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def nova_connection_options
     connection_options = {:service => "Compute"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    connection_options[:proxy] = openstack_proxy if openstack_proxy
+    proxy = openstack_proxy
+    connection_options[:proxy] = proxy.to_s if proxy
     connection_options
   end
 
   def self.cinder_connection_options(cloud_tenant = nil)
     connection_options = {:service => "Volume"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    connection_options[:proxy] = openstack_proxy if openstack_proxy
+    proxy = openstack_proxy
+    connection_options[:proxy] = proxy.to_s if proxy
     connection_options
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume.rb
@@ -171,14 +171,14 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
   def nova_connection_options
     connection_options = {:service => "Compute"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    connection_options[:proxy] = openstack_proxy
+    connection_options[:proxy] = openstack_proxy if openstack_proxy
     connection_options
   end
 
   def self.cinder_connection_options(cloud_tenant = nil)
     connection_options = {:service => "Volume"}
     connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    connection_options[:proxy] = openstack_proxy
+    connection_options[:proxy] = openstack_proxy if openstack_proxy
     connection_options
   end
 

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -1,8 +1,9 @@
 module ManageIQ::Providers::Openstack::HelperMethods
   extend ActiveSupport::Concern
 
+  # Return the openstack proxy, if any, as a string. Otherwise return nil.
   def openstack_proxy
-    VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+    ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
   end
 
   def parse_error_message_from_fog_response(exception)
@@ -19,7 +20,7 @@ module ManageIQ::Providers::Openstack::HelperMethods
 
   module ClassMethods
     def openstack_proxy
-      VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
     end
 
     def parse_error_message_from_fog_response(exception)

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -1,6 +1,10 @@
 module ManageIQ::Providers::Openstack::HelperMethods
   extend ActiveSupport::Concern
 
+  def openstack_proxy
+    VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+  end
+
   def parse_error_message_from_fog_response(exception)
     self.class.parse_error_message_from_fog_response(exception)
   end

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -18,6 +18,10 @@ module ManageIQ::Providers::Openstack::HelperMethods
   end
 
   module ClassMethods
+    def openstack_proxy
+      VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+    end
+
     def parse_error_message_from_fog_response(exception)
       exception_string = exception.to_s
       matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -115,7 +115,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
 
     def raw_connect(password, params, service = "Compute")
-      params[:proxy] = openstack_proxy
+      params[:proxy] = openstack_proxy if openstack_proxy
 
       case params[:event_stream_selection]
       when "amqp"
@@ -171,7 +171,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       extra_options[:region]            = provider_region if provider_region.present?
       extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
       extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
-      extra_options[:proxy]             = openstack_proxy
+      extra_options[:proxy]             = openstack_proxy if openstack_proxy
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -40,6 +40,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.api_version            = params[:api_version].strip
       ems.security_protocol      = params[:default_security_protocol].strip
       ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
+      ems.http_proxy_uri         = parmas[:proxy].strip if params[:proxy]
 
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].try(:strip)
 
@@ -115,6 +116,9 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
 
     def raw_connect(password, params, service = "Compute")
+      proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      params[:proxy] = proxy.to_s if proxy
+
       case params[:event_stream_selection]
       when "amqp"
         amqp_available?(password, params)
@@ -169,7 +173,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       extra_options[:region]            = provider_region if provider_region.present?
       extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
       extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
-      extra_options[:proxy]             = VMDB::Util.http_proxy_uri(:openstack).to_s
+
+      # The proxy must be a string, so we use the helper methods here
+      proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      extra_options[:proxy] = proxy.to_s if proxy
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -115,7 +115,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
 
     def raw_connect(password, params, service = "Compute")
-      params[:proxy] = openstack_proxy.to_s if openstack_proxy
+      params[:proxy] = openstack_proxy
 
       case params[:event_stream_selection]
       when "amqp"
@@ -171,9 +171,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       extra_options[:region]            = provider_region if provider_region.present?
       extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
       extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
-
-      # The proxy must be a string, so we use the helper methods here
-      extra_options[:proxy] = openstack_proxy.to_s if openstack_proxy
+      extra_options[:proxy]             = openstack_proxy
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -115,8 +115,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
 
     def raw_connect(password, params, service = "Compute")
-      proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
-      params[:proxy] = proxy.to_s if proxy
+      params[:proxy] = openstack_proxy.to_s if openstack_proxy
 
       case params[:event_stream_selection]
       when "amqp"
@@ -174,8 +173,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
 
       # The proxy must be a string, so we use the helper methods here
-      proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
-      extra_options[:proxy] = proxy.to_s if proxy
+      extra_options[:proxy] = openstack_proxy.to_s if openstack_proxy
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -40,7 +40,6 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.api_version            = params[:api_version].strip
       ems.security_protocol      = params[:default_security_protocol].strip
       ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
-      ems.http_proxy_uri         = params[:proxy].strip if params[:proxy]
 
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].try(:strip)
 

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.api_version            = params[:api_version].strip
       ems.security_protocol      = params[:default_security_protocol].strip
       ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
-      ems.http_proxy_uri         = parmas[:proxy].strip if params[:proxy]
+      ems.http_proxy_uri         = params[:proxy].strip if params[:proxy]
 
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].try(:strip)
 

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -169,6 +169,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       extra_options[:region]            = provider_region if provider_region.present?
       extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
       extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
+      extra_options[:proxy]             = VMDB::Util.http_proxy_uri(:openstack).to_s
 
       osh = OpenstackHandle::Handle.new(username, password, address, port, api_version, security_protocol, extra_options)
       osh.connection_options = {:instrumentor => $fog_log}

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -40,6 +40,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.api_version            = params[:api_version].strip
       ems.security_protocol      = params[:default_security_protocol].strip
       ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
+      ems.http_proxy_uri         = parmas[:proxy].strip if params[:proxy]
 
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].try(:strip)
 

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/baremetal_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/compute_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/event_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -135,6 +135,7 @@ module OpenstackHandle
       @excon_options[:omit_default_port] = @extra_options[:omit_default_port] unless
                                            @extra_options[:omit_default_port].blank?
       @excon_options[:read_timeout]      = @extra_options[:read_timeout] unless @extra_options[:read_timeout].blank?
+      @excon_options[:proxy]             = @extra_options[:proxy] if @extra_options[:proxy].present?
       @excon_options
     end
 

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -136,6 +136,7 @@ module OpenstackHandle
                                            @extra_options[:omit_default_port].blank?
       @excon_options[:read_timeout]      = @extra_options[:read_timeout] unless @extra_options[:read_timeout].blank?
 
+      # Beware of proxies that lie about gzip encoding and content length.
       if @extra_options[:proxy].present?
         @excon_options[:proxy] = @extra_options[:proxy]
         @excon_options[:headers] = {'Accept-Encoding' => 'identity,deflate'}

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -135,7 +135,12 @@ module OpenstackHandle
       @excon_options[:omit_default_port] = @extra_options[:omit_default_port] unless
                                            @extra_options[:omit_default_port].blank?
       @excon_options[:read_timeout]      = @extra_options[:read_timeout] unless @extra_options[:read_timeout].blank?
-      @excon_options[:proxy]             = @extra_options[:proxy] if @extra_options[:proxy].present?
+
+      if @extra_options[:proxy].present?
+        @excon_options[:proxy] = @extra_options[:proxy]
+        @excon_options[:headers] = {'Accept-Encoding' => 'identity,deflate'}
+      end
+
       @excon_options
     end
 

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
@@ -93,5 +93,9 @@ module OpenstackHandle
       # OpenstackHandle::MultiTenancy::None
       OpenstackHandle::MultiTenancy::Loop
     end
+
+    def openstack_proxy
+      VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+    end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handled_list.rb
@@ -95,7 +95,7 @@ module OpenstackHandle
     end
 
     def openstack_proxy
-      VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def visible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def visible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     def visible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/identity_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def visible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
@@ -12,7 +12,7 @@ module OpenstackHandle
       @delegated_object = dobj
       @os_handle        = os_handle
       @name             = name
-      @proxy            = openstack_proxy.to_s if openstack_proxy
+      @proxy            = openstack_proxy
     end
 
     def version

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
@@ -12,7 +12,7 @@ module OpenstackHandle
       @delegated_object = dobj
       @os_handle        = os_handle
       @name             = name
-      @proxy            = openstack_proxy
+      @proxy            = openstack_proxy.to_s if openstack_proxy
     end
 
     def version

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
@@ -12,6 +12,7 @@ module OpenstackHandle
       @delegated_object = dobj
       @os_handle        = os_handle
       @name             = name
+      @proxy            = openstack_proxy
     end
 
     def version

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/image_delegate.rb
@@ -12,7 +12,7 @@ module OpenstackHandle
       @delegated_object = dobj
       @os_handle        = os_handle
       @name             = name
-      @proxy            = openstack_proxy
+      @proxy            = openstack_proxy if openstack_proxy
     end
 
     def version

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/introspection_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metering_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     # Ceilometer-like methods provided by Gnocchi backend to serve code expecting Ceilometer API

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     # Ceilometer-like methods provided by Gnocchi backend to serve code expecting Ceilometer API

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     # Ceilometer-like methods provided by Gnocchi backend to serve code expecting Ceilometer API

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/metric_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     # Ceilometer-like methods provided by Gnocchi backend to serve code expecting Ceilometer API

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
@@ -9,7 +9,8 @@ module OpenstackHandle
         @options            = options
         @method             = method
 
-        @options[:proxy] ||= ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
+        proxy = ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
+        @options[:proxy] ||= proxy if proxy
       end
     end
   end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
@@ -9,8 +9,7 @@ module OpenstackHandle
         @options            = options
         @method             = method
 
-        proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
-        @options[:proxy] ||= proxy.to_s if proxy
+        @options[:proxy] ||= ManageIQ::Providers::Openstack::CloudManager.http_proxy_uri&.to_s
       end
     end
   end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
@@ -8,6 +8,9 @@ module OpenstackHandle
         @collection_type    = collection_type
         @options            = options
         @method             = method
+
+        proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+        @options[:proxy] ||= proxy if proxy
       end
     end
   end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/multi_tenancy/base.rb
@@ -10,7 +10,7 @@ module OpenstackHandle
         @method             = method
 
         proxy = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
-        @options[:proxy] ||= proxy if proxy
+        @options[:proxy] ||= proxy.to_s if proxy
       end
     end
   end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/network_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def quotas_for_current_tenant

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/nfv_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def stacks_for_accessible_tenants(opts = {})

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def stacks_for_accessible_tenants(opts = {})

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
     end
 
     def stacks_for_accessible_tenants(opts = {})

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/orchestration_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def stacks_for_accessible_tenants(opts = {})

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/storage_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = VMDB::Util.http_proxy_uri(:openstack) || VMDB::Util.http_proxy_uri(:default)
     end
   end
 end

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def snapshots_for_accessible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     def snapshots_for_accessible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def snapshots_for_accessible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/volume_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def snapshots_for_accessible_tenants

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy.to_s if openstack_proxy
     end
 
     def execute_action(action, input)

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
@@ -11,6 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
+      @proxy     = openstack_proxy
     end
 
     def execute_action(action, input)

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy.to_s if openstack_proxy
+      @proxy     = openstack_proxy
     end
 
     def execute_action(action, input)

--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/workflow_delegate.rb
@@ -11,7 +11,7 @@ module OpenstackHandle
       super(dobj)
       @os_handle = os_handle
       @name      = name
-      @proxy     = openstack_proxy
+      @proxy     = openstack_proxy if openstack_proxy
     end
 
     def execute_action(action, input)


### PR DESCRIPTION
At the moment it doesn't appear that the Openstack cloud provider is honoring default or openstack-specific proxy settings. As far as I can tell they're completely ignored.

~~WIP for now until I figure out why it's failing.~~

Steps to reproduce:

* Create a simple proxy server locally.
* Add openstack cloud provider.
* Update proxy settings in the advanced settings screen to use your local proxy settings.
* Refresh the provider and/or update authentication.

A basic proxy you can use to test:
```
#!/usr/bin/env ruby

require 'webrick'
require 'webrick/httpproxy'

proxy = WEBrick::HTTPProxyServer.new(Port: 8080) # Adjust port as desired.

trap 'INT'  do proxy.shutdown end
trap 'TERM' do proxy.shutdown end

proxy.start
```

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1649903

Regarding the extensive nature of the PR itself, this was largely due to the heavy use of delegation in combination with the fog client that was already present when I got here. This required, as far as I can tell, the addition of a proxy setting to each delegate class individually, which the fog internals would then consume.