### PR TITLE
Update excon gem dependency

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
-  s.add_runtime_dependency "excon",                "~> 0.40"
+  s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
   s.add_runtime_dependency "parallel",             "~> 1.12.0"


### PR DESCRIPTION
Update excon gem version to not older than v0.71 to avoid CVE-2019-16779.