### PR TITLE
Add graph refresh to the OpenStack InfraManager

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -26,6 +26,10 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
     build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
   end
 
+  def allow_targeted_refresh?
+    false
+  end
+
   # A placeholder relation for NetworkTopology to work
   def availability_zones
   end

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -30,6 +30,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   attr_reader :cloud_volume_snapshots
   attr_reader :cloud_volume_backups
   attr_reader :cloud_volume_types
+  attr_reader :servers
 
   def initialize(_manager, _target)
     super
@@ -67,6 +68,9 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
     @cloud_volume_snapshots     = []
     @cloud_volume_backups       = []
     @cloud_volume_types         = []
+
+    # infra
+    @servers                    = []
   end
 
   def connection

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -31,6 +31,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   attr_reader :cloud_volume_backups
   attr_reader :cloud_volume_types
   attr_reader :servers
+  attr_reader :hosts
 
   def initialize(_manager, _target)
     super
@@ -71,6 +72,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
 
     # infra
     @servers                    = []
+    @hosts                      = []
   end
 
   def connection

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -14,7 +14,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   attr_reader :host_aggregates
   attr_reader :key_pairs
   attr_reader :miq_templates
-  attr_reader :orchestration_stacks
   attr_reader :quotas
   attr_reader :vms
   attr_reader :vnfs
@@ -108,18 +107,58 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
     @orchestration_service ||= manager.openstack_handle.detect_orchestration_service
   end
 
+  def orchestration_stacks
+    all_orchestration_stacks
+  end
+
+  def root_stacks
+    @root_stacks ||= load_orchestration_stacks(:show_nested => false)
+  end
+
+  def indexed_orchestration_stacks
+    @indexed_orchestration_stacks ||= all_orchestration_stacks.index_by(&:id)
+  end
+
+  def orchestration_outputs(stack)
+    safe_list { stack.outputs }
+  end
+
+  def orchestration_parameters(stack)
+    safe_list { stack.parameters }
+  end
+
+  def orchestration_resources(stack)
+    safe_list { stack.resources }
+  end
+
+  def orchestration_template(stack)
+    safe_call { stack.template }
+  end
+
+  def images
+    return [] unless image_service
+    return @images if @images.any?
+
+    @images = openstack_admin? ? image_service.images_with_pagination_loop : image_service.handled_list(:images)
+  end
+
+  private
+
   def all_orchestration_stacks
+    @all_orchestration_stacks ||= load_orchestration_stacks
+  end
+
+  def load_orchestration_stacks(show_nested: true)
     return [] unless orchestration_service
+
     # TODO(lsmola) We need a support of GET /{tenant_id}/stacks/detail in FOG, it was implemented here
     # https://review.openstack.org/#/c/35034/, but never documented in API reference, so right now we
     # can't get list of detailed stacks in one API call.
-    return @all_orchestration_stacks unless @all_orchestration_stacks.nil?
-
-    @all_orchestration_stacks = if openstack_heat_global_admin?
-                                  orchestration_service.handled_list(:stacks, {:show_nested => true, :global_tenant => true}, true).collect(&:details)
-                                else
-                                  orchestration_service.handled_list(:stacks, :show_nested => true).collect(&:details)
-                                end
+    if openstack_heat_global_admin?
+      orchestration_service.handled_list(:stacks, {:show_nested => show_nested, :global_tenant => true}, true).collect(&:details)
+    else
+      orchestration_service.handled_list(:stacks, :show_nested => show_nested).collect(&:details)
+    end
   rescue Excon::Errors::Forbidden
     # Orchestration service is detected but not open to the user
     log.warn("Skip refreshing stacks because the user cannot access the orchestration service")

--- a/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/cloud_manager.rb
@@ -55,16 +55,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
     @host_aggregates = safe_list { compute_service.aggregates.all }
   end
 
-  def images
-    return [] unless image_service
-    return @images if @images.any?
-    @images = if openstack_admin?
-                image_service.images_with_pagination_loop
-              else
-                image_service.handled_list(:images)
-              end
-  end
-
   def key_pairs
     return @key_pairs if @key_pairs.any?
     @key_pairs = compute_service.handled_list(:key_pairs, {}, openstack_admin?)
@@ -108,26 +98,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager < Manag
     return [] unless nfv_service
     return @vnfds if @vnfds.any?
     @vnfds = nfv_service.handled_list(:vnfds, {}, openstack_admin?)
-  end
-
-  def orchestration_stacks
-    all_orchestration_stacks
-  end
-
-  def orchestration_outputs(stack)
-    safe_list { stack.outputs }
-  end
-
-  def orchestration_parameters(stack)
-    safe_list { stack.parameters }
-  end
-
-  def orchestration_resources(stack)
-    safe_list { stack.resources }
-  end
-
-  def orchestration_template(stack)
-    safe_call { stack.template }
   end
 
   def volume_templates

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -1,3 +1,9 @@
 class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < ManageIQ::Providers::Openstack::Inventory::Collector
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
+
+  def images
+    return [] unless image_service
+    return @images if @images.any?
+    @images = uniques(image_service.handled_list(:images))
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < ManageIQ::Providers::Openstack::Inventory::Collector
+  include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
+end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -26,4 +26,11 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
 
     @servers = uniques(compute_service.handled_list(:servers))
   end
+
+  def hosts
+    return [] unless baremetal_service
+    return @hosts if @hosts.any?
+
+    @hosts = uniques(baremetal_service.handled_list(:nodes))
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
   def images
     return [] unless image_service
     return @images if @images.any?
+
     @images = uniques(image_service.handled_list(:images))
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -87,12 +87,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
     end
   end
 
-  def cloud_host_attributes_by_host
-    @cloud_host_attributes_by_host ||= cloud_host_attributes.group_by do |host_attrs|
-      host_attrs[:host_name]
-    end
-  end
-
   def introspection_details(host)
     return {} unless introspection_service
 

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -1,6 +1,18 @@
 class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < ManageIQ::Providers::Openstack::Inventory::Collector
   include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
 
+  def baremetal_service
+    @baremetal_service ||= manager.openstack_handle.detect_baremetal_service
+  end
+
+  def storage_service
+    @storage_service ||= manager.openstack_handle.detect_storage_service
+  end
+
+  def introspection_service
+    @introspection_service ||= manager.openstack_handle.detect_introspection_service
+  end
+
   def images
     return [] unless image_service
     return @images if @images.any?

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -19,4 +19,11 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
 
     @images = uniques(image_service.handled_list(:images))
   end
+
+  def servers
+    return [] unless compute_service
+    return @servers if @servers.any?
+
+    @servers = uniques(compute_service.handled_list(:servers))
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -48,6 +48,10 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
     @stacks ||= uniques(detailed_stacks)
   end
 
