### PR TITLE
Consolidate event parsing

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_parser.rb
@@ -1,55 +1,10 @@
 module ManageIQ::Providers::Openstack::CloudManager::EventParser
   def self.event_to_hash(event, ems_id)
-    content = message_content(event, ems_id)
-    event_type = content["event_type"]
-    payload = content["payload"] || {}
-
-    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
-    _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?
-
-    # attributes that are common to all notifications
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => content["timestamp"],
-      :username   => content["_context_user_name"],
-      :full_data  => event,
-      :ems_id     => ems_id
-    }
-
-    event_hash[:vm_ems_ref] = payload["instance_id"]                      if payload.key? "instance_id"
-    event_hash[:host_ems_ref] = payload["host"]                           if payload.key? "host"
-    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
-    event_hash[:chain_id] = payload["reservation_id"]                     if payload.key? "reservation_id"
-    event_hash
-  end
-
-  def self.message_content(event, ems_id)
-    unless ems_id.nil?
-      ems = ExtManagementSystem.find_by_id(ems_id)
-      if ems.connection_configuration_by_role("amqp")
-        if event[:content].key?("oslo.message")
-          return JSON.parse(event[:content]["oslo.message"])
-        end
-      end
+    ManageIQ::Providers::Openstack::EventParserCommon.event_to_hash(event, ems_id) do |event_hash, payload|
+      event_hash[:vm_ems_ref]                = payload["instance_id"]       if payload.key? "instance_id"
+      event_hash[:host_ems_ref]              = payload["host"]              if payload.key? "host"
+      event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
+      event_hash[:chain_id]                  = payload["reservation_id"]    if payload.key? "reservation_id"
     end
-    event[:content]
-  end
-
-  def self.extract_content(ems_event)
-    if (oslo_message = ems_event.full_data.fetch_path(:content, 'oslo.message'))
-      begin
-        JSON.parse(oslo_message)
-      rescue JSON::ParserError
-        {}
-      end
-    else
-      ems_event.full_data.fetch(:content, {})
-    end
-  end
-
-  def self.extract_payload(ems_event)
-    extract_content(ems_event).fetch('payload', {})
   end
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
@@ -82,6 +82,6 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
   end
 
   def event_payload
-    @event_payload ||= ManageIQ::Providers::Openstack::CloudManager::EventParser.extract_payload(ems_event)
+    @event_payload ||= ManageIQ::Providers::Openstack::EventParserCommon.message_content(ems_event).fetch('payload', {})
   end
 end

--- a/app/models/manageiq/providers/openstack/event_parser_common.rb
+++ b/app/models/manageiq/providers/openstack/event_parser_common.rb
@@ -1,0 +1,40 @@
+module ManageIQ::Providers::Openstack::EventParserCommon
+  def self.event_to_hash(event, ems_id)
+    content = message_content(event)
+    event_type = content["event_type"]
+    payload = content.fetch("payload", {})
+
+    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
+    _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?
+
+    # attributes that are common to all notifications
+    event_hash = {
+      :event_type => event_type,
+      :source     => "OPENSTACK",
+      :message    => payload,
+      :timestamp  => content["timestamp"],
+      :username   => content["_context_user_name"],
+      :full_data  => event,
+      :ems_id     => ems_id
+    }
+
+    yield(event_hash, payload) if block_given?
+
+    event_hash
+  end
+
+  def self.message_content(event)
+    # If this is an EmsEvent record, pull out the full_data
+    event = event.full_data if event.respond_to?(:full_data)
+
+    if (oslo_message = event.fetch_path(:content, 'oslo.message'))
+      begin
+        JSON.parse(oslo_message)
+      rescue JSON::ParserError
+        {}
+      end
+    else
+      event.fetch(:content, {})
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_parser.rb
@@ -1,43 +1,14 @@
 module ManageIQ::Providers::Openstack::InfraManager::EventParser
