### PR TITLE
[IVANCHUK] Use qpid_proton 0.26.0 for Travis

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -9,7 +9,7 @@ sudo apt-get install -y libsasl2-2 libsasl2-dev
 
 # Get the latest Qpid Proton source
 cd $HOME/build
-git clone --branch 0.30.0 https://github.com/apache/qpid-proton.git
+git clone --branch 0.26.0 https://github.com/apache/qpid-proton.git
 cd qpid-proton
 
 # Configure the source of Qpid Proton.


### PR DESCRIPTION
Follow-up for https://github.com/ManageIQ/manageiq-providers-openstack/pull/556 backport. Ivanchuk branch is using qpid_proton 0.26.0 in core repo