### PR TITLE
Fix StorageManager initialization

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -48,9 +48,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :swift_service
   supports :create_host_aggregate
 
-  before_create :ensure_managers,
-                :ensure_cinder_managers,
-                :ensure_swift_managers
+  before_create :ensure_managers
 
   before_update :ensure_managers_zone_and_provider_region
   after_save :refresh_parent_infra_manager
@@ -416,19 +414,29 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     end
   end
 
+  def ensure_managers
+    ensure_network_manager
+    ensure_cinder_manager
+    ensure_swift_manager
+    ensure_managers_zone_and_provider_region
+  end
+
   def ensure_managers_zone_and_provider_region
     if network_manager
       network_manager.zone_id         = zone_id
+      network_manager.tenant_id       = tenant_id
       network_manager.provider_region = provider_region
     end
 
     if cinder_manager
       cinder_manager.zone_id         = zone_id
+      cinder_manager.tenant_id       = tenant_id
       cinder_manager.provider_region = provider_region
     end
 
     if swift_manager
       swift_manager.zone_id         = zone_id
+      swift_manager.tenant_id       = tenant_id
       swift_manager.provider_region = provider_region
     end
   end


### PR DESCRIPTION
Openstack was calling ensure_managers which builds the NetworkManager and calls ensure_managers_zone_and_provider_region which is overridden here to set the zone/region for all child managers but before the storage managers were being built.

Typically cloud_managers with child storage managers will override the `HasNetworkManagerMixin#ensure_managers` method to include initializing the child storage managers as well, see https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager.rb#L77-L90

https://github.com/ManageIQ/manageiq/pull/20701 appears to have kept this "working" but very non-obviously
Fixes API spec failures: https://github.com/ManageIQ/manageiq-api/pull/940