### PR TITLE
Remove unused sub-manager refresh worker

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_openstack_network
-  end
-end

--- a/app/models/manageiq/providers/openstack/network_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/refresh_worker/runner.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end


### PR DESCRIPTION
Refresh of the network manager is handled by the parent manager
refresh worker

see also: https://github.com/ManageIQ/manageiq/pull/19524