### PR TITLE
Handle Keystone service without a region

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -174,7 +174,7 @@ module OpenstackHandle
         opts[:openstack_user_domain_id]    = domain
       end
 
-      opts[:openstack_region]            = region
+      opts[:openstack_region] = region unless service == "Identity"
 
       svc_cache = (@connection_cache[service] ||= {})
       svc_cache[tenant] ||= begin


### PR DESCRIPTION
If the keystone identity service is deployed without a region then passing `:openstack_region` will cause a missing endpoint failure.