### PR TITLE
[WIP]Fix incorrect metrics name

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/metrics_capture.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::MetricsCapture < ManageIQ::P
   include ManageIQ::Providers::Openstack::BaseMetricsCapture
   CPU_METERS     = ["cpu_util"]
   MEMORY_METERS  = ["memory.usage"]
-  DISK_METERS    = ["disk.read.bytes", "disk.write.bytes"]
+  DISK_METERS    = ["disk.device.read.bytes", "disk.device.write.bytes"]
   NETWORK_METERS = ["network.incoming.bytes", "network.outgoing.bytes"]
 
   # The list of meters that provide "cumulative" meters instead of "gauge"


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1872312#c9 CloudForms attempts to collect disk IO metrics from Gnocchi but holds the wrong name for it. In Gnocchi it's `disk.device.read.bytes` and `disk.device.write.bytes`