### PR TITLE
Refactor STF Event Monitor - service switch in manager mixin

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -363,9 +363,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
 
     def raw_connect(password, params, service = "Compute")
-      if params[:event_stream_selection] == 'amqp'
+      case params[:event_stream_selection]
+      when "amqp"
         amqp_available?(password, params)
-      elsif params[:event_stream_selection] == 'stf'
+      when "stf"
         stf_available?(password, params)
       else
         ems_connect?(password, params, service)


### PR DESCRIPTION
Updating ManagerMixin raw_connect method to use more readable
switch statement instead of conditions.

Related to https://github.com/ManageIQ/manageiq-providers-openstack/pull/556