### PR TITLE
Update Network Refresh error logging for not-OpenStack provider

### DIFF
--- a/app/models/manageiq/providers/openstack/refresh_parser_common/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/helper_methods.rb
@@ -52,22 +52,22 @@ module ManageIQ::Providers
           yield
         rescue Excon::Errors::Forbidden => err
           # It can happen user doesn't have rights to read some tenant, in that case log warning but continue refresh
-          _log.warn "Forbidden response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
+          _log.warn "Forbidden response code returned in provider: #{@manager&.hostname}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")
           nil
         rescue Excon::Errors::Unauthorized => err
           # It can happen user doesn't have rights to read some tenant, in that case log warning but continue refresh
-          _log.warn "Unauthorized response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
+          _log.warn "Unauthorized response code returned in provider: #{@manager&.hostname}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")
           nil
         rescue Excon::Errors::NotFound, Fog::Errors::NotFound => err
           # It can happen that some data do not exist anymore,, in that case log warning but continue refresh
-          _log.warn "Not Found response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
+          _log.warn "Not Found response code returned in provider: #{@manager&.hostname}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")
           nil
         rescue Excon::Errors::BadRequest => err
           # This can happen if stack resources are missing, among other reasons. In such a case log a warning but continue the refresh.
-          _log.warn "Bad Request response code returned in provider: #{@os_handle.address}. Message=#{err.message}"
+          _log.warn "Bad Request response code returned in provider: #{@manager&.hostname}. Message=#{err.message}"
           _log.warn err.backtrace.join("\n")
           nil
         end


### PR DESCRIPTION
A logic for catch/rescue errors for refresh uses @os_handle for warn logging.
RHV/ovirt provider uses OpenStack networking, but doesn't provide @os_handle.

Updating warn error output to ignore nil @os_handle to allow pass refresh
even with skipped records (as until how, just logging raised the error).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1815479