### PR TITLE
Check qpid_proton installation on local machines before running tests

### DIFF
--- a/spec/legacy/events/openstack_stf_event_monitor_spec.rb
+++ b/spec/legacy/events/openstack_stf_event_monitor_spec.rb
@@ -1,9 +1,18 @@
 require 'manageiq/providers/openstack/legacy/events/openstack_stf_event_monitor'
-require 'qpid_proton'
 
-describe OpenstackStfEventMonitor do
+describe OpenstackStfEventMonitor, :qpid_proton => true do
   let(:qdr_options) { {:hostname => "machine.local", :port => '5666', :security_protocol => 'non-ssl'} }
   let(:qdr_ssl_options) { {:hostname => "machine.local", :port => '5672', :security_protocol => 'ssl'} }
+
+  before do
+    unless ENV["CI"]
+      begin
+        require 'qpid_proton'
+      rescue LoadError => err
+        skip "test expects installation of qpid_proton" if err.message.include?("qpid_proton")
+      end
+    end
+  end
 
   context "connecting to STF service" do
     describe "URL prepare" do


### PR DESCRIPTION
Fixes #643

On CI, enforces the tests must run; on local dev will skip the tests unless qpid_proton is installed.  Either way, one can choose to skip the tests using rspec tags (i.e. `SPEC_OPTS="--tag ~qpid_proton"`)