### PR TITLE
Override inventory object refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
@@ -12,6 +12,21 @@ module ManageIQ
         EmsRefresh.queue_refresh(ems.network_manager)
       end
 
+      def collect_inventory_for_targets(ems, _targets)
+        [[ems, nil]]
+      end
+
+      def parse_targeted_inventory(ems, _target, _inventory)
+        log_header = format_ems_for_logging(ems)
+        _log.debug("#{log_header} Parsing inventory...")
+        hashes = ems.class::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+        _log.debug("#{log_header} Parsing inventory...Complete")
+        hashes
+      end
+
+      def preprocess_targets_manager_refresh
+      end
+
       def post_process_refresh_classes
         [::Vm, ManageIQ::Providers::Openstack::InfraManager::Host]
       end


### PR DESCRIPTION
we need to do this for removal of the legacy ems_refresh stuff
it's adam's circus 