### PR TITLE
Don't connect to Volume service on VM provisioning without Volumes

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
         new_volume_attrs[:destination_type] = 'volume'
         volumes_attrs_list << new_volume_attrs
       end
-    end
+    end if requested_volumes.any?
     volumes_attrs_list
   end
 


### PR DESCRIPTION
VM provisioning code connected to Volume (Cinder) service before was iterating volumes hat
should be created. This connection was not needed if the Volumes array was empty.

Adding conditional skipping the Volume service connection.