### PR TITLE
Do not call gettext on DDF form select option values

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -209,16 +209,16 @@ module ManageIQ::Providers::Openstack::ManagerMixin
                       :options      => [
                         {
                           :label => _('Ceilometer'),
-                          :value => _('ceilometer'),
+                          :value => 'ceilometer',
                         },
                         {
                           :label => _('STF'),
-                          :value => _('stf'),
+                          :value => 'stf',
                           :pivot => 'endpoints.stf.hostname',
                         },
                         {
                           :label => _('AMQP'),
-                          :value => _('amqp'),
+                          :value => 'amqp',
                           :pivot => 'endpoints.amqp.hostname',
                         },
                       ],


### PR DESCRIPTION
This might cause issues when using MiQ with a language other than English.

@miq-bot add_label bug

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818