### PR TITLE
Make the credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -148,6 +148,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :id                     => 'authentications.default.valid',
                     :name                   => 'authentications.default.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[name type api_version provider_region keystone_v3_domain_id],
                     :fields                 => [
                       {
@@ -257,6 +258,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :id                     => 'endpoints.amqp.valid',
                     :name                   => 'endpoints.amqp.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[type event_stream_selection],
                     :condition              => {
                       :when => 'event_stream_selection',
@@ -305,6 +307,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :id                     => 'endpoints.stf.valid',
                     :name                   => 'endpoints.stf.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[type event_stream_selection],
                     :condition              => {
                       :when => 'event_stream_selection',

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -81,6 +81,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
                     :id                     => 'authentications.default.valid',
                     :name                   => 'authentications.default.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[name type api_version provider_region keystone_v3_domain_id],
                     :fields                 => [
                       {
@@ -185,6 +186,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
                     :id                     => 'endpoints.amqp.valid',
                     :name                   => 'endpoints.amqp.valid',
                     :skipSubmit             => true,
+                    :isRequired             => true,
                     :validationDependencies => %w[type event_stream_selection],
                     :condition              => {
                       :when => 'event_stream_selection',


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here. This is a little different from any other provider, not just the default credentials are required as all the other components are only rendered when the user selects the right protocol from the dropdown.