+  def stacks_by_id
+    @stacks_by_id ||= stacks.index_by(&:id)
+  end
+
   def root_stacks
     @root_stacks ||= uniques(detailed_stacks(false))
   end
@@ -108,8 +112,8 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
     @stack_server_resources ||= filter_stack_resources_by_resource_type(stack_server_resource_types)
   end
 
-  def stack_resources_by_id
-    @stack_resources_by_id ||= stack_server_resources.index_by { |p| p['physical_resource_id'] }
+  def server_purpose_by_instance_uuid
+    @server_purpose_by_instance_uuid ||= Hash[stack_server_resources.map { |res| [res['physical_resource_id'], res['resource_name']] }]
   end
 
   private

--- a/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/infra_manager.rb
@@ -52,6 +52,16 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::InfraManager < Manag
     @cloud_managers ||= (manager.provider&.cloud_ems || [])
   end
 
+  def introspection_details(host)
+    return {} unless introspection_service
+
+    begin
+      introspection_service.get_introspection_details(host.uuid).body
+    rescue
+      {}
+    end
+  end
+
   private
 
   def validate_required_services

--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -111,15 +111,11 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
     []
   end
 
-  def indexed_all_orchestration_stacks
-    @indexed_all_orchestration_stacks ||= all_orchestration_stacks.index_by(&:id)
-  end
-
   def get_orchestration_stack(stack_id, _tenant_id = nil)
     # TODO: fog needs to implement /v1/{tenant_id}/stacks/{stack_identity} call, right now the only supported call
     # excepts get(name, id). And when we do just get(id) it degrades to fetching all stacks and O(n) search in them.
     # But the method for fetching all stack doesn't include nested stacks, so we were missing those.
-    indexed_all_orchestration_stacks[stack_id]
+    indexed_orchestration_stacks[stack_id]
   end
 
   def vms

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
   require_nested :CloudManager
+  require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -3,4 +3,39 @@ class ManageIQ::Providers::Openstack::Inventory::Parser < ManageIQ::Providers::I
   require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
+
+  def orchestration_stack_parameters(stack, stack_inventory_object)
+    collector.orchestration_parameters(stack).each do |param_key, param_val|
+      uid = compose_ems_ref(stack.id, param_key)
+      o = persister.orchestration_stacks_parameters.find_or_build(uid)
+      o.ems_ref = uid
+      o.name = param_key
+      o.value = param_val
+      o.stack = stack_inventory_object
+    end
+  end
+
+  def orchestration_stack_outputs(stack, stack_inventory_object)
+    collector.orchestration_outputs(stack).each do |output|
+      uid = compose_ems_ref(stack.id, output['output_key'])
+      o = persister.orchestration_stacks_outputs.find_or_build(uid)
+      o.ems_ref = uid
+      o.key = output['output_key']
+      o.value = output['output_value']
+      o.description = output['description']
+      o.stack = stack_inventory_object
+    end
+  end
+
+  def orchestration_template(stack)
+    template = collector.orchestration_template(stack)
+    if template
+      o = persister.orchestration_templates.find_or_build(stack.id)
+      o.name = stack.stack_name
+      o.description = stack.template.description
+      o.content = stack.template.content
+      o.orderable = false
+      o
+    end
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -268,46 +268,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
     end
   end
 
-  def orchestration_stack_parameters(stack, stack_inventory_object)
-    collector.orchestration_parameters(stack).each do |param_key, param_val|
-      uid = compose_ems_ref(stack.id, param_key)
-      o = persister.orchestration_stacks_parameters.find_or_build(uid)
-      o.ems_ref = uid
-      o.name = param_key
-      o.value = param_val
-      o.stack = stack_inventory_object
-    end
-  end
-
-  def orchestration_stack_outputs(stack, stack_inventory_object)
-    collector.orchestration_outputs(stack).each do |output|
-      uid = compose_ems_ref(stack.id, output['output_key'])
-      o = persister.orchestration_stacks_outputs.find_or_build(uid)
-      o.ems_ref = uid
-      o.key = output['output_key']
-      o.value = output['output_value']
-      o.description = output['description']
-      o.stack = stack_inventory_object
-    end
-  end
-
-  def orchestration_template(stack)
-    template = collector.orchestration_template(stack)
-    if template
-      o = persister.orchestration_templates.find_or_build(stack.id)
-      o.type = "ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate"
-      o.name = stack.stack_name
-      o.description = stack.template.description
-      o.content = stack.template.content
-      o.orderable = false
-      o
-    end
-  end
-
   def orchestration_stacks
     collector.orchestration_stacks.each do |stack|
       o = persister.orchestration_stacks.find_or_build(stack.id.to_s)
-      o.type = "ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack"
       o.name = stack.stack_name
       o.description = stack.description
       o.status = stack.stack_status

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -19,32 +19,11 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     @storage_service            = collector.storage_service
     @introspection_service      = collector.introspection_service
 
-    validate_required_services
-
     images
     get_object_store
     hosts
     orchestration_stacks
     clusters
-  end
-
-  def validate_required_services
-    unless @identity_service
-      raise MiqException::MiqOpenstackKeystoneServiceMissing, "Required service Keystone is missing in the catalog."
-    end
-
-    unless @compute_service
-      raise MiqException::MiqOpenstackNovaServiceMissing, "Required service Nova is missing in the catalog."
-    end
-
-    unless @image_service
-      raise MiqException::MiqOpenstackGlanceServiceMissing, "Required service Glance is missing in the catalog."
-    end
-
-    # log a warning but don't fail on missing Ironicggg
-    unless collector.baremetal_service
-      _log.warn "Ironic service is missing in the catalog. No host data will be synced."
-    end
   end
 
   def images

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -230,10 +230,8 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
     new_result = {
       :name                 => host_name,
-      :type                 => 'ManageIQ::Providers::Openstack::InfraManager::Host',
       :uid_ems              => host.instance_uuid,
       :ems_ref              => uid,
-      :operating_system     => {:product_name => 'linux'},
       :vmm_vendor           => 'redhat',
       :vmm_product          => identify_product(indexed_resources, host.instance_uuid),
       # Can't get this from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
@@ -246,14 +244,15 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
       :connection_state     => lookup_connection_state(host.power_state),
       :maintenance          => host.maintenance,
       :maintenance_reason   => host.maintenance_reason,
-      :hardware             => process_host_hardware(host, introspection_details),
       :hypervisor_hostname  => hypervisor_hostname,
       :service_tag          => extra_attributes.fetch_path('system', 'product', 'serial'),
       # TODO(lsmola) need to add column for connection to SecurityGroup
       # :security_group_id  => security_group_id
       # Attributes taken from the Cloud provider
-      :availability_zone_id => cloud_host_attributes.try(:[], :availability_zone_id)
+      #:availability_zone_id => cloud_host_attributes.try(:[], :availability_zone_id)
     }
