### PR TITLE
Use log_start_user_event_message in Scanning::Job

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/scanning/job.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/scanning/job.rb
@@ -128,7 +128,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Scanning::Job < VmScan
     if vm.ext_management_system
       sn_description = snapshotDescription
       _log.info("Creating snapshot, description: [#{sn_description}]")
-      user_event = start_user_event_message
+      log_start_user_event_message
       options[:snapshot] = :server
       begin
         # TODO: should this be a vm method?


### PR DESCRIPTION
Originally this started as a linter warning, but it appears to be a bug. The original warning was that the `user_event` variable wasn't being used. However, it also revealed that `start_user_event_message` doesn't actually do anything, it's just a string. Instead, I'm pretty sure we want `log_start_user_event_message`.

See https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_scan.rb#L242-L256 for more info.

It's also up for debate as to whether or not we should also be calling a corresponding `log_end_user_event_message` which is only called in a different method.