### PR TITLE
Fix VMDBLogger NoMethodError "instrument"

### DIFF
--- a/lib/manageiq/providers/openstack/engine.rb
+++ b/lib/manageiq/providers/openstack/engine.rb
@@ -15,7 +15,7 @@ module ManageIQ
         end
 
         def self.init_loggers
-          $fog_log ||= Vmdb::Loggers.create_logger("fog.log")
+          $fog_log ||= Vmdb::Loggers.create_logger("fog.log", Vmdb::Loggers::FogLogger)
         end
 
         def self.apply_logger_config(config)


### PR DESCRIPTION
The `$fog_log` has to respond to `#instrument`

```
13) ManageIQ::Providers::Openstack::InfraManager::Refresher will perform a full refresh
    Failure/Error: Fog.const_get(service).new(opts)

    Fog::Service::NotFound:
      openstack has no compute service

  --- Caused by: ---
  NoMethodError:
    undefined method `instrument' for #<VMDBLogger:0x00000000038f73e0>
    ./lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb:81:in `raw_connect'
```

Fixes: https://travis-ci.com/github/ManageIQ/manageiq-providers-openstack/jobs/472355101