### PR TITLE
Remove unused ems_inv_to_hashes

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresher.rb
@@ -1,10 +1,6 @@
 module ManageIQ
   module Providers
     class Openstack::InfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-      def parse_legacy_inventory(ems)
-        ManageIQ::Providers::Openstack::InfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
-      end
-
       # TODO(lsmola) NetworkManager, remove this once we have a full representation of the NetworkManager.
       # NetworkManager should refresh base on it;s own conditions
       def save_inventory(ems, target, hashes)

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/refresher.rb
@@ -3,12 +3,5 @@ module ManageIQ::Providers
     def post_process_refresh_classes
       []
     end
-
-    # Legacy parse
-    #
-    # @param ems [ManageIQ::Providers::BaseManager]
-    def parse_legacy_inventory(ems)
-      ::ManageIQ::Providers::Openstack::StorageManager::CinderManager::RefreshParser.ems_inv_to_hashes(ems)
-    end
   end
 end


### PR DESCRIPTION
The RefreshParser.ems_inv_to_hashes method was used by legacy refresh
and no longer needed