### PR TITLE
Make the infra provider field in the DDF form clearable

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -69,10 +69,11 @@ module ManageIQ::Providers::Openstack::ManagerMixin
             :label     => _("Provider Region"),
           },
           {
-            :component => "select-field",
-            :name      => "provider_id",
-            :label     => _("Openstack Infra Provider"),
-            :options   => ManageIQ::Providers::Openstack::Provider.pluck(:name, :id).map do |name, id|
+            :component   => "select-field",
+            :name        => "provider_id",
+            :label       => _("Openstack Infra Provider"),
+            :isClearable => true,
+            :options     => ManageIQ::Providers::Openstack::Provider.pluck(:name, :id).map do |name, id|
               {
                 :label => name,
                 :value => id.to_s,


### PR DESCRIPTION
Fixes the problem described here: https://github.com/ManageIQ/manageiq-ui-classic/pull/6698#issuecomment-634290544

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818