### PR TITLE
Implemented authentication_class selection logic based on authtype

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -217,4 +217,10 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
       end
     end
   end
+
+  private
+
+  def authentication_class(attributes)
+    attributes.symbolize_keys[:auth_key] ? ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair : super
+  end
 end


### PR DESCRIPTION
This is required for selecting the correct STI subclass in https://github.com/ManageIQ/manageiq/pull/20157

Related issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot add_label enhancement