### PR TITLE
Update activesupport requirement

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        ">= 5.2.4.3", "~> 5.2.4"
+  s.add_runtime_dependency "activesupport",        "~> 5.2.4.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        ">= 5.0", "< 5.3"
+  s.add_runtime_dependency "activesupport",        "~>5.2.4", ">= 5.2.4.3", "< 5.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        "~>5.2.4", ">= 5.2.4.3"
+  s.add_runtime_dependency "activesupport",        "~> 5.2.4", ">= 5.2.4.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        "~> 5.2.4", ">= 5.2.4.3"
+  s.add_runtime_dependency "activesupport",        ">= 5.2.4.3", "~> 5.2.4"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        "~> 5.2.4.3"
+  s.add_runtime_dependency "activesupport",        "~> 5.2.4", ">= 5.2.4.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_runtime_dependency "activesupport",        "~>5.2.4", ">= 5.2.4.3", "< 5.3"
+  s.add_runtime_dependency "activesupport",        "~>5.2.4", ">= 5.2.4.3"
   s.add_runtime_dependency "bunny",                "~> 2.1.0"
   s.add_runtime_dependency "excon",                "~> 0.71"
   s.add_runtime_dependency "fog-openstack",        ">= 0.3.10"


### PR DESCRIPTION
This updates the activesupport gem from 5.0.0 to 5.2.4. This addresses CVE-2020-8165, which apparently suffers from a potential issue with MemCacheStore and RedisCacheStore.

https://groups.google.com/forum/#!topic/rubyonrails-security/bv6fW4S0Y1c