### PR TITLE
Move SwiftManager to Openstack plugin

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
            :autosave    => true
   has_many :snapshots, :through => :vms_and_templates
   include ManageIQ::Providers::Openstack::CinderManagerMixin
-  include SwiftManagerMixin
+  include ManageIQ::Providers::Openstack::SwiftManagerMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
   include ManageIQ::Providers::Openstack::IdentitySyncMixin
 
@@ -455,7 +455,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def ensure_swift_manager
     return false if swift_manager
-    build_swift_manager(:type => 'ManageIQ::Providers::StorageManager::SwiftManager')
+    build_swift_manager(:type => 'ManageIQ::Providers::Openstack::StorageManager::SwiftManager')
     true
   end
 

--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
@@ -1,3 +1,4 @@
 module ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager
   require_nested :CinderManager
+  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/swift_manager.rb
@@ -1,0 +1,36 @@
+class ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager::SwiftManager < ManageIQ::Providers::Openstack::Inventory::Collector
+  include ManageIQ::Providers::Openstack::Inventory::Collector::HelperMethods
+
+  def swift_service
+    @swift_service ||= manager.parent_manager&.swift_service
+  end
+
+  def directories
+    @directories ||= swift_service.handled_list(:directories)
+  end
+
+  def files(directory)
+    safe_list { directory.files }
+  end
+
+  private
+
+  def safe_call
+    # Safe call wrapper for any Fog call not going through handled_list
+    yield
+  rescue Excon::Errors::Forbidden => err
+    # It can happen user doesn't have rights to read some tenant, in that case log warning but continue refresh
+    _log.warn("Forbidden response code returned in provider: #{manager.address}. Message=#{err.message}")
+    _log.log_backtrace(err, :warn)
+    nil
+  rescue Excon::Errors::NotFound => err
+    # It can happen that some data do not exist anymore, in that case log warning but continue refresh
+    _log.warn("Not Found response code returned in provider: #{manager.address}. Message=#{err.message}")
+    _log.log_backtrace(err, :warn)
+    nil
+  end
+
+  def safe_list(&block)
+    safe_call(&block) || []
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
@@ -1,3 +1,4 @@
 module ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager
   require_nested :CinderManager
+  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/swift_manager.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::SwiftManager < ManageIQ::Providers::Openstack::Inventory::Parser
+  def parse
+    collector.directories.each do |dir|
+      tenant_ref = dir.project.id
+      persister_conatiner = parse_container(dir, tenant_ref)
+      collector.files(dir).each do |file|
+        parse_object(file, persister_conatiner, tenant_ref)
+      end
+    end
+  end
+
+  def parse_container(container, cloud_tenant_ref)
+    persister.cloud_object_store_containers.build(
+      :ems_ref      => container_ems_ref(container),
+      :key          => container.key,
+      :object_count => container.count,
+      :bytes        => container.bytes,
+      :cloud_tenant => persister.cloud_tenants.lazy_find(cloud_tenant_ref)
+    )
+  end
+
+  def parse_object(object, persister_conatiner, cloud_tenant_ref)
+    persister.cloud_object_store_objects.build(
+      :ems_ref                      => object.key,
+      :etag                         => object.etag,
+      :last_modified                => object.last_modified,
+      :content_length               => object.content_length,
+      :content_type                 => object.content_type,
+      :key                          => object.key,
+      :cloud_object_store_container => persister_conatiner,
+      :cloud_tenant                 => persister.cloud_tenants.lazy_find(cloud_tenant_ref)
+    )
+  end
+
+  private
+
+  def container_ems_ref(container)
+    "#{container.project.id}/#{container.key}"
+  end
+end

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
@@ -1,3 +1,4 @@
 module ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager
   require_nested :CinderManager
+  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/swift_manager.rb
@@ -1,0 +1,10 @@
+class ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::SwiftManager < ManageIQ::Providers::Openstack::Inventory::Persister
+  def initialize_inventory_collections
+    add_collection(storage, :cloud_object_store_objects)
+    add_collection(storage, :cloud_object_store_containers)
+
+    add_collection(cloud, :cloud_tenants, :parent => manager.parent_manager) do |builder|
+      builder.add_properties(:strategy => :local_db_cache_all, :complete => false)
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
@@ -1,0 +1,76 @@
+class ManageIQ::Providers::Openstack::StorageManager::SwiftManager < ManageIQ::Providers::StorageManager::SwiftManager
+  require_nested :Refresher
+
+  include ManageIQ::Providers::StorageManager::ObjectMixin
+
+  delegate :authentication_check,
+           :authentication_status,
+           :authentication_status_ok,
+           :authentications,
+           :authentication_for_summary,
+           :zone,
+           :swift_service,
+           :connect,
+           :verify_credentials,
+           :with_provider_connection,
+           :address,
+           :ip_address,
+           :hostname,
+           :default_endpoint,
+           :endpoints,
+           :to        => :parent_manager,
+           :allow_nil => true
+
+  supports :swift_service do
+    if parent_manager
+      unsupported_reason_add(:swift_service, parent_manager.unsupported_reason(:swift_service)) unless
+        parent_manager.supports_swift_service?
+    else
+      unsupported_reason_add(:swift_service, _('no parent_manager to ems'))
+    end
+  end
+
+  def self.hostname_required?
+    false
+  end
+
+  def self.ems_type
+    @ems_type ||= "swift".freeze
+  end
+
+  def self.description
+    @description ||= "Swift ".freeze
+  end
+
+  def description
+    @description ||= "Swift ".freeze
+  end
+
+  def name
+    "#{parent_manager.try(:name)} Swift Manager"
+  end
+
+  def supports_api_version?
+    true
+  end
+
+  def supports_security_protocol?
+    true
+  end
+
+  def supports_provider_id?
+    true
+  end
+
+  def allow_targeted_refresh?
+    false
+  end
+
+  def self.event_monitor_class
+    ManageIQ::Providers::StorageManager::SwiftManager::EventCatcher
+  end
+
+  def self.display_name(number = 1)
+    n_('Storage Manager (Swift)', 'Storage Managers (Swift)', number)
+  end
+end

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager/refresher.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager/refresher.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Openstack::StorageManager::SwiftManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+  end
+end

--- a/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
@@ -1,0 +1,21 @@
+module ManageIQ::Providers::Openstack::SwiftManagerMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_one  :swift_manager,
+             :foreign_key => :parent_ems_id,
+             :class_name  => "ManageIQ::Providers::StorageManager::SwiftManager",
+             :autosave    => true
+
+    delegate :cloud_object_store_containers,
+             :cloud_object_store_objects,
+             :to        => :swift_manager,
+             :allow_nil => true
+  end
+
+  private
+
+  def ensure_swift_manager
+    swift_manager || build_swift_manager
+  end
+end


### PR DESCRIPTION
The SwiftManager refresh is unable to run without a parent_manager, refresh logic should be moved to openstack

Related:
- [ ] https://github.com/ManageIQ/manageiq/pull/20927

Dependent:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/543
- [ ] https://github.com/ManageIQ/manageiq/pull/20927