### PR TITLE
Fix not needed Events reloading after restart

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
+++ b/lib/manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor.rb
@@ -147,7 +147,7 @@ class OpenstackCeilometerEventMonitor < OpenstackEventMonitor
   def latest_event_timestamp
     return @since if @since.present?
 
-    @since = @ems.ems_events.maximum(:timestamp) || skip_history? ? @ems.created_on.iso8601 : nil
+    @since = @ems.ems_events.maximum(:timestamp).try(:iso8601) || (skip_history? ? @ems.created_on.iso8601 : nil)
   end
 
   def tenant_sensitive?


### PR DESCRIPTION
Ceilometer/Panko Event monitor starts with the oldest events from OpenStack after each process
(re)start. Which leads to slow event catching up on larger deployments which can lead to temporarily
not working targeted refresh.

Fixing expression for ```@since``` timestamp initialization. To use last ems_event timestamp and if there is none, check skip_history? etc.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1812408