### PR TITLE
Set the supports :auth_key_pair_create on the CloudManager

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -35,6 +35,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   include ManageIQ::Providers::Openstack::ManagerMixin
   include ManageIQ::Providers::Openstack::IdentitySyncMixin
 
+  supports :auth_key_pair_create
   supports :provisioning
   supports :cloud_tenants
   supports :cloud_tenant_mapping do


### PR DESCRIPTION
@Fryguy you're not gonna like this, but we need a way to query the API for this :disappointed: 

@miq-bot assign @agrare 
@miq-bot add_label enhancement, kasparov/no