### PR TITLE
Parse oslo.message in all events

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
@@ -36,4 +36,20 @@ module ManageIQ::Providers::Openstack::CloudManager::EventParser
     end
     event[:content]
   end
+
+  def self.extract_content(ems_event)
+    if (oslo_message = ems_event.full_data.fetch_path(:content, 'oslo.message'))
+      begin
+        JSON.parse(oslo_message)
+      rescue JSON::ParserError
+        {}
+      end
+    else
+      ems_event.full_data.fetch(:content, {})
+    end
+  end
+
+  def self.extract_payload(ems_event)
+    extract_content(ems_event).fetch('payload', {})
+  end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
@@ -48,31 +48,31 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
   end
 
   def collect_compute_instance_references!(target_collection, ems_event)
-    instance_id = ems_event.full_data.fetch_path(:content, 'payload', 'instance_id')
+    instance_id = event_payload['instance_id']
     add_target(target_collection, :vms, instance_id) if instance_id
   end
 
   def collect_image_references!(target_collection, ems_event)
-    resource_id = ems_event.full_data.fetch_path(:content, 'payload', 'resource_id') || parse_oslo_message(ems_event.full_data).fetch("payload", {}).fetch("id", nil)
+    resource_id = event_payload['resource_id'] || event_payload['id']
     add_target(target_collection, :images, resource_id) if resource_id # Works for Create and Update action
     add_target(target_collection, :miq_templates, resource_id) if resource_id # Existing association name needed for Delete action
   end
 
   def collect_identity_tenant_references!(target_collection, ems_event)
-    tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'tenant_id') || ems_event.full_data.fetch_path(:content, 'payload', 'project_id') || ems_event.full_data.fetch_path(:content, 'payload', 'initiator', 'project_id')
+    tenant_id = event_payload['tenant_id'] || event_payload['project_id'] || event_payload.fetch_path('initiator', 'project_id')
     add_target(target_collection, :cloud_tenants, tenant_id) if tenant_id
   end
 
   def collect_orchestration_stack_references!(target_collection, ems_event)
-    stack_id = ems_event.full_data.fetch_path(:content, 'payload', 'stack_id') || ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
-    tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'tenant_id')
+    stack_id = event_payload['stack_id'] || event_payload['resource_id']
+    tenant_id = event_payload['tenant_id']
     target_collection.add_target(:association => :orchestration_stacks, :manager_ref => {:ems_ref => stack_id}, :options => {:tenant_id => tenant_id})
   end
 
   def collect_host_aggregate_references!(target_collection, ems_event)
     # aggregate events from ceilometer don't have an id field for the aggregate,
     # but they do have a "service" field in the form of "aggregate.<id>"
-    aggregate_id = ems_event.full_data.fetch_path(:content, 'payload', 'service')
+    aggregate_id = event_payload['service']
     aggregate_id&.sub!('aggregate.', '')
     add_target(target_collection, :host_aggregates, aggregate_id) if aggregate_id
   end
@@ -81,9 +81,7 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
     add_target(target_collection, :key_pairs, nil)
   end
 
-  def parse_oslo_message(msg_data)
-    JSON.parse(msg_data.fetch_path(:content, 'oslo.message'))
-  rescue JSON::ParserError
-    {}
+  def event_payload
+    @event_payload ||= ManageIQ::Providers::Openstack::CloudManager::EventParser.extract_payload(ems_event)
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
@@ -8,81 +8,98 @@ describe ManageIQ::Providers::Openstack::CloudManager::EventTargetParser do
   end
 
   context "Openstack Event Parsing" do
-    it "parses compute.instance events" do
-      ems_event = create_ems_event("compute.instance.create.end", "instance_id" => "instance_id_test",
-                                                                  "tenant_id"   => "tenant_id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(2)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:vms, {:ems_ref => "instance_id_test"}],
-            [:cloud_tenants, {:ems_ref => "tenant_id_test"}]
-          ]
-        )
-      )
-    end
+    [true, false].each do |oslo_message|
+      oslo_message_text = "with#{"out" unless oslo_message} oslo_message"
 
-    it "parses identity.project events" do
-      ems_event = create_ems_event("identity.project.create.end", "project_id" => "tenant_id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:cloud_tenants, {:ems_ref => "tenant_id_test"}]
-          ]
-        )
-      )
-    end
+      it "parses compute.instance events #{oslo_message_text}" do
+        payload = {
+          "instance_id" => "instance_id_test",
+          "tenant_id"   => "tenant_id_test"
+        }
+        ems_event = create_ems_event("compute.instance.create.end", oslo_message, payload)
 
