### PR TITLE
Update Network Targeted refresh to skip not found network

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -41,7 +41,11 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
     return [] if references(:cloud_networks).blank?
     return @cloud_networks if @cloud_networks.any?
     @cloud_networks = references(:cloud_networks).collect do |network_id|
-      safe_get { network_service.networks.get(network_id) }
+      safe_get do
+        network_service.get_network(network_id).body["network"]
+      rescue Fog::OpenStack::Network::NotFound
+        nil
+      end
     end.compact
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/target_collection.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::TargetCollection < M
     return [] if references(:cloud_networks).blank?
     return @cloud_networks if @cloud_networks.any?
     @cloud_networks = references(:cloud_networks).collect do |network_id|
-      safe_get { network_service.get_network(network_id).body["network"] }
+      safe_get { network_service.networks.get(network_id) }
     end.compact
   end
 


### PR DESCRIPTION
If an Event like network.delete.end is received, targeted refresh tries find the network by a raw fog request method which doesn't handle Not Found error, that could break the refresh attempt.

<del>Updating to Fog's model method (network.get) which returns nil for Not Found error request - https://github.com/fog/fog-openstack/blob/master/lib/fog/openstack/network/models/networks.rb#L22-L28 - this requires bigger change also in full graph refresh - decided to keep current code</del>

Adding ```rescue``` block to handle Not Found Error from Fog and return nil (which is already expected that nil could be returned).

This could be related to https://bugzilla.redhat.com/show_bug.cgi?id=1896581, however we're not 100% sure whether this is the main problem on the BZ.