### PR TITLE
Add display name for cinder storage manager

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -84,4 +84,8 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
       stop_event_monitor_queue
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Cinder Block Storage Manager (OpenStack)', 'Cinder Block Storage Managers (OpenStack)', number)
+  end
 end


### PR DESCRIPTION
This is pluggable version of https://github.com/ManageIQ/manageiq/pull/19909