### PR TITLE
Declared DDF schema for creating snapshots

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -163,6 +163,28 @@ class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::Cl
     true
   end
 
+  def params_for_create_snapshot
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'name',
+          :id         => 'name',
+          :label      => _('Name'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
+        {
+          :component => 'textarea',
+          :name      => 'description',
+          :id        => 'description',
+          :label     => _('Description'),
+          :validate  => [{:type => 'required'}],
+        },
+      ],
+    }
+  end
+
   def self.display_name(number = 1)
     n_('Instance (OpenStack)', 'Instances (OpenStack)', number)
   end


### PR DESCRIPTION
The snapshot form in ui-classic has too complex provider-specific logic to decide what fields to show, so I'm making this simpler by moving the ovirt-specific form into this repo. The API will be able to [expose](https://github.com/ManageIQ/manageiq-api/pull/943) this schema if asked.

@miq-bot assign @agrare 
@miq-bot add_label enhancement