+
+    persister.hosts.build(new_result)
 
     return uid, new_result
   end

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -12,12 +12,9 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     @data_index        = {}
     @resource_to_stack = {}
 
-    @compute_service            = collector.compute_service
-    @identity_service           = collector.identity_service
-    @orchestration_service      = collector.orchestration_service
-    @image_service              = collector.image_service
-    @storage_service            = collector.storage_service
-    @introspection_service      = collector.introspection_service
+    @orchestration_service = collector.orchestration_service
+    @image_service         = collector.image_service
+    @storage_service       = collector.storage_service
 
     images
     get_object_store
@@ -155,17 +152,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     hosts_attributes
   end
 
-  def get_introspection_details(host)
-    return {} unless @introspection_service
-
-    begin
-      @introspection_service.get_introspection_details(host.uuid).body
-    rescue
-      # introspection data not available
-      {}
-    end
-  end
-
   def get_extra_attributes(introspection_details)
     return {} if introspection_details.blank? || introspection_details["extra"].nil?
 
@@ -179,8 +165,8 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     ip_address          = identify_primary_ip_address(host, indexed_servers)
     hostname            = ip_address
 
-    introspection_details = get_introspection_details(host)
-    extra_attributes = get_extra_attributes(introspection_details)
+    introspection_details = collector.introspection_details(host)
+    extra_attributes      = get_extra_attributes(introspection_details)
 
     # Get the cloud_host_attributes by hypervisor hostname, only compute hosts can get this
     cloud_host_attributes = cloud_hosts_attributes.select do |x|

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -192,12 +192,8 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     server&.addresses&.fetch_path('ctlplane', 0, key)
   end
 
-  def get_purpose(instance_uuid)
-    collector.stack_resources_by_id[instance_uuid]&.dig('resource_name')
-  end
-
   def identify_product(instance_uuid)
-    purpose = get_purpose(instance_uuid)
+    purpose = collector.server_purpose_by_instance_uuid[instance_uuid]
     return nil unless purpose
 
     if purpose == 'NovaCompute'
@@ -208,7 +204,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
   end
 
   def identify_host_name(instance_uuid, uid)
-    purpose = get_purpose(instance_uuid)
+    purpose = collector.server_purpose_by_instance_uuid[instance_uuid]
     return uid unless purpose
 
     "#{uid} (#{purpose})"

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -98,7 +98,10 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     extra_attributes      = introspection_details&.dig("extra") || {}
 
     # Get the cloud_host_attributes by hypervisor hostname, only compute hosts can get this
