### PR TITLE
The vm_delete_snapshot method is missing a require

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -551,6 +551,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   end
 
   def vm_remove_snapshot(vm, options = {})
+    require 'OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance'
+
     snapshot_uid = options[:snMor]
 
     log_prefix = "snapshot=[#{snapshot_uid}]"


### PR DESCRIPTION
All snapshot methods except vm_remove_snapshot require the 'MiqOpenstackInstance' class, without this require the operation is faililng with an uninitialized constant error.

```
Failed to remove snapshot of test-snpsh-j8hs: uninitialized constant ManageIQ::Providers::Openstack::CloudManager::MiqOpenStackInstance
```