### PR TITLE
Update Targeted refresh for VolumeTemplate objects

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
@@ -36,6 +36,8 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
     tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'project_id')
     resource_id = ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
     add_target(target_collection, :cloud_volumes, resource_id, :tenant_id => tenant_id) if resource_id
+    # Bootable Volume can be modelled also as VolumeTemplate for new VM provisioning based on the Bootable Volume
+    add_target(target_collection, :volume_templates, resource_id, :tenant_id => tenant_id) if resource_id
   end
 
   def collect_snapshot_references!(target_collection, ems_event)

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
@@ -11,11 +11,11 @@ describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTar
     it "parses volume events" do
       ems_event = create_ems_event("volume.create.end", "resource_id" => "volume_id_test",)
       parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
+      expect(parsed_targets.size).to eq(2)
       expect(target_references(parsed_targets)).to(
         match_array(
           [
-            [:cloud_volumes, {:ems_ref => "volume_id_test"}]
+            [:cloud_volumes, {:ems_ref=>"volume_id_test"}], [:volume_templates, {:ems_ref=>"volume_id_test"}]
           ]
         )
       )


### PR DESCRIPTION
Bootable Volumes from OpenStack are modelled as CloudVolumes, but also as VolumeTemplates
what allows use it in new Instance provision. Targeted refresh refreshed only CloudVolumes.

Updating target collection to trigger refresh for VolumeTemplates too.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1770831