### PR TITLE
Check for ssl-no-validation string

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -25,8 +25,8 @@ module OpenstackHandle
     }
 
     def self.try_connection(security_protocol, ssl_options = {})
-      if security_protocol.blank? || security_protocol == 'ssl'
-        # For backwards compatibility take blank security_protocol as SSL
+      # For backwards compatibility take blank security_protocol as SSL
+      if security_protocol.blank? || security_protocol == 'ssl' || security_protocol == 'ssl-no-validation'
         yield "https", {:ssl_verify_peer => false}
       elsif security_protocol == 'ssl-with-validation'
         excon_ssl_options = {:ssl_verify_peer => true}.merge(ssl_options)


### PR DESCRIPTION
When determining the connection protocol for an Openstack connection, we now need to check explicitly for the string "ssl-no-validation", otherwise it will inadvertently set the protocol to "http" instead of "https".

This started happening as a result of the recent DDF form changes, because prior to that we used to just pass "ssl" as the string via the angular controller.

https://github.com/ManageIQ/manageiq-ui-classic/blob/ivanchuk/app/controllers/mixins/ems_common/angular.rb#L563-L569

To ensure backwards compatibility I've left the previous check for now.

Thanks go to Jay Carman for the spot and original patch via gitter.