-    cloud_host_attributes = collector.cloud_host_attributes_by_host[hypervisor_hostname.downcase]&.first
+    cloud_host_attributes = collector.cloud_host_attributes.select do |x|
+      hypervisor_hostname && x[:host_name].include?(hypervisor_hostname.downcase)
+    end
+    cloud_host_attributes = cloud_host_attributes.first if cloud_host_attributes
 
     cluster_ref = collector.cluster_by_host[host.instance_uuid]
     ems_cluster = persister.clusters.lazy_find(cluster_ref) if cluster_ref

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -1,0 +1,413 @@
+class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ::Providers::Openstack::Inventory::Parser
+  include Vmdb::Logging
+
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::HelperMethods
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::Images
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::Objects
+  include ManageIQ::Providers::Openstack::RefreshParserCommon::OrchestrationStacks
+
+  def parse
+    @ems               = collector.manager
+    @connection        = @ems.connect
+    @data              = {}
+    @data_index        = {}
+    @host_hash_by_name = {}
+    @resource_to_stack = {}
+
+    @known_flavors = Set.new
+
+    @os_handle                  = @ems.openstack_handle
+    @compute_service            = @connection # for consistency
+    @baremetal_service          = @os_handle.detect_baremetal_service
+    @identity_service           = @os_handle.identity_service
+    @orchestration_service      = @os_handle.detect_orchestration_service
+    @image_service              = @os_handle.detect_image_service
+    @storage_service            = @os_handle.detect_storage_service
+    @introspection_service      = @os_handle.detect_introspection_service
+
+    validate_required_services
+
+    log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data" \
+                 " for EMS name: [#{@ems.name}] id: [#{@ems.id}]"
+    $fog_log.info("#{log_header}...")
+    # The order of the below methods does matter, because there are inner dependencies of the data!
+
+    # get_flavors # Not needed in infra
+    # get_availability_zones # Not needed in infra
+    # get_tenants # TODO(lsmola) should be needed, add it
+    # get_quotas # Not needed in infra
+    # get_key_pairs # Not needed in infra
+    get_images
+
+    get_object_store
+    # get_object_store needs to run before load hosts
+    load_hosts
+
+    load_orchestration_stacks
+    # Cluster processing needs to run after host and stacks processing
+    get_clusters
+
+    $fog_log.info("#{log_header}...Complete")
+    @data
+  end
+
+  def validate_required_services
+    unless @identity_service
+      raise MiqException::MiqOpenstackKeystoneServiceMissing, "Required service Keystone is missing in the catalog."
+    end
+
+    unless @compute_service
+      raise MiqException::MiqOpenstackNovaServiceMissing, "Required service Nova is missing in the catalog."
+    end
+
+    unless @image_service
+      raise MiqException::MiqOpenstackGlanceServiceMissing, "Required service Glance is missing in the catalog."
+    end
+
+    # log a warning but don't fail on missing Ironicggg
+    unless @baremetal_service
+      _log.warn "Ironic service is missing in the catalog. No host data will be synced."
+    end
+  end
+
+  private
+
+  def stack_resources_by_depth(stack)
+    return @stack_resources if @stack_resources
+    # TODO(lsmola) loading this from already obtained nested stack hierarchy will be more effective. This is one
+    # extra API call. But we will need to change order of loading, so we have all resources first.
+    @stack_resources = @orchestration_service.list_resources(:stack => stack, :nested_depth => 2).body['resources']
+  end
+
+  def filter_stack_resources_by_resource_type(resource_type_list)
+    resources = []
+    root_stacks.each do |stack|
+      # Filtering just server resources which is important to us for getting Purpose of the node
+      # (compute, controller, etc.).
+      resources += stack_resources_by_depth(stack).select do |x|
+        resource_type_list.include?(x["resource_type"])
+      end
+    end
+    resources
+  end
+
+  def stack_resource_groups
+    return @stack_resource_groups if @stack_resource_groups
+    @stack_resource_groups = filter_stack_resources_by_resource_type(["OS::Heat::ResourceGroup"])
+  end
+
+  def stack_server_resource_types
+    return @stack_server_resource_types if @stack_server_resource_types
+    @stack_server_resource_types = ["OS::TripleO::Server", "OS::Nova::Server"]
+    @stack_server_resource_types += stack_resource_groups.map { |rg| "OS::TripleO::" + rg["resource_name"] + "Server" }
+  end
+
+  def stack_server_resources
+    return @stack_server_resources if @stack_server_resources
+    @stack_server_resources = filter_stack_resources_by_resource_type(stack_server_resource_types)
+  end
+
+  def servers
+    @servers ||= uniques(@connection.handled_list(:servers))
+  end
+
+  def hosts
+    @hosts ||= @baremetal_service && uniques(@baremetal_service.handled_list(:nodes))
+  end
+
+  def clouds
+    @ems.provider.try(:cloud_ems)
+  end
+
+  def cloud_ems_hosts_attributes
+    hosts_attributes = []
+    return hosts_attributes unless clouds
+
+    clouds.each do |cloud_ems|
+      compute_hosts = nil
+      begin
+        cloud_ems.with_provider_connection do |connection|
+          compute_hosts = connection.hosts.select { |x| x.service_name == "compute" }
+        end
+      rescue => err
+        _log.error "Error Class=#{err.class.name}, Message=#{err.message}"
+        $log.error err.backtrace.join("\n")
+        # Just log the error and continue the refresh, we don't want error in cloud side to affect infra refresh
+        next
+      end
+
+      compute_hosts.each do |compute_host|
+        # We need to take correct zone id from correct provider, since the zone name can be the same
+        # across providers
+        availability_zone_id = cloud_ems.availability_zones.find_by(:name => compute_host.zone).try(:id)
+        hosts_attributes << {:host_name => compute_host.host_name, :availability_zone_id => availability_zone_id}
+      end
+    end
+    hosts_attributes
+  end
+
+  def load_hosts
+    # Servers contains assigned IP address of hosts, there can be only
+    # one nova server per host, only if the host is provisioned.
+    indexed_servers = {}
+    servers.each { |s| indexed_servers[s.id] = s }
+
+    # Indexed Heat resources, we are interested only in OS::Nova::Server/OS::TripleO::Server
+    indexed_resources = {}
+    stack_server_resources.each { |p| indexed_resources[p['physical_resource_id']] = p }
+
+    process_collection(hosts, :hosts) do  |host|
+      parse_host(host, indexed_servers, indexed_resources, cloud_ems_hosts_attributes)
+    end
+  end
+
+  def get_introspection_details(host)
+    return {} unless @introspection_service
+    begin
+      @introspection_service.get_introspection_details(host.uuid).body
+    rescue
+      # introspection data not available
+      {}
+    end
+  end
+
+  def get_extra_attributes(introspection_details)
+    return {} if introspection_details.blank? || introspection_details["extra"].nil?
+    introspection_details["extra"]
+  end
+
+  def parse_host(host, indexed_servers, indexed_resources, cloud_hosts_attributes)
+    uid                 = host.uuid
+    host_name           = identify_host_name(indexed_resources, host.instance_uuid, uid)
+    hypervisor_hostname = identify_hypervisor_hostname(host, indexed_servers)
+    ip_address          = identify_primary_ip_address(host, indexed_servers)
+    hostname            = ip_address
+
+    introspection_details = get_introspection_details(host)
+    extra_attributes = get_extra_attributes(introspection_details)
+
+    # Get the cloud_host_attributes by hypervisor hostname, only compute hosts can get this
+    cloud_host_attributes = cloud_hosts_attributes.select do |x|
+      hypervisor_hostname && x[:host_name].include?(hypervisor_hostname.downcase)
+    end
+    cloud_host_attributes = cloud_host_attributes.first if cloud_host_attributes
+
+    new_result = {
+      :name                 => host_name,
+      :type                 => 'ManageIQ::Providers::Openstack::InfraManager::Host',
+      :uid_ems              => host.instance_uuid,
+      :ems_ref              => uid,
+      :operating_system     => {:product_name => 'linux'},
+      :vmm_vendor           => 'redhat',
+      :vmm_product          => identify_product(indexed_resources, host.instance_uuid),
+      # Can't get this from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
+      :vmm_version          => nil,
+      :ipaddress            => ip_address,
+      :hostname             => hostname,
+      :mac_address          => identify_primary_mac_address(host, indexed_servers),
+      :ipmi_address         => identify_ipmi_address(host),
+      :power_state          => lookup_power_state(host.power_state),
+      :connection_state     => lookup_connection_state(host.power_state),
+      :maintenance          => host.maintenance,
+      :maintenance_reason   => host.maintenance_reason,
+      :hardware             => process_host_hardware(host, introspection_details),
+      :hypervisor_hostname  => hypervisor_hostname,
+      :service_tag          => extra_attributes.fetch_path('system', 'product', 'serial'),
+      # TODO(lsmola) need to add column for connection to SecurityGroup
+      # :security_group_id  => security_group_id
+      # Attributes taken from the Cloud provider
+      :availability_zone_id => cloud_host_attributes.try(:[], :availability_zone_id)
+    }
+
+    return uid, new_result
+  end
+
+  def process_host_hardware(host, introspection_details)
+    extra_attributes     = get_extra_attributes(introspection_details)
+    cpu_sockets          = extra_attributes.fetch_path('cpu', 'physical', 'number').to_i
+    cpu_total_cores      = extra_attributes.fetch_path('cpu', 'logical', 'number').to_i
+    cpu_cores_per_socket = cpu_sockets > 0 ? cpu_total_cores / cpu_sockets : 0
+    cpu_speed            = introspection_details.fetch_path('inventory', 'cpu', 'frequency').to_i
+
+    {
+      :memory_mb            => host.properties['memory_mb'],
+      :disk_capacity        => host.properties['local_gb'],
+      :cpu_total_cores      => cpu_total_cores,
+      :cpu_sockets          => cpu_sockets,
+      :cpu_cores_per_socket => cpu_cores_per_socket,
+      :cpu_speed            => cpu_speed,
+      :cpu_type             => extra_attributes.fetch_path('cpu', 'physical_0', 'version'),
+      :manufacturer         => extra_attributes.fetch_path('system', 'product', 'vendor'),
+      :model                => extra_attributes.fetch_path('system', 'product', 'name'),
+      :number_of_nics       => extra_attributes.fetch_path('network').try(:keys).try(:count).to_i,
+      :bios                 => extra_attributes.fetch_path('firmware', 'bios', 'version'),
+      # Can't get these 2 from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
+      :guest_os_full_name   => nil,
+      :guest_os             => nil,
+      :disks                => process_host_hardware_disks(extra_attributes),
+      :introspected         => !introspection_details.blank?,
+      # fog-openstack baremetal service defaults to Ironic API v1.1.
+      # In version 1.1 "available" is shown as null in JSON. It is correctly
+      # shown as "available" starting with version 1.2.
+      # This may need to change once this issue is addressed:
+      # https://github.com/fog/fog-openstack/issues/197
+      :provision_state      => host.provision_state.nil? ? "available" : host.provision_state,
+    }
+  end
+
+  def process_host_hardware_disks(extra_attributes)
+    return [] if extra_attributes.nil? || (disks = extra_attributes.fetch_path('disk')).blank?
+
+    disks.keys.delete_if { |x| x.include?('{') || x == 'logical' }.map do |disk|
+      # Logical index contains number of logical disks
+      # TODO(lsmola) For now ignoring smart data, that are in format e.g. sda{cciss,1}, we need to design
+      # how to represent RAID
+      # Convert the disk size from GB to B
+      disk_size = disks.fetch_path(disk, 'size').to_i * 1_024**3
+      {
+        :device_name     => disk,
+        :device_type     => 'disk',
+        :controller_type => 'scsi',
+        :present         => true,
+        :filename        => disks.fetch_path(disk, 'id') || disks.fetch_path(disk, 'scsi-id'),
+        :location        => disk,
+        :size            => disk_size,
+        :disk_type       => nil,
+        :mode            => 'persistent'
+      }
+    end
+  end
+
+  def server_address(server, key)
+    # TODO(lsmola) Nova is missing information which address is primary now,
+    # so just taking first. We need to figure out how to identify it if
+    # there are multiple.
+    server.addresses.fetch_path('ctlplane', 0, key) if server
+  end
+
+  def get_purpose(indexed_resources, instance_uuid)
+    indexed_resources.fetch_path(instance_uuid, 'resource_name')
+  end
+
+  def identify_product(indexed_resources, instance_uuid)
+    purpose = get_purpose(indexed_resources, instance_uuid)
+    return nil unless purpose
+
+    if purpose == 'NovaCompute'
+      'rhel (Nova Compute hypervisor)'
+    else
+      "rhel (No hypervisor, Host Type is #{purpose})"
+    end
+  end
+
+  def identify_host_name(indexed_resources, instance_uuid, uid)
+    purpose = get_purpose(indexed_resources, instance_uuid)
+    return uid unless purpose
+
+    "#{uid} (#{purpose})"
+  end
+
+  def identify_primary_mac_address(host, indexed_servers)
+    server_address(indexed_servers[host.instance_uuid], 'OS-EXT-IPS-MAC:mac_addr')
+  end
+
+  def identify_primary_ip_address(host, indexed_servers)
+    server_address(indexed_servers[host.instance_uuid], 'addr')
+  end
+
+  def identify_ipmi_address(host)
+    host.driver_info["ipmi_address"]
+  end
+
+  def identify_hypervisor_hostname(host, indexed_servers)
+    indexed_servers.fetch_path(host.instance_uuid).try(:name)
+  end
+
+  def lookup_power_state(power_state_input)
+    case power_state_input
+    when "power on"               then "on"
+    when "power off", "rebooting" then "off"
+    else                               "unknown"
+    end
+  end
+
+  def lookup_connection_state(power_state_input)
+    case power_state_input
+    when "power on"               then "connected"
+    when "power off", "rebooting" then "disconnected"
+    else                               "disconnected"
+    end
+  end
+
+  def get_clusters
+    # This counts with hosts being already collected
+    hosts = @data.fetch_path(:hosts)
+    clusters, cluster_host_mapping = get_clusters_and_host_mapping
+    process_collection(clusters, :clusters) { |cluster| parse_cluster(cluster) }
+
+    set_relationship_on_hosts(hosts, cluster_host_mapping)
+  end
+
+  def get_clusters_and_host_mapping
+    clusters = []
+    cluster_host_mapping = {}
+    orchestration_stacks = @data_index.fetch_path(:orchestration_stacks)
+    orchestration_stacks.each_value do |stack|
+      uid = stack.fetch_path(:parent, :ems_ref)
+      next unless uid
+
+      nova_server = stack[:resources].detect do |r|
+        stack_server_resource_types.include?(r[:resource_category])
+      end
+      next unless nova_server
+
+      cluster_host_mapping[nova_server[:physical_resource]] = uid
+      clusters << {:name => stack[:parent][:name], :uid => uid}
+    end if orchestration_stacks
+    return clusters.uniq, cluster_host_mapping
+  end
+
+  def parse_cluster(cluster)
+    name = cluster[:name]
+    uid = cluster[:uid]
+
+    new_result = {
+      :ems_ref => uid,
+      :uid_ems => uid,
+      :name    => name,
+      :type    => 'ManageIQ::Providers::Openstack::InfraManager::Cluster'
+    }
+    return uid, new_result
+  end
+
+  def set_relationship_on_hosts(hosts, cluster_host_mapping)
+    hosts.each do |host|
+      host[:ems_cluster] = @data_index.fetch_path(:clusters, cluster_host_mapping[host[:uid_ems]])
+    end
+  end
+
+  def get_object_content(obj)
+    obj.body
+  end
+
+  def self.miq_template_type
+    "ManageIQ::Providers::Openstack::InfraManager::Template"
+  end
+
+  #
+  # Helper methods
+  #
+
+
+  def process_collection(collection, key)
+    @data[key] ||= []
+    return if collection.nil?
+
+    collection.each do |item|
+      uid, new_result = yield(item)
+
+      @data[key] << new_result
+      @data_index.store_path(key, uid, new_result)
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -390,16 +390,16 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     cluster_host_mapping = {}
     orchestration_stacks = @data_index.fetch_path(:orchestration_stacks)
     orchestration_stacks.each_value do |stack|
-      uid = stack[:parent]&.stringified_reference
-      next unless uid
+      parent = orchestration_stacks[stack[:parent]&.stringified_reference]
+      next unless parent
 
       nova_server = stack[:resources].detect do |r|
         stack_server_resource_types.include?(r[:resource_category])
       end
       next unless nova_server
 
-      cluster_host_mapping[nova_server[:physical_resource]] = uid
-      clusters << {:name => stack[:parent][:name], :uid => uid}
+      cluster_host_mapping[nova_server[:physical_resource]] = parent[:ems_ref]
+      clusters << {:name => parent[:name], :uid => parent[:ems_ref]}
     end if orchestration_stacks
     return clusters.uniq, cluster_host_mapping
   end

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -410,9 +410,11 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     new_result = {
       :ems_ref => uid,
       :uid_ems => uid,
-      :name    => name,
-      :type    => 'ManageIQ::Providers::Openstack::InfraManager::Cluster'
+      :name    => name
     }
+
+    persister.clusters.build(new_result)
+
     return uid, new_result
   end
 
@@ -424,10 +426,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def get_object_content(obj)
     obj.body
-  end
-
-  def self.miq_template_type
-    "ManageIQ::Providers::Openstack::InfraManager::Template"
   end
 
   #

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -129,10 +129,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     @stack_server_resources = filter_stack_resources_by_resource_type(stack_server_resource_types)
   end
 
-  def servers
-    @servers ||= uniques(@connection.handled_list(:servers))
-  end
-
   def hosts
     @hosts ||= @baremetal_service && uniques(@baremetal_service.handled_list(:nodes))
   end
@@ -172,7 +168,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     # Servers contains assigned IP address of hosts, there can be only
     # one nova server per host, only if the host is provisioned.
     indexed_servers = {}
-    servers.each { |s| indexed_servers[s.id] = s }
+    collector.servers.each { |s| indexed_servers[s.id] = s }
 
     # Indexed Heat resources, we are interested only in OS::Nova::Server/OS::TripleO::Server
     indexed_resources = {}

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def hosts
     host_attributes = cloud_ems_hosts_attributes
-    process_collection(collector.hosts, :hosts) { |host| parse_host(host, host_attributes) }
+    collector.hosts.each { |host| parse_host(host, host_attributes) }
   end
 
   def orchestration_stacks
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def clusters
     clusters, cluster_host_mapping = clusters_and_host_mapping
-    process_collection(clusters, :clusters) { |cluster| parse_cluster(cluster) }
+    clusters.each { |cluster| parse_cluster(cluster) }
 
     set_relationship_on_hosts(persister.hosts, cluster_host_mapping)
   end

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -375,12 +375,10 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
   end
 
   def get_clusters
-    # This counts with hosts being already collected
-    hosts = @data.fetch_path(:hosts)
     clusters, cluster_host_mapping = get_clusters_and_host_mapping
     process_collection(clusters, :clusters) { |cluster| parse_cluster(cluster) }
 
-    set_relationship_on_hosts(hosts, cluster_host_mapping)
+    set_relationship_on_hosts(persister.hosts, cluster_host_mapping)
   end
 
   def get_clusters_and_host_mapping
@@ -419,7 +417,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def set_relationship_on_hosts(hosts, cluster_host_mapping)
     hosts.each do |host|
-      host[:ems_cluster] = @data_index.fetch_path(:clusters, cluster_host_mapping[host[:uid_ems]])
+      host.ems_cluster = persister.clusters.lazy_find(cluster_host_mapping[host[:uid_ems]])
     end
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -45,7 +45,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
     load_orchestration_stacks
     # Cluster processing needs to run after host and stacks processing
-    get_clusters
+    clusters
 
     $fog_log.info("#{log_header}...Complete")
     @data
@@ -101,7 +101,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
         :memory_mb_minimum   => image.min_ram,
         :root_device_type    => image.disk_format,
         :size_on_disk        => image.size,
-        :virtualization_type => image.properties.try(:[], 'hypervisor_type') || image.attributes['hypervisor_type'],
+        :virtualization_type => image.properties.try(:[], 'hypervisor_type') || image.attributes['hypervisor_type']
       )
     end
   end
