### PR TITLE
Set the monitor_running event to unblock the main thread

### DIFF
--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -37,8 +37,8 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
 
   def monitor_events
     event_monitor_handle.start
+    event_monitor_running
     event_monitor_handle.each_batch do |events|
-      event_monitor_running
       if events && !events.empty?
         _log.debug("#{log_prefix} Received events #{events.collect { |e| e.payload["event_type"] }}") if _log.debug?
         @queue.enq events


### PR DESCRIPTION
Without setting the monitor_running concurrent event the main event_catcher worker thread doesn't ever leave the do_before_work_loop which means it can't be shutdown cleanly until the first event is raised.

Related to: https://github.com/ManageIQ/manageiq-providers-amazon/pull/633