### PR TITLE
Delegate cloud_tenants to parent_manager from storage_manager

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -26,8 +26,13 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
            :hostname,
            :default_endpoint,
            :endpoints,
+           :cloud_tenants,
+           :volume_availability_zones,
            :to        => :parent_manager,
            :allow_nil => true
+
+  virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
+  virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
 
   def self.default_blacklisted_event_names
     %w(


### PR DESCRIPTION
When dealing with a CloudVolume that is owned by a storage manager we
should delegate collections owned by the CloudManager without having to
invoke the parent_manager directly.

Dependant: https://github.com/ManageIQ/manageiq-ui-classic/pull/7133