### PR TITLE
Move OpenStack CloudVolume* from CloudManager to CinderManager

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -4,10 +4,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   require_nested :AvailabilityZoneNull
   require_nested :CloudResourceQuota
   require_nested :CloudTenant
-  require_nested :CloudVolume
-  require_nested :CloudVolumeBackup
-  require_nested :CloudVolumeSnapshot
-  require_nested :CloudVolumeType
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :Flavor

--- a/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_type.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/cloud_volume_type.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType < ::CloudVolumeType
-end

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/cinder_manager.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
   def cloud_volumes
     collector.cloud_volumes.each do |v|
       volume = persister.cloud_volumes.find_or_build(v.id)
-      volume.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolume"
+
       volume.name = volume_name(v).blank? ? v.id : volume_name(v)
       volume.status = v.status
       volume.bootable = v.attributes['bootable']
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
   def cloud_volume_snapshots
     collector.cloud_volume_snapshots.each do |s|
       snapshot = persister.cloud_volume_snapshots.find_or_build(s['id'])
-      snapshot.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot"
+
       snapshot.creation_time = s['created_at']
       snapshot.status = s['status']
       snapshot.size = s['size'].to_i.gigabytes
@@ -45,7 +45,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
   def cloud_volume_backups
     collector.cloud_volume_backups.each do |b|
       backup = persister.cloud_volume_backups.find_or_build(b['id'])
-      backup.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup"
+
       backup.status = b['status']
       backup.creation_time = b['create_at']
       backup.size = b['size'].to_i.gigabytes
@@ -63,7 +63,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderM
   def cloud_volume_types
     collector.cloud_volume_types.each do |t|
       volume_type = persister.cloud_volume_types.find_or_build(t.id)
-      volume_type.type = "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeType"
+
       volume_type.name = t.name
       if t.extra_specs.present?
         volume_type.backend_name = t.extra_specs["volume_backend_name"]

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::Providers::StorageManager::CinderManager
+  require_nested :CloudVolume
+  require_nested :CloudVolumeBackup
+  require_nested :CloudVolumeSnapshot
+  require_nested :CloudVolumeType
   require_nested :Refresher
   require_nested :EventCatcher
   require_nested :EventParser

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::CloudVolume < ::CloudVolume
+class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume < ::CloudVolume
   include ManageIQ::Providers::Openstack::HelperMethods
   include_concern 'Operations'
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume/operations.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume/operations.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Openstack::CloudManager::CloudVolume::Operations
+module ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume::Operations
   def validate_attach_volume
     validate_volume_available
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup < ::CloudVolumeBackup
+class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup < ::CloudVolumeBackup
   include ManageIQ::Providers::Openstack::HelperMethods
   include SupportsFeatureMixin
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_snapshot.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
+class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeSnapshot < ::CloudVolumeSnapshot
   include ManageIQ::Providers::Openstack::HelperMethods
   include SupportsFeatureMixin
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_type.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_type.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeType < ::CloudVolumeType
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :ems_openstack_cinder,
+          :aliases => ["manageiq/providers/openstack/storage_manager/cinder_manager"],
+          :class   => "ManageIQ::Providers::Openstack::StorageManager::CinderManager",
+          :parent  => :ems_cinder do
+    parent_manager :factory => :ems_openstack
+  end
+end

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup_spec.rb
@@ -1,6 +1,6 @@
-describe ManageIQ::Providers::Openstack::CloudManager::CloudVolumeBackup do
-  let(:ems) { FactoryBot.create(:ems_openstack) }
-  let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems, :name => 'test') }
+describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolumeBackup do
+  let(:ems) { FactoryBot.create(:ems_openstack_cinder) }
+  let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems.parent_manager, :name => 'test') }
   let(:raw_cloud_volume_backup) { double }
 
   let(:cloud_volume) do

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
@@ -1,6 +1,6 @@
-describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
-  let(:ems) { FactoryBot.create(:ems_openstack) }
-  let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
+describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume do
+  let(:ems) { FactoryBot.create(:ems_openstack_cinder) }
+  let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems.parent_manager) }
   let(:cloud_volume) do
     FactoryBot.create(:cloud_volume_openstack,
                        :ext_management_system => ems,
@@ -23,8 +23,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
       handle = double
       allow(handle).to receive(:volumes).and_return(volumes)
       allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-      allow(ems).to receive(:connect).with(hash_including(:service     => 'Volume',
-                                                          :tenant_name => tenant.name)).and_return(handle)
+      allow(ExtManagementSystem).to receive(:find).with(ems.parent_manager.id).and_return(ems.parent_manager)
+      allow(ems.parent_manager).to receive(:connect)
+                               .with(hash_including(:service => 'Volume', :tenant_name => tenant.name))
+                               .and_return(handle)
       allow(volumes).to receive(:get).with(cloud_volume.ems_ref).and_return(the_raw_volume)
     end
   end
@@ -152,8 +154,10 @@ describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
           volume_service = double
           allow(volume_service).to receive(:backups).and_return(fog_backups)
           allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-          allow(ems).to receive(:connect).with(hash_including(:service     => 'Volume',
-                                                              :tenant_name => tenant.name)).and_return(volume_service)
+          allow(ExtManagementSystem).to receive(:find).with(ems.parent_manager.id).and_return(ems.parent_manager)
+          allow(ems.parent_manager).to receive(:connect)
+                                   .with(hash_including(:service => 'Volume', :tenant_name => tenant.name))
+                                   .and_return(volume_service)
           allow(fog_backups).to receive(:new).and_return(fog_backup)
         end
       end


### PR DESCRIPTION
These models belong to the Openstack::StorageManager::CinderManager but their class name indicates that they belong to the Openstack::CloudManager which is quite confusing.

Schema migration: https://github.com/ManageIQ/manageiq-schema/pull/532
Depends on: https://github.com/ManageIQ/manageiq/pull/20782
Ref: https://github.com/ManageIQ/manageiq-providers-openstack/pull/644#issuecomment-722281752