### PR TITLE
[CloudTenant] Fix "Dangerous query method"

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb
@@ -59,7 +59,7 @@ class ManageIQ::Providers::Openstack::CloudManager::CloudTenant < ::CloudTenant
     # then return the security group with the most VMs in it.
     security_groups.left_joins(:network_port_security_groups)
                    .group(:id)
-                   .order('COUNT(network_ports_security_groups.security_group_id) DESC NULLS LAST')
+                   .order(Arel.sql('COUNT(network_ports_security_groups.security_group_id) DESC NULLS LAST'))
                    .first
   end
 


### PR DESCRIPTION
Similar fixes to what was given in https://github.com/ManageIQ/manageiq/pull/20036 and https://github.com/ManageIQ/manageiq/pull/20045

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as
raw SQL) called with non-attribute argument(s): "lower(description) ASC".
Non-attribute arguments will be disallowed in Rails 6.0. This method should not
be called with user-provided values, such as request parameters or model
attributes. Known-safe values can be passed by wrapping them in Arel.sql().

(called from default_security_group at app/models/manageiq/providers/openstack/cloud_manager/cloud_tenant.rb:62)
```

These deprecation warnings display in rails 5.2
These fixes work in 5.1


Links
-----

* Part of the Rails 5.2 effort: https://github.com/ManageIQ/manageiq/issues/20032
* Similar to:
  - https://github.com/ManageIQ/manageiq/pull/20036
  - https://github.com/ManageIQ/manageiq/pull/20045