### PR TITLE
Remove ems_ref_obj

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
@@ -19,7 +19,7 @@ module ManageIQ::Providers::Openstack::InfraManager::EventParser
     }
 
     if payload.key? "instance_id"
-      event_hash[:host_id] = Host.find_by("ems_ref_obj" => YAML.dump(payload["instance_id"])).try(:id)
+      event_hash[:host_id] = Host.find_by(:uid_ems => payload["instance_id"]).try(:id)
       event_hash[:host_name] = payload["instance_id"]
     end
     event_hash[:message]                   = payload["message"]           if payload.key? "message"

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -481,10 +481,9 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
   end
 
   def update_create_event
-    parsed_ems_ref_obj = YAML.safe_load(ems_ref_obj)
     create_event = ext_management_system.ems_events.find_by(:host_id    => nil,
                                                             :event_type => "compute.instance.create.end",
-                                                            :host_name  => parsed_ems_ref_obj)
+                                                            :host_name  => uid_ems)
     create_event&.update!(:host_id => id)
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -377,7 +377,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
   def destroy_ironic_queue(userid = "system")
     task_opts = {
-      :action => "Deleting Ironic node: #{uid_ems} for user #{userid}",
+      :action => "Deleting Ironic node: #{ems_ref} for user #{userid}",
       :userid => userid
     }
 
@@ -407,7 +407,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
       end
     end
   rescue => e
-    _log.error "ironic node=[#{uid_ems}], error: #{e}"
+    _log.error "ironic node=[#{ems_ref}], error: #{e}"
     if archived?
       raise e
     else

--- a/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::Openstack::InfraManager::Host::Operations
   def ironic_fog_node
     connection_options = {:service => "Baremetal"}
     ext_management_system.with_provider_connection(connection_options) do |service|
-      service.nodes.get(uid_ems)
+      service.nodes.get(ems_ref)
     end
   end
 

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
@@ -122,9 +122,8 @@ class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::P
   def perf_capture_data(start_time, end_time)
     # Metadata filter covers all resources, resource filter can be nil
     resource_filter = nil
-    metadata_filter = target.ems_ref_obj ? {"field" => "metadata.resource_id", "value" => target.ems_ref_obj} : nil
+    metadata_filter = target.uid_ems ? {"field" => "metadata.resource_id", "value" => target.uid_ems} : nil
 
-    perf_capture_data_openstack_base(self.class, start_time, end_time, resource_filter,
-                                     metadata_filter)
+    perf_capture_data_openstack_base(self.class, start_time, end_time, resource_filter, metadata_filter)
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/orchestration_stack.rb
@@ -85,7 +85,7 @@ class ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack < ::Orche
     raise_exception_if_stack_not_ready
     if can_use_scale_down_workflow?
       # OSP >= 10 use workflows
-      host_uuids_to_remove = hosts.map { |n| Host.find(n).ems_ref_obj }
+      host_uuids_to_remove = hosts.map { |n| Host.find(n).uid_ems }
       scale_down_using_workflows(host_uuids_to_remove)
     else
       # OSP < 10 use heat stack update

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -203,9 +203,8 @@ module ManageIQ
         new_result = {
           :name                 => host_name,
           :type                 => 'ManageIQ::Providers::Openstack::InfraManager::Host',
-          :uid_ems              => uid,
+          :uid_ems              => host.instance_uuid,
           :ems_ref              => uid,
-          :ems_ref_obj          => host.instance_uuid,
           :operating_system     => {:product_name => 'linux'},
           :vmm_vendor           => 'redhat',
           :vmm_product          => identify_product(indexed_resources, host.instance_uuid),
@@ -391,7 +390,7 @@ module ManageIQ
 
       def set_relationship_on_hosts(hosts, cluster_host_mapping)
         hosts.each do |host|
-          host[:ems_cluster] = @data_index.fetch_path(:clusters, cluster_host_mapping[host[:ems_ref_obj]])
+          host[:ems_cluster] = @data_index.fetch_path(:clusters, cluster_host_mapping[host[:uid_ems]])
         end
       end
 

--- a/app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/network_manager.rb
@@ -179,7 +179,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager < Manage
     when /^compute\:.*?$/
       # Owner is in format compute:<availability_zone> or compute:None
       # TODO(slucidi): replace this query for hosts once the infra manager uses the graph inventory system
-      host = collector.manager.hosts.where(Host.arel_table[:ems_ref_obj].matches("%#{network_port.device_id}%")).first
+      host = collector.manager.hosts.where(:uid_ems => network_port.device_id).first
       return host || persister.vms.lazy_find(network_port.device_id)
     when "network:router_interface", "network:router_ha_interface", "network:ha_router_replicated_interface"
       subnet_id = network_port.fixed_ips.try(:first).try(:[], "subnet_id")

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -669,7 +669,6 @@ module Openstack
         expect(template).to have_attributes(
           :template              => true,
           #:publicly_available    => is_public, # is not exposed now
-          :ems_ref_obj           => nil,
           :vendor                => "openstack",
           :power_state           => "never",
           :location              => "unknown",
@@ -754,7 +753,6 @@ module Openstack
       expect(vm).to have_attributes({
         :template              => false,
         :cloud                 => true,
-        :ems_ref_obj           => nil,
         :vendor                => "openstack",
         :power_state           => "on",
         :location              => "unknown",
@@ -903,7 +901,6 @@ module Openstack
       expect(vm).to have_attributes({
         :template              => false,
         :cloud                 => true,
-        :ems_ref_obj           => nil,
         :vendor                => "openstack",
         :power_state           => "on",
         :location              => "unknown",

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -132,7 +132,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     @host = ManageIQ::Providers::Openstack::InfraManager::Host.all.detect { |x| x.name.include?('(Controller)') }
 
     expect(@host.ems_ref).not_to be nil
-    expect(@host.ems_ref_obj).not_to be nil
+    expect(@host.uid_ems).not_to be nil
     expect(@host.mac_address).not_to be nil
     expect(@host.ipaddress).not_to be nil
     expect(@host.ems_cluster).not_to be nil
@@ -206,7 +206,6 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
     expect(template).to have_attributes(
       :template              => true,
       :publicly_available    => is_public,
-      :ems_ref_obj           => nil,
       :vendor                => "openstack",
       :power_state           => "never",
       :location              => "unknown",


### PR DESCRIPTION
We are looking to remove ems_ref_obj since it was originally added to store the "full" VMware object reference