### PR TITLE
Fix bash condition for services list

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -188,8 +188,8 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
   end
 
   def list_all_service_containers_cmd
-    'if [ -e /usr/bin/podman ]; then sudo podman ps --format "{{.Names}} {{.Status}}"; \
-    elif [ -e /usr/bin/docker ]; then docker ps --format "table {{.Names}}\t{{.Status}}" | tail -n +2; fi'
+    'bash -c "if [ -e /usr/bin/podman ]; then sudo podman ps --format \"{{.Names}} {{.Status}}\"; \
+    elif [ -e /usr/bin/docker ]; then docker ps --format \"table {{.Names}}\t{{.Status}}\" | tail -n +2; fi"'
   end
 
   def refresh_custom_attributes_from_conf_files(files)


### PR DESCRIPTION
A small update that fixes bash `if` condition to use it with `sudo`.
In addition to https://github.com/ManageIQ/manageiq-providers-openstack/pull/585
Refers to https://github.com/ManageIQ/manageiq-providers-openstack/pull/586
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1723864