### PR TITLE
Declared DDF schema for cloud volume creation and editing

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -47,6 +47,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :create_flavor
   supports :create_host_aggregate
   supports :label_mapping
+  supports :cloud_volume
+  supports :cloud_volume_create
 
   before_create :ensure_managers
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -9,6 +9,73 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
   supports :backup_restore
   supports :snapshot_create
 
+  def self.params_for_create(ems)
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'size',
+          :id         => 'size',
+          :label      => _('Size (in bytes)'),
+          :type       => 'number',
+          :step       => 1.gigabytes,
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
+        {
+          :component  => 'select',
+          :name       => 'cloud_tenant_id',
+          :id         => 'cloud_tenant_id',
+          :label      => _('Cloud Tenant'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+          :condition  => {
+            :when => 'edit',
+            :is   => false,
+          },
+          :options    => ems.cloud_tenants.map do |ct|
+            {
+              :label => ct.name,
+              :value => ct.id,
+            }
+          end,
+        },
+        {
+          :component => 'select',
+          :name      => 'availability_zone_id',
+          :id        => 'availability_zone_id',
+          :label     => _('Availability Zone'),
+          :condition => {
+            :when => 'edit',
+            :is   => false,
+          },
+          :options   => ems.availability_zones.map do |az|
+            {
+              :label => az.name,
+              :value => az.id,
+            }
+          end,
+        },
+        {
+          :component => 'select',
+          :name      => 'volume_type',
+          :id        => 'volume_type',
+          :label     => _('Cloud Volume Type'),
+          :condition => {
+            :when => 'edit',
+            :is   => false,
+          },
+          :options   => ems.cloud_volume_types.map do |cvt|
+            {
+              :label => cvt.name,
+              :value => cvt.type,
+            }
+          end,
+        },
+      ]
+    }
+  end
+
   def self.validate_create_volume(ext_management_system)
     validate_volume(ext_management_system)
   end


### PR DESCRIPTION
This is an initial Cloud Volume form schema for the fields that are specific to the ibm-cloud-provided cloud volumes.

@miq-bot add_label enhancement
@miq-bot add_reviewer @agrare

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7334