-  def self.event_to_hash(event, ems_id)
-    content = message_content(event, ems_id)
-    event_type = content["event_type"]
-    payload = content["payload"] || {}
-
-    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
-    _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?
-
-    # attributes that are common to all notifications
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => content["timestamp"],
-      :username   => content["_context_user_name"],
-      :full_data  => event,
-      :ems_id     => ems_id
-    }
-
-    if payload.key? "instance_id"
-      event_hash[:host_id] = Host.find_by(:uid_ems => payload["instance_id"]).try(:id)
-      event_hash[:host_name] = payload["instance_id"]
-    end
-    event_hash[:message]                   = payload["message"]           if payload.key? "message"
-    event_hash[:host_ems_ref]              = payload["node"]              if payload.key? "node"
-    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
-    event_hash[:chain_id]                  = payload["reservation_id"]    if payload.key? "reservation_id"
-    event_hash
-  end
-
-  def self.message_content(event, ems_id)
-    unless ems_id.nil?
-      ems = ExtManagementSystem.find_by_id(ems_id)
-      if ems.connection_configuration_by_role("amqp")
-        if event[:content].key?("oslo.message")
-          return JSON.parse(event[:content]["oslo.message"])
-        end
+ def self.event_to_hash(event, ems_id)
+    ManageIQ::Providers::Openstack::EventParserCommon.event_to_hash(event, ems_id) do |event_hash, payload|
+      if payload.key? "instance_id"
+        event_hash[:host_id] = Host.find_by(:uid_ems => payload["instance_id"]).try(:id)
+        event_hash[:host_name] = payload["instance_id"]
       end
+      event_hash[:message]                   = payload["message"]           if payload.key? "message"
+      event_hash[:host_ems_ref]              = payload["node"]              if payload.key? "node"
+      event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
+      event_hash[:chain_id]                  = payload["reservation_id"]    if payload.key? "reservation_id"
     end
-    event[:content]
   end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_parser.rb
@@ -1,39 +1,5 @@
 module ManageIQ::Providers::Openstack::NetworkManager::EventParser
   def self.event_to_hash(event, ems_id)
-    content = message_content(event, ems_id)
-    event_type = content["event_type"]
-    payload = content["payload"] || {}
-
-    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
-    _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?
-
-    # attributes that are common to all notifications
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => content["timestamp"],
-      :username   => content["_context_user_name"],
-      :full_data  => event,
-      :ems_id     => ems_id
-    }
-
-    event_hash[:vm_ems_ref] = payload["instance_id"]                      if payload.key? "instance_id"
-    event_hash[:host_ems_ref] = payload["host"]                           if payload.key? "host"
-    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
-    event_hash[:chain_id] = payload["reservation_id"]                     if payload.key? "reservation_id"
-    event_hash
-  end
-
-  def self.message_content(event, ems_id)
-    unless ems_id.nil?
-      ems = ExtManagementSystem.find_by_id(ems_id)
-      if ems.connection_configuration_by_role("amqp")
-        if event[:content].key?("oslo.message")
-          return JSON.parse(event[:content]["oslo.message"])
-        end
-      end
-    end
-    event[:content]
+    ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, ems_id)
   end
 end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_parser.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_parser.rb
@@ -1,39 +1,5 @@
 module ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventParser
   def self.event_to_hash(event, ems_id)
-    content = message_content(event, ems_id)
-    event_type = content["event_type"]
-    payload = content["payload"] || {}
-
-    log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
-    _log.debug("#{log_header}event: [#{event_type}]") if $log && $log.debug?
-
-    # attributes that are common to all notifications
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => content["timestamp"],
-      :username   => content["_context_user_name"],
-      :full_data  => event,
-      :ems_id     => ems_id
-    }
-
-    event_hash[:vm_ems_ref] = payload["instance_id"]                      if payload.key? "instance_id"
-    event_hash[:host_ems_ref] = payload["host"]                           if payload.key? "host"
-    event_hash[:availability_zone_ems_ref] = payload["availability_zone"] if payload.key? "availability_zone"
-    event_hash[:chain_id] = payload["reservation_id"]                     if payload.key? "reservation_id"
-    event_hash
-  end
-
-  def self.message_content(event, ems_id)
-    unless ems_id.nil?
-      ems = ExtManagementSystem.find_by_id(ems_id)
-      if ems.connection_configuration_by_role("amqp")
-        if event[:content].key?("oslo.message")
-          return JSON.parse(event[:content]["oslo.message"])
-        end
-      end
-    end
-    event[:content]
+    ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, ems_id)
   end
 end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
@@ -33,18 +33,18 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
   end
 
   def collect_volume_references!(target_collection, ems_event)
-    tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'project_id')
-    resource_id = ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
+    tenant_id = event_payload['project_id']
+    resource_id = event_payload['resource_id']
     add_target(target_collection, :cloud_volumes, resource_id, :tenant_id => tenant_id) if resource_id
     # Bootable Volume can be modelled also as VolumeTemplate for new VM provisioning based on the Bootable Volume
     add_target(target_collection, :volume_templates, resource_id, :tenant_id => tenant_id) if resource_id
   end
 
   def collect_snapshot_references!(target_collection, ems_event)
