### PR TITLE
Update metric network interface lookup

### DIFF
--- a/app/models/manageiq/providers/openstack/base_metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/base_metrics_capture.rb
@@ -111,9 +111,9 @@ module ManageIQ::Providers::Openstack::BaseMetricsCapture
           # the network interface's resource
           if port.ems_ref
             original_resource_id = "#{target.ems_ref}-tap#{port.ems_ref[0..10]}"
-            resources = @perf_ems.list_resources.body
+            resources = @perf_ems.list_resources("instance_network_interface").body
             resources.each do |r|
-              if r["type"].to_s == "instance_network_interface" && r["original_resource_id"].include?(original_resource_id)
+              if r["original_resource_id"].include?(original_resource_id)
                 resource_filter = {"field" => "resource_id", "value" => r["id"]}
                 counters = counters + list_resource_meters(resource_filter, log_header)
               end


### PR DESCRIPTION
Metric resources for an Instance network interfaces are separated as "instance_network_resources" in
Gnocchi. ManageIQ searches for such resources across all resources and filters it later after the query.

Updating resources query to request only instance_network_resources (instead of default generic - https://github.com/fog/fog-openstack/blob/master/lib/fog/openstack/metric/requests/list_resources.rb) to reduce
amount of API response data and more efficient filtering which could fix network metrics loading on larger
OpenStack deployments.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1805020