### PR TITLE
Ignore the tools/openstack_data directory in yaml lint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 ignore: |
   /vendor/**
   /spec/manageiq/**
+  /spec/tools/openstack_data/**
   /spec/vcr_cassettes/**
 
 extends: relaxed


### PR DESCRIPTION
This was left over in the core repo's .yamllint file https://github.com/ManageIQ/manageiq/pull/20530/files#diff-b97c55dd898003930e2858fadd3b5c9cR5