### PR TITLE
Update qpid_proton spec handling using exclude filter

### DIFF
--- a/spec/legacy/events/openstack_stf_event_monitor_spec.rb
+++ b/spec/legacy/events/openstack_stf_event_monitor_spec.rb
@@ -1,18 +1,12 @@
 require 'manageiq/providers/openstack/legacy/events/openstack_stf_event_monitor'
 
 describe OpenstackStfEventMonitor, :qpid_proton => true do
+  before(:all) do
+    require 'qpid_proton'
+  end
+
   let(:qdr_options) { {:hostname => "machine.local", :port => '5666', :security_protocol => 'non-ssl'} }
   let(:qdr_ssl_options) { {:hostname => "machine.local", :port => '5672', :security_protocol => 'ssl'} }
-
-  before do
-    unless ENV["CI"]
-      begin
-        require 'qpid_proton'
-      rescue LoadError => err
-        skip "test expects installation of qpid_proton" if err.message.include?("qpid_proton")
-      end
-    end
-  end
 
   context "connecting to STF service" do
     describe "URL prepare" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 require "manageiq-providers-openstack"
 
+RSpec.configure do |config|
+  config.filter_run_excluding(:qpid_proton) unless Gem.loaded_specs.has_key?(:qpid_proton)
+end
+
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::Openstack::Engine.root, 'spec/vcr_cassettes')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 require "manageiq-providers-openstack"
 
 RSpec.configure do |config|
-  config.filter_run_excluding(:qpid_proton) unless Gem.loaded_specs.key?(:qpid_proton)
+  config.filter_run_excluding(:qpid_proton) unless ENV['CI'] || Gem.loaded_specs.key?(:qpid_proton)
 end
 
 VCR.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 require "manageiq-providers-openstack"
 
 RSpec.configure do |config|
-  config.filter_run_excluding(:qpid_proton) unless Gem.loaded_specs.has_key?(:qpid_proton)
+  config.filter_run_excluding(:qpid_proton) unless Gem.loaded_specs.key?(:qpid_proton)
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-providers-openstack/pull/646, this uses an exclude filter in the `spec_helper.rb` to skip `qpid_proton` tags if the `qpid_proton` gem is not loaded.

This is a little cleaner, and will work for any other spec examples that might eventually get tagged.

If you're wondering why I have `require 'qpid_proton'` in a `before(:all)` block, it's because the filter works on examples. If you remove that then it will still try to load `qpid_proton` and again we're back to failure.