@@ -110,6 +110,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def stack_resources_by_depth(stack)
     return @stack_resources if @stack_resources
+
     # TODO(lsmola) loading this from already obtained nested stack hierarchy will be more effective. This is one
     # extra API call. But we will need to change order of loading, so we have all resources first.
     @stack_resources = @orchestration_service.list_resources(:stack => stack, :nested_depth => 2).body['resources']
@@ -129,17 +130,20 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def stack_resource_groups
     return @stack_resource_groups if @stack_resource_groups
+
     @stack_resource_groups = filter_stack_resources_by_resource_type(["OS::Heat::ResourceGroup"])
   end
 
   def stack_server_resource_types
     return @stack_server_resource_types if @stack_server_resource_types
+
     @stack_server_resource_types = ["OS::TripleO::Server", "OS::Nova::Server"]
     @stack_server_resource_types += stack_resource_groups.map { |rg| "OS::TripleO::" + rg["resource_name"] + "Server" }
   end
 
   def stack_server_resources
     return @stack_server_resources if @stack_server_resources
+
     @stack_server_resources = filter_stack_resources_by_resource_type(stack_server_resource_types)
   end
 
@@ -166,8 +170,8 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
           compute_hosts = connection.hosts.select { |x| x.service_name == "compute" }
         end
       rescue => err
