### PR TITLE
Don't require qpid_proton in gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
+  - BUNDLE_WITH=qpid_proton
 addons:
   postgresql: '10'
 before_install:

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"
-  s.add_runtime_dependency "qpid_proton",          "~> 0.30.0"
   s.add_runtime_dependency "more_core_extensions", "~> 3.2"
   s.add_runtime_dependency "parallel",             "~> 1.12.0"
 


### PR DESCRIPTION
This gem requires the installation of a C library and shouldn't be required for other repos which don't use it

Follow-up to: https://github.com/ManageIQ/manageiq-providers-openstack/pull/556