### PR TITLE
parent is a method, not an association, and cannot be included

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -384,7 +384,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
 
   def infer_related_vm_ems_refs_db!
     changed_vms = manager.vms.where(:ems_ref => references(:vms)).includes(:key_pairs, :network_ports, :floating_ips,
-                                                                           :orchestration_stack, :cloud_networks, :cloud_tenant, :parent)
+                                                                           :orchestration_stack, :cloud_networks, :cloud_tenant)
     changed_vms.each do |vm|
       stack      = vm.orchestration_stack
       all_stacks = ([stack] + (stack.try(:ancestors) || [])).compact


### PR DESCRIPTION
Fixes an error seen in rails 5.2 because it's more strict about validating
`includes` are associations:

```
     ActiveRecord::AssociationNotFoundError:
       Association named 'parent' was not found on ManageIQ::Providers::Openstack::CloudManager::Vm; perhaps you misspelled it?
     # ./app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb:388:in `infer_related_vm_ems_refs_db!'
     # ./app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb:297:in `infer_related_ems_refs!'
     # ./app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb:8:in `initialize'
```

Related to ManageIQ/manageiq#20032

Below, you can see all of the other "included" values is an association that can
be reflected on by the model, while :parent cannot.  Note, this was the case
with rails 5.1 and it must have silently discarded these bogus includes while
5.2 raises `ActiveRecord::AssociationNotFoundError`.

```
irb(main):001:0> vm_klass = ManageIQ::Providers::CloudManager::Vm
irb(main):002:0> vm_klass._reflect_on_association(:key_pairs)
irb(main):003:0> vm_klass._reflect_on_association(:network_ports)
irb(main):004:0> vm_klass._reflect_on_association(:floating_ips)
irb(main):005:0> vm_klass._reflect_on_association(:orchestration_stack)
irb(main):006:0> vm_klass._reflect_on_association(:cloud_networks)
irb(main):007:0> vm_klass._reflect_on_association(:cloud_tenant)
irb(main):008:0> vm_klass._reflect_on_association(:parent)
```