-    it "parses orchestration.stack events" do
-      ems_event = create_ems_event("orchestration.stack.create.end", "stack_id" => "stack_id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:orchestration_stacks, {:ems_ref => "stack_id_test"}]
-          ]
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:vms, {:ems_ref => "instance_id_test"}],
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}]
+            ]
+          )
         )
-      )
-    end
+      end
 
-    it "parses image events" do
-      ems_event = create_ems_event("image.create.end", "resource_id" => "image_id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(2)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:images, {:ems_ref=>"image_id_test"}], [:miq_templates, {:ems_ref=>"image_id_test"}]
-          ]
+      it "parses identity.project events #{oslo_message_text}" do
+        payload = {"project_id" => "tenant_id_test"}
+        ems_event = create_ems_event("identity.project.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}]
+            ]
+          )
         )
-      )
-    end
+      end
 
-    it "parses host aggregate events" do
-      ems_event = create_ems_event("aggregate.create.end", "service" => "aggregate.id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:host_aggregates, {:ems_ref => "id_test"}]
-          ]
+      it "parses orchestration.stack events #{oslo_message_text}" do
+        payload = {"stack_id" => "stack_id_test"}
+        ems_event = create_ems_event("orchestration.stack.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:orchestration_stacks, {:ems_ref => "stack_id_test"}]
+            ]
+          )
         )
-      )
-    end
+      end
 
-    it "doesn't create duplicate events" do
-      create_ems_event("compute.instance.create.start", "service" => "compute")
-      # these two should have identical timestamps, event_types, and ems_ids,
-      # so they are probably duplicate events. As such, only one EmsEvent
-      # should be created.
-      create_ems_event("compute.instance.create.end", "service" => "compute")
-      create_ems_event("compute.instance.create.end", "service" => "compute")
-      expect(EmsEvent.all.count).to eq(2)
+      it "parses image events #{oslo_message_text}" do
+        payload = {"resource_id" => "image_id_test"}
+        ems_event = create_ems_event("image.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:images, {:ems_ref=>"image_id_test"}], [:miq_templates, {:ems_ref=>"image_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses host aggregate events #{oslo_message_text}" do
+        payload = {"service" => "aggregate.id_test"}
+        ems_event = create_ems_event("aggregate.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:host_aggregates, {:ems_ref => "id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "doesn't create duplicate events #{oslo_message_text}" do
+        payload = {"service" => "compute"}
+        create_ems_event("compute.instance.create.start", oslo_message, payload)
+        # these two should have identical timestamps, event_types, and ems_ids,
+        # so they are probably duplicate events. As such, only one EmsEvent
+        # should be created.
+        create_ems_event("compute.instance.create.end", oslo_message, payload)
+        create_ems_event("compute.instance.create.end", oslo_message, payload)
+        expect(EmsEvent.all.count).to eq(2)
+      end
     end
   end
 
@@ -90,14 +107,21 @@ describe ManageIQ::Providers::Openstack::CloudManager::EventTargetParser do
     parsed_targets.map { |x| [x.association, x.manager_ref] }.uniq
   end
 
-  def create_ems_event(event_type, payload)
+  def create_ems_event(event_type, oslo_message, payload)
+    full_data =
+      if oslo_message
+        {:content => {'oslo.message' => {'payload' => payload}.to_json}}
+      else
+        {:content => {'payload' => payload}}
+      end
+
     event_hash = {
       :event_type => event_type,
       :source     => "OPENSTACK",
       :message    => payload,
       :timestamp  => "2016-03-13T16:59:01.760000",
       :username   => "",
-      :full_data  => {:content => {'payload' => payload}},
+      :full_data  => full_data,
       :ems_id     => @ems.id
     }
     EmsEvent.add(@ems.id, event_hash)


### PR DESCRIPTION
@aufi @agrare Please review.

Some notes:

- This only handles the events in the CloudManager.  I was going to bump this higher as there's an EventTargetParser for the other managers as well, but I didn't know if that made sense.  If you think I should, I'll add to this PR.
- I didn't reuse the message_content method on purpose, because it does an EMS lookup.  Ultimately, I'd like to remove that lookup and just always process `oslo.message` if it's there, because a hash lookup is relatively cheap compared to an EMS lookup and if `oslo.message` is present it needs to be parsed anyway.  Since this would require a signature change, I opted for not doing that in this PR, and can do that in a follow up.  I did, however put the message_payload method next to the message_content method so that the oslo.message code would stay close together.