-    tenant_id = ems_event.full_data.fetch_path(:content, 'payload', 'project_id')
-    resource_id = ems_event.full_data.fetch_path(:content, 'payload', 'resource_id')
+    tenant_id = event_payload['project_id']
+    resource_id = event_payload['resource_id']
     add_target(target_collection, :cloud_volume_snapshots, resource_id, :tenant_id => tenant_id) if resource_id
-    volume_id = ems_event.full_data.fetch_path(:content, 'payload', 'volume_id')
+    volume_id = event_payload['volume_id']
     add_target(target_collection, :cloud_volumes, volume_id, :tenant_id => tenant_id) if volume_id
   end
 
@@ -61,5 +61,9 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
 
   def add_target(target_collection, association, ref, options = {})
     target_collection.add_target(:association => association, :manager_ref => {:ems_ref => ref}, :options => options)
+  end
+
+  def event_payload
+    @event_payload ||= ManageIQ::Providers::Openstack::EventParserCommon.message_content(ems_event).fetch('payload', {})
   end
 end

--- a/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
@@ -2,105 +2,109 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
   before :each do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems                 = FactoryBot.create(:ems_openstack, :zone => zone)
+    @manager             = @ems.network_manager
 
     allow_any_instance_of(EmsEvent).to receive(:handle_event)
     allow(EmsEvent).to receive(:create_completed_event)
   end
 
   context "Openstack Event Parsing" do
-    it "parses network events" do
-      ems_event = create_ems_event("network.create.end", "resource_id" => "network_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:cloud_networks, {:ems_ref => "network_id_test"}]
-          ]
-        )
-      )
-    end
+    [true, false].each do |oslo_message|
+      oslo_message_text = "with#{"out" unless oslo_message} oslo_message"
 
-    it "parses subnet events" do
-      ems_event = create_ems_event("subnet.create.end", "resource_id" => "subnet_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:cloud_subnets, {:ems_ref => "subnet_id_test"}]
-          ]
-        )
-      )
-    end
+      it "parses network events #{oslo_message_text}" do
+        payload = {"resource_id" => "network_id_test"}
+        ems_event = create_ems_event(@manager, "network.create.end", oslo_message, payload)
 
-    it "parses router events" do
-      ems_event = create_ems_event("router.create.end", "resource_id" => "router_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:network_routers, {:ems_ref => "router_id_test"}]
-          ]
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_networks, {:ems_ref => "network_id_test"}]
+            ]
+          )
         )
-      )
-    end
+      end
 
-    it "parses port events" do
-      ems_event = create_ems_event("port.create.end", "resource_id" => "port_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:network_ports, {:ems_ref => "port_id_test"}]
-          ]
-        )
-      )
-    end
+      it "parses subnet events #{oslo_message_text}" do
+        payload = {"resource_id" => "subnet_id_test"}
+        ems_event = create_ems_event(@manager, "subnet.create.end", oslo_message, payload)
 
-    it "parses floating ip events" do
-      ems_event = create_ems_event("floatingip.create.end", "resource_id" => "floating_ip_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:floating_ips, {:ems_ref => "floating_ip_id_test"}]
-          ]
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_subnets, {:ems_ref => "subnet_id_test"}]
+            ]
+          )
         )
-      )
-    end
+      end
 
-    it "parses security_group events" do
-      ems_event = create_ems_event("security_group.create.end", "resource_id" => "security_group_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(1)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:security_groups, {:ems_ref => "security_group_id_test"}]
-          ]
+      it "parses router events #{oslo_message_text}" do
+        payload = {"resource_id" => "router_id_test"}
+        ems_event = create_ems_event(@manager, "router.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:network_routers, {:ems_ref => "router_id_test"}]
+            ]
+          )
         )
-      )
+      end
+
+      it "parses port events #{oslo_message_text}" do
+        payload = {"resource_id" => "port_id_test"}
+        ems_event = create_ems_event(@manager, "port.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:network_ports, {:ems_ref => "port_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses floating ip events #{oslo_message_text}" do
+        payload = {"resource_id" => "floating_ip_id_test"}
+        ems_event = create_ems_event(@manager, "floatingip.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:floating_ips, {:ems_ref => "floating_ip_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses security_group events #{oslo_message_text}" do
+        payload = {"resource_id" => "security_group_id_test"}
+        ems_event = create_ems_event(@manager, "security_group.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:security_groups, {:ems_ref => "security_group_id_test"}]
+            ]
+          )
+        )
+      end
     end
   end
 
   def target_references(parsed_targets)
     parsed_targets.map { |x| [x.association, x.manager_ref] }.uniq
