### PR TITLE
Add support for the create_network_router feature for network mgr

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
   include SupportsFeatureMixin
 
   supports :create
+  supports :create_network_router
 
   has_many :public_networks,  :foreign_key => :ems_id, :dependent => :destroy,
            :class_name => "ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork::Public"


### PR DESCRIPTION
There's also a method called [`create_network_router`](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/network_manager.rb#L135) so I really hope it doesn't cause any collision.

Depends on: https://github.com/ManageIQ/manageiq/pull/20958
Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6862

@miq-bot assign @agrare 
@miq-bot add_label enhancement