-        _log.error "Error Class=#{err.class.name}, Message=#{err.message}"
-        $log.error err.backtrace.join("\n")
+        _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+        _log.error(err.backtrace.join("\n"))
         # Just log the error and continue the refresh, we don't want error in cloud side to affect infra refresh
         next
       end
@@ -192,13 +196,14 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     indexed_resources = {}
     stack_server_resources.each { |p| indexed_resources[p['physical_resource_id']] = p }
 
-    process_collection(hosts, :hosts) do  |host|
+    process_collection(hosts, :hosts) do |host|
       parse_host(host, indexed_servers, indexed_resources, cloud_ems_hosts_attributes)
     end
   end
 
   def get_introspection_details(host)
     return {} unless @introspection_service
+
     begin
       @introspection_service.get_introspection_details(host.uuid).body
     rescue
@@ -209,6 +214,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
   def get_extra_attributes(introspection_details)
     return {} if introspection_details.blank? || introspection_details["extra"].nil?
+
     introspection_details["extra"]
   end
 
@@ -229,27 +235,27 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     cloud_host_attributes = cloud_host_attributes.first if cloud_host_attributes
 
     new_result = {
-      :name                 => host_name,
-      :uid_ems              => host.instance_uuid,
-      :ems_ref              => uid,
-      :vmm_vendor           => 'redhat',
-      :vmm_product          => identify_product(indexed_resources, host.instance_uuid),
+      :name                => host_name,
+      :uid_ems             => host.instance_uuid,
+      :ems_ref             => uid,
+      :vmm_vendor          => 'redhat',
+      :vmm_product         => identify_product(indexed_resources, host.instance_uuid),
       # Can't get this from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
-      :vmm_version          => nil,
-      :ipaddress            => ip_address,
-      :hostname             => hostname,
-      :mac_address          => identify_primary_mac_address(host, indexed_servers),
-      :ipmi_address         => identify_ipmi_address(host),
-      :power_state          => lookup_power_state(host.power_state),
-      :connection_state     => lookup_connection_state(host.power_state),
-      :maintenance          => host.maintenance,
-      :maintenance_reason   => host.maintenance_reason,
-      :hypervisor_hostname  => hypervisor_hostname,
-      :service_tag          => extra_attributes.fetch_path('system', 'product', 'serial'),
+      :vmm_version         => nil,
+      :ipaddress           => ip_address,
+      :hostname            => hostname,
+      :mac_address         => identify_primary_mac_address(host, indexed_servers),
+      :ipmi_address        => identify_ipmi_address(host),
+      :power_state         => lookup_power_state(host.power_state),
+      :connection_state    => lookup_connection_state(host.power_state),
+      :maintenance         => host.maintenance,
+      :maintenance_reason  => host.maintenance_reason,
+      :hypervisor_hostname => hypervisor_hostname,
+      :service_tag         => extra_attributes.fetch_path('system', 'product', 'serial'),
       # TODO(lsmola) need to add column for connection to SecurityGroup
       # :security_group_id  => security_group_id
       # Attributes taken from the Cloud provider
-      #:availability_zone_id => cloud_host_attributes.try(:[], :availability_zone_id)
+      :availability_zone_id => cloud_host_attributes.try(:[], :availability_zone_id)
     }
 
     persister_host = persister.hosts.build(new_result)
