### PR TITLE
Subclass CloudManager metrics capture

### DIFF
--- a/app/models/manageiq/providers/openstack/base_metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/base_metrics_capture.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::BaseMetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+module ManageIQ::Providers::Openstack::BaseMetricsCapture
   def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
     log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/metrics_capture.rb
@@ -1,4 +1,5 @@
-class ManageIQ::Providers::Openstack::CloudManager::MetricsCapture < ManageIQ::Providers::Openstack::BaseMetricsCapture
+class ManageIQ::Providers::Openstack::CloudManager::MetricsCapture < ManageIQ::Providers::CloudManager::MetricsCapture
+  include ManageIQ::Providers::Openstack::BaseMetricsCapture
   CPU_METERS     = ["cpu_util"]
   MEMORY_METERS  = ["memory.usage"]
   DISK_METERS    = ["disk.read.bytes", "disk.write.bytes"]

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_capture.rb
@@ -1,4 +1,5 @@
-class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::Providers::Openstack::BaseMetricsCapture
+class ManageIQ::Providers::Openstack::InfraManager::MetricsCapture < ManageIQ::Providers::InfraManager::MetricsCapture
+  include ManageIQ::Providers::Openstack::BaseMetricsCapture
   CPU_METERS     = %w(hardware.cpu.util)
   MEMORY_METERS  = %w(hardware.memory.used
                       hardware.memory.total

--- a/app/models/manageiq/providers/openstack/network_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/metrics_capture.rb
@@ -1,4 +1,5 @@
-class ManageIQ::Providers::Openstack::NetworkManager::MetricsCapture < ManageIQ::Providers::Openstack::BaseMetricsCapture
+class ManageIQ::Providers::Openstack::NetworkManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  include ManageIQ::Providers::Openstack::BaseMetricsCapture
   NETWORK_METERS = [].freeze
 
   # The list of meters that provide "cumulative" meters instead of "gauge"

--- a/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
@@ -18,6 +18,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
     @vm = FactoryBot.create(:vm_perf_openstack, :ext_management_system => @ems_openstack)
   end
 
+  context "#perf_capture_object" do
+    it "returns the correct class" do
+      expect(@vm.perf_capture_object.class).to eq(described_class)
+    end
+  end
+
   context "with standard interval data" do
     before :each do
       allow(@metering).to receive(:get_statistics) do |name, _options|


### PR DESCRIPTION
openstack is a cloud metrics capture class. subclassing the proper parent

part of ManageIQ/manageiq#19684

NOTE: this one is not open/shut like the others.

The hierarchy is a little odd. Especially since there is a `NetworkManager` with network capture
Wondering if this is good enough, or if we need to get into modules and the like