### PR TITLE
Don't seed NotificationTypes in the main spec_helper

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_backup_spec.rb
@@ -32,6 +32,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
 
   context 'raw_backup_restore' do
     it 'restores backup' do
+      NotificationType.seed
+
       expect(raw_cloud_volume_backup).to receive(:restore)
       cloud_volume_backup.raw_restore(cloud_volume)
     end
@@ -57,6 +59,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
 
   context 'raw_delete_backup' do
     it 'deletes backup' do
+      NotificationType.seed
+
       expect(raw_cloud_volume_backup).to receive(:destroy)
       cloud_volume_backup.raw_delete
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_snapshot_spec.rb
@@ -46,6 +46,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot do
   end
 
   describe 'snapshot actions' do
+    before { NotificationType.seed }
     context ".create_snapshot" do
       let(:the_new_snapshot) { double }
       let(:snapshot_options) { {:cloud_tenant => tenant, :name => "new_name"} }

--- a/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/cloud_volume_spec.rb
@@ -39,6 +39,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
       let(:volume_options) { {:cloud_tenant => tenant, :name => "new_name", :size => 2} }
 
       before do
+        NotificationType.seed
         allow(raw_volumes).to receive(:new).and_return(the_new_volume)
       end
 
@@ -76,6 +77,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
     end
 
     context "#update_volume" do
+      before { NotificationType.seed }
+
       it 'updates the volume' do
         expect(the_raw_volume).to receive(:save)
         expect(the_raw_volume).to receive(:size)
@@ -100,6 +103,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
     end
 
     context "#delete_volume" do
+      before { NotificationType.seed }
+
       it "validates the volume delete operation when status is in-use" do
         expect(cloud_volume).to receive(:status).and_return("in-use")
         validation = cloud_volume.validate_delete_volume
@@ -154,6 +159,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
       end
 
       before do
+        NotificationType.seed
         fog_backups
       end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -49,6 +49,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
   end
 
   describe "vm actions" do
+    before { NotificationType.seed }
+
     context "#live_migrate" do
       it "live migrates with default options" do
         expect(handle).to receive(:live_migrate_server).with(vm.ems_ref, nil, false, false)
@@ -217,6 +219,8 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
       double("vm_openstack_provider_object", :destroy => nil).as_null_object
     end
     let(:vm)  { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+
+    before { NotificationType.seed }
 
     it "sets the raw_power_state and not state" do
       expect(vm).to receive(:with_provider_object).and_yield(provider_object)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,13 +12,3 @@ VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Openstack::Engine.root, 'spec/vcr_cassettes')
 end
-
-RSpec.configure do |config|
-  config.before(:suite) do
-    NotificationType.seed
-  end
-
-  config.after(:suite) do
-    NotificationType.delete_all
-  end
-end


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-openstack/pull/636#discussion_r490535548

This was kind of a shortcut rather than seeding these only in tests which actually use NotificationTypes.  A number of tests do this already so I guess someone got fed-up with doing it one by one and just seeded them everytime?