### PR TITLE
Adjust the support features and ddf schema after CloudVolume remodel

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -47,8 +47,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   supports :create_flavor
   supports :create_host_aggregate
   supports :label_mapping
-  supports :cloud_volume
-  supports :cloud_volume_create
 
   before_create :ensure_managers
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -13,6 +13,8 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
   supports :volume_multiattachment
   supports :volume_resizing
   supports :volume_availability_zones
+  supports :cloud_volume
+  supports :cloud_volume_create
 
   # Auth and endpoints delegations, editing of this type of manager must be disabled
   delegate :authentication_check,

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -49,7 +49,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
             :when => 'edit',
             :is   => false,
           },
-          :options   => ems.availability_zones.map do |az|
+          :options   => ems.volume_availability_zones.map do |az|
             {
               :label => az.name,
               :value => az.id,


### PR DESCRIPTION
These were not adjusted since @agrare moved the `CloudVolume` under `CinderManager` which caused issues in the UI. @agrare I'm not entirely sure about the correctness of the `volume_availability_zones` but there was no other method delegated and I wasn't sure I have to delegate all of the AZs.

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/7334

@miq-bot add_label bug, kasparov/no
@miq-bot assign @agrare 