### PR TITLE
Use the tag_mapper from the core Persister

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -7,8 +7,6 @@ class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers
 
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below
   attr_reader :collector
-  # Accessed by cloud parser.
-  attr_reader :tag_mapper
 
   # @param manager [ManageIQ::Providers::BaseManager] A manager object
   # @param target [Object] A refresh Target object
@@ -21,14 +19,5 @@ class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers
     @collections = {}
 
     initialize_inventory_collections
-  end
-
-  protected
-
-  # TODO: this reads whole table ContainerLabelTagMapping.all.
-  #   Is this expensive for each targeted refresh?
-  def initialize_tag_mapper
-    @tag_mapper = ContainerLabelTagMapping.mapper
-    collections[:tags_to_resolve] = @tag_mapper.tags_to_resolve_collection
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/20561 moved the tag mapper initialization to core so it doesn't have to be duplicated in every provider persister definition