@@ -284,7 +290,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
       # Can't get these 2 from ironic, maybe from Glance metadata, when it will be there, or image fleecing?
       :guest_os_full_name   => nil,
       :guest_os             => nil,
-      :introspected         => !introspection_details.blank?,
+      :introspected         => introspection_details.present?,
       # fog-openstack baremetal service defaults to Ironic API v1.1.
       # In version 1.1 "available" is shown as null in JSON. It is correctly
       # shown as "available" starting with version 1.2.
@@ -321,7 +327,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     # TODO(lsmola) Nova is missing information which address is primary now,
     # so just taking first. We need to figure out how to identify it if
     # there are multiple.
-    server.addresses.fetch_path('ctlplane', 0, key) if server
+    server&.addresses&.fetch_path('ctlplane', 0, key)
   end
 
   def get_purpose(indexed_resources, instance_uuid)
@@ -378,18 +384,18 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     end
   end
 
-  def get_clusters
-    clusters, cluster_host_mapping = get_clusters_and_host_mapping
+  def clusters
+    clusters, cluster_host_mapping = clusters_and_host_mapping
     process_collection(clusters, :clusters) { |cluster| parse_cluster(cluster) }
 
     set_relationship_on_hosts(persister.hosts, cluster_host_mapping)
   end
 
-  def get_clusters_and_host_mapping
+  def clusters_and_host_mapping
     clusters = []
     cluster_host_mapping = {}
     orchestration_stacks = @data_index.fetch_path(:orchestration_stacks)
-    orchestration_stacks.each_value do |stack|
+    orchestration_stacks&.each_value do |stack|
       parent = orchestration_stacks[stack[:parent]&.stringified_reference]
       next unless parent
 
@@ -400,7 +406,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
 
       cluster_host_mapping[nova_server[:physical_resource]] = parent[:ems_ref]
       clusters << {:name => parent[:name], :uid => parent[:ems_ref]}
-    end if orchestration_stacks
+    end
     return clusters.uniq, cluster_host_mapping
   end
 
@@ -449,17 +455,17 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     )
 
     resources.each do |res|
-      res.merge!(:stack => persister_stack)
+      res[:stack] = persister_stack
       persister.orchestration_stacks_resources.build(res)
     end
 
     outputs.each do |output|
-      output.merge!(:stack => persister_stack)
+      output[:stack] = persister_stack
       persister.orchestration_stacks_outputs.build(output)
     end
 
     parameters.each do |param|
-      param.merge!(:stack => persister_stack)
+      param[:stack] = persister_stack
       persister.orchestration_stacks_parameters.build(param)
     end
 
@@ -490,7 +496,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
   #
   # Helper methods
   #
-
 
   def process_collection(collection, key)
     @data[key] ||= []

--- a/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/infra_manager.rb
@@ -214,41 +214,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::InfraManager < ManageIQ
     end
   end
 
-  def orchestration_stack_outputs(stack, persister_stack)
-    collector.orchestration_outputs(stack).each do |output|
-      persister.orchestration_stacks_outputs.build(
-        :stack       => persister_stack,
-        :ems_ref     => compose_ems_ref(stack.id, output['output_key']),
-        :key         => output['output_key'],
-        :value       => output['output_value'],
-        :description => output['description']
-      )
-    end
-  end
-
-  def orchestration_stack_parameters(stack, persister_stack)
-    collector.orchestration_parameters(stack).each do |param_key, param_val|
-      persister.orchestration_stacks_parameters.build(
-        :stack   => persister_stack,
-        :ems_ref => compose_ems_ref(stack.id, param_key),
-        :name    => param_key,
-        :value   => param_val
-      )
-    end
-  end
-
-  def orchestration_template(stack)
-    template = collector.orchestration_template(stack)
-
-    persister.orchestration_templates.build(
-      :name        => stack.stack_name,
-      :ems_ref     => stack.id,
-      :description => template.description,
-      :content     => template.content,
-      :orderable   => false
-    )
-  end
-
   def server_address(server, key)
     # TODO(lsmola) Nova is missing information which address is primary now,
     # so just taking first. We need to figure out how to identify it if

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
+  require_nested :InfraManager
   require_nested :NetworkManager
   require_nested :StorageManager
   require_nested :TargetCollection

--- a/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
@@ -1,0 +1,34 @@
+class ManageIQ::Providers::Openstack::Inventory::Persister::InfraManager < ManageIQ::Providers::Openstack::Inventory::Persister
+  def initialize_inventory_collections
+    add_collection(infra, :miq_templates) { |b| b.add_properties(:model_class => manager.class::Template) }
+    add_collection(infra, :hardwares)
+    add_collection(infra, :operating_systems)
+    add_collection(infra, :clusters)  { |b| b.add_properties(:model_class => manager.class::Cluster) }
+    add_collection(infra, :orchestration_stacks)
+    add_collection(infra, :hosts)
+    add_collection(infra, :host_disks)
+    add_collection(infra, :host_hardwares)
+    add_collection(infra, :host_operating_systems)
+    add_collection(infra, :orchestration_stacks)
+    add_collection(infra, :orchestration_stacks_resources)
+    add_collection(infra, :orchestration_stacks_outputs)
+    add_collection(infra, :orchestration_stacks_parameters)
+    add_collection(infra, :orchestration_templates)
+
+    add_cloud_collection(:cloud_tenants)
+  end
+
+  private
+
+  def add_cloud_collection(collection)
+    add_collection(cloud, collection, shared_cloud_properties)
+  end
+
+  def cloud_manager
+    manager.provider.cloud_ems.first
+  end
+
+  def shared_cloud_properties
+    {:parent => cloud_manager, :strategy => :local_db_cache_all}
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::InfraManager < Manag
     add_collection(infra, :orchestration_stacks_resources)
     add_collection(infra, :orchestration_stacks_outputs)
     add_collection(infra, :orchestration_stacks_parameters)
