### PR TITLE
Ensure that the AMQP port gets properly to the validation in DDF

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         :hostname => params[:amqp_hostname],
         :username => params[:amqp_userid],
         :password => ManageIQ::Password.try_decrypt(password),
-        :port     => params[:amqp_api_port]
+        :port     => params[:amqp_api_port] || params[:amqp_port].to_s
       )
     end
     private :amqp_available?
@@ -311,12 +311,12 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     #   "endpoints" => {
     #     "default" => {
     #       "hostname" => String,
-    #       "api_port" => Integer,
+    #       "port" => Integer,
     #       "security_protocol" => String,
     #     },
     #     "amqp" => {
     #       "hostname" => String,
-    #       "api_port" => String,
+    #       "port" => String,
     #     },
     #   },
     #   "authentications" => {
@@ -339,7 +339,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       password = MiqPassword.try_decrypt(password)
       password ||= find(args["id"]).authentication_password(endpoint_name)
 
-      params = %w[hostname api_port security_protocol].reduce(
+      params = %w[hostname port security_protocol].reduce(
         [endpoint_name, 'userid'].join('_')   => userid,
         [endpoint_name, 'password'].join('_') => password
       ) do |obj, item|


### PR DESCRIPTION
The `Endpoint` model has a `port` field, but in the AMQP vaidation it's referred as `api_port` which is not very consistent. The DDF schema should and uses the `port` version, as the data from the API arrives so. In order to make sure that the validation will get the port, I had to add a fallback.

I'm not sure if the string conversion is necessary, but the old forms were sending the value as a string, so I wanted to play it safe.

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot assign @agrare 
@miq-bot add_label bug 