-  end
-
-  def create_ems_event(event_type, payload)
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => "2016-03-13T16:59:01.760000",
-      :username   => "",
-      :full_data  => {:content => {'payload' => payload}},
-      :ems_id     => @ems.network_manager.id
-    }
-    EmsEvent.add(@ems.network_manager.id, event_hash)
   end
 end

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
@@ -2,55 +2,53 @@ describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTar
   before :each do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems                 = FactoryBot.create(:ems_openstack, :zone => zone)
+    @manager             = @ems.cinder_manager
 
     allow_any_instance_of(EmsEvent).to receive(:handle_event)
     allow(EmsEvent).to receive(:create_completed_event)
   end
 
   context "Openstack Event Parsing" do
-    it "parses volume events" do
-      ems_event = create_ems_event("volume.create.end", "resource_id" => "volume_id_test",)
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(2)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:cloud_volumes, {:ems_ref=>"volume_id_test"}], [:volume_templates, {:ems_ref=>"volume_id_test"}]
-          ]
-        )
-      )
-    end
+    [true, false].each do |oslo_message|
+      oslo_message_text = "with#{"out" unless oslo_message} oslo_message"
 
-    it "parses snapshot events" do
-      ems_event = create_ems_event("snapshot.create.end", "resource_id" => "snapshot_id_test",
-                                                          "volume_id"   => "volume_id_test")
-      parsed_targets = described_class.new(ems_event).parse
-      expect(parsed_targets.size).to eq(2)
-      expect(target_references(parsed_targets)).to(
-        match_array(
-          [
-            [:cloud_volume_snapshots, {:ems_ref => "snapshot_id_test"}],
-            [:cloud_volumes, {:ems_ref => "volume_id_test"}]
-          ]
+      it "parses volume events #{oslo_message_text}" do
+        payload = {"resource_id" => "volume_id_test"}
+        ems_event = create_ems_event(@manager, "volume.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_volumes, {:ems_ref=>"volume_id_test"}], [:volume_templates, {:ems_ref=>"volume_id_test"}]
+            ]
+          )
         )
-      )
+      end
+
+      it "parses snapshot events #{oslo_message_text}" do
+        payload = {
+          "resource_id" => "snapshot_id_test",
+          "volume_id"   => "volume_id_test"
+        }
+        ems_event = create_ems_event(@manager, "snapshot.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_volume_snapshots, {:ems_ref => "snapshot_id_test"}],
+              [:cloud_volumes, {:ems_ref => "volume_id_test"}]
+            ]
+          )
+        )
+      end
     end
   end
 
   def target_references(parsed_targets)
     parsed_targets.map { |x| [x.association, x.manager_ref] }.uniq
-  end
-
-  def create_ems_event(event_type, payload)
-    event_hash = {
-      :event_type => event_type,
-      :source     => "OPENSTACK",
-      :message    => payload,
-      :timestamp  => "2016-03-13T16:59:01.760000",
-      :username   => "",
-      :full_data  => {:content => {'payload' => payload}},
-      :ems_id     => @ems.cinder_manager.id
-    }
-    EmsEvent.add(@ems.cinder_manager.id, event_hash)
   end
 end

--- a/spec/support/ems_event_helper.rb
+++ b/spec/support/ems_event_helper.rb
@@ -1,0 +1,18 @@
+def create_ems_event(manager, event_type, oslo_message, payload)
+  full_data =
+    if oslo_message
+      {:content => {'oslo.message' => {'payload' => payload}.to_json}}
+    else
+      {:content => {'payload' => payload}}
+    end
+
+  event_hash = {
+    :event_type => event_type,
+    :message    => payload,
+    :timestamp  => "2016-03-13T16:59:01.760000",
+    :username   => "",
+    :full_data  => full_data,
+    :ems_id     => manager.id
+  }
+  EmsEvent.add(manager.id, event_hash)
+end


### PR DESCRIPTION
Consolidates the duplicated event parsing and oslo.message handling for all EventParsers and EventTargetParsers.

- Removes the unnecessary lookup and check of the ems and it's "amqp" role
- Handles oslo.message on events coming from anywhere, so tests were added for NetworkManager and CinderManager EventTargetParsers
- Makes it clearer that the NetworkManager and CinderManager event parser are exactly the same as the CloudManager

@agrare Please review.
