### PR TITLE
If we fail to find a tenant don't return an Array

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -350,6 +350,7 @@ module OpenstackHandle
         next if name == "services"
         return @default_tenant_name ||= name if tenant_accessible?(name)
       end
+      nil
     end
 
     def service_for_each_accessible_tenant(service_name)


### PR DESCRIPTION
If we fail to find a tenant that works the default_tenant_name method was return the list of tenant_names to the caller.