### PR TITLE
Move supports :create to Openstack provider repo

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
@@ -1,6 +1,9 @@
 class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
   include ManageIQ::Providers::Openstack::HelperMethods
 
+  supports :create
+  supports :delete
+
   def self.raw_create_flavor(ext_management_system, create_options)
     ext_management_system.with_provider_connection({:service => 'Compute'}) do |service|
       cloud_tenant_refs = create_options.delete("cloud_tenant_refs")


### PR DESCRIPTION
Currently the supports :create/:delete features are enabled at the base Flavor model, however only Openstack implements these operations

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/149
Dependent PR: https://github.com/ManageIQ/manageiq/pull/20332