### PR TITLE
Remove invalid partials from specs

### DIFF
--- a/spec/models/manageiq/providers/openstack/infra_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/orchestration_stack_spec.rb
@@ -102,7 +102,6 @@ describe ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack do
 
     context 'queuing' do
       it 'should do direct stack updates if workflows are not available' do
-        allow(orchestration_stack).to receive(:queue_post_scaledown_task).and_return(true)
         allow(orchestration_stack).to receive(:update_ready?).and_return(true)
         expect(orchestration_stack).to receive(:update_stack).with(any_args).twice
 

--- a/spec/models/manageiq/providers/openstack/openstack_stubs.rb
+++ b/spec/models/manageiq/providers/openstack/openstack_stubs.rb
@@ -37,14 +37,6 @@ module OpenstackStubs
       receive(:delete).and_raise("Not allowed delete operation detected. The probable cause is a wrong manager_ref"\
                                  " causing create&delete instead of update")
     )
-    allow_any_instance_of(ApplicationRecord).to(
-      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
-                                         " manager_ref causing create&disconnect_inv instead of update")
-    )
-    allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to(
-      receive(:disconnect_inv).and_raise("Not allowed delete operation detected. The probable cause is a wrong"\
-                                         "manager_ref causing create&disconnect_inv instead of update")
-    )
   end
 
   def mocked_availability_zones


### PR DESCRIPTION
This removes a few invalid partials that aren't actually implemented, which will cause failures if strict partial validation is enabled.

Removing these had no effect.