+    add_collection(infra, :orchestration_stack_ancestry)
     add_collection(infra, :orchestration_templates)
 
     add_cloud_collection(:cloud_tenants)

--- a/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
@@ -15,21 +15,5 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::InfraManager < Manag
     add_collection(infra, :orchestration_stacks_parameters)
     add_collection(infra, :orchestration_stack_ancestry)
     add_collection(infra, :orchestration_templates)
-
-    add_cloud_collection(:cloud_tenants)
-  end
-
-  private
-
-  def add_cloud_collection(collection)
-    add_collection(cloud, collection, shared_cloud_properties)
-  end
-
-  def cloud_manager
-    manager.provider.cloud_ems.first
-  end
-
-  def shared_cloud_properties
-    {:parent => cloud_manager, :strategy => :local_db_cache_all}
   end
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/infra_manager.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::InfraManager < Manag
     add_collection(infra, :miq_templates) { |b| b.add_properties(:model_class => manager.class::Template) }
     add_collection(infra, :hardwares)
     add_collection(infra, :operating_systems)
-    add_collection(infra, :clusters)  { |b| b.add_properties(:model_class => manager.class::Cluster) }
+    add_collection(infra, :clusters) { |b| b.add_properties(:model_class => manager.class::Cluster) }
     add_collection(infra, :orchestration_stacks)
     add_collection(infra, :hosts)
     add_collection(infra, :host_disks)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,10 @@
     :parallel_thread_limit: 0
   :openstack_network:
     :is_admin: false
+    :inventory_object_refresh: true
+  :openstack_infra:
+    :is_admin: false
+    :inventory_object_refresh: true
   :cinder:
     :is_admin: false
 :ems:

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -78,39 +78,31 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
 
   def assert_table_counts
     expect(ExtManagementSystem.count).to         eq 2
-    expect(EmsCluster.count).to                  be > 0
-    expect(Host.count).to                        be > 0
-    expect(OrchestrationStack.count).to          be > 0
-    expect(OrchestrationStackParameter.count).to be > 0
-    expect(OrchestrationStackResource.count).to  be > 0
-    expect(OrchestrationStackOutput.count).to    be > 0
-    expect(OrchestrationTemplate.count).to       be > 0
-    expect(CloudNetwork.count).to                be > 0
-    expect(CloudSubnet.count).to                 be > 0
-    expect(NetworkPort.count).to                 be > 0
-    expect(VmOrTemplate.count).to                be > 0
-    expect(OperatingSystem.count).to             be > 0
-    expect(Hardware.count).to                    be > 0
-    # TODO(tzumainn) Introspection no longer returns disk information, may be
-    # an OpenStack issue?
-    expect(Disk.count).to                        be > -1
+    expect(EmsCluster.count).to                  eq 2
+    expect(Host.count).to                        eq 3
+    expect(OrchestrationStack.count).to          eq 317
+    expect(OrchestrationStackParameter.count).to eq 2929
+    expect(OrchestrationStackResource.count).to  eq 504
+    expect(OrchestrationStackOutput.count).to    eq 439
+    expect(OrchestrationTemplate.count).to       eq 151
+    expect(CloudNetwork.count).to                eq 6
+    expect(CloudSubnet.count).to                 eq 6
+    expect(NetworkPort.count).to                 eq 21
+    expect(VmOrTemplate.count).to                eq 5
+    expect(OperatingSystem.count).to             eq 8
+    expect(Hardware.count).to                    eq 8
+    expect(Disk.count).to                        eq 3
     expect(ResourcePool.count).to                eq 0
     expect(Vm.count).to                          eq 0
     expect(CustomAttribute.count).to             eq 0
     expect(CustomizationSpec.count).to           eq 0
-    # expect(GuestDevice.count).to                 eq > 0
     expect(Lan.count).to                         eq 0
     expect(MiqScsiLun.count).to                  eq 0
     expect(MiqScsiTarget.count).to               eq 0
-    # expect(Network.count).to                     eq 0
     expect(Snapshot.count).to                    eq 0
     expect(Switch.count).to                      eq 0
     expect(SystemService.count).to               eq 0
-    expect(EmsFolder.count).to                   eq 0 # HACK: Folder structure for UI a la VMware
-    # TODO(lsmola) investigate if this should be filled or not, also why
-    # it behaves strangely, it has different values in CI then locally
-    # expect(Relationship.count).to                eq 0
-    # expect(MiqQueue.count).to                    eq 9
+    expect(EmsFolder.count).to                   eq 0
     expect(Storage.count).to                     eq 0
   end
 
@@ -121,17 +113,17 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       :uid_ems           => nil
     )
 
-    expect(@ems.ems_clusters.size).to                be > 0
-    expect(@ems.hosts.size).to                       be > 0
-    expect(@ems.orchestration_stacks.size).to        be > 0
-    expect(@ems.direct_orchestration_stacks.size).to be > 0
-    expect(@ems.vms_and_templates.size).to           be > 0
-    expect(@ems.miq_templates.size).to               be > 0
+    expect(@ems.ems_clusters.size).to                eq 2
+    expect(@ems.hosts.size).to                       eq 3
+    expect(@ems.orchestration_stacks.size).to        eq 317
+    expect(@ems.direct_orchestration_stacks.size).to eq 1
+    expect(@ems.vms_and_templates.size).to           eq 5
+    expect(@ems.miq_templates.size).to               eq 5
     expect(@ems.customization_specs.size).to         eq 0
     expect(@ems.resource_pools.size).to              eq 0
     expect(@ems.storages.size).to                    eq 0
     expect(@ems.vms.size).to                         eq 0
-    expect(@ems.ems_folders.size).to                 eq 0 # HACK: Folder structure for UI a la VMware
+    expect(@ems.ems_folders.size).to                 eq 0
   end
 
   def assert_specific_host

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -29,7 +29,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
       before { stub_settings_merge(:ems_refresh => {:openstack_infra => refresh_settings}) }
 
       it "will perform a full refresh" do
-        2.times do  # Run twice to verify that a second run with existing data does not change anything
+        2.times do # Run twice to verify that a second run with existing data does not change anything
           full_refresh
 
           assert_table_counts


### PR DESCRIPTION
This adds the option for graph refresh to the Openstack::InfraManager.

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/19958
- [x] https://github.com/ManageIQ/manageiq/pull/19960

Core issue: https://github.com/ManageIQ/manageiq/issues/19888