### PR TITLE
Pass CloudVolumeType#name in the CloudVolume form instead of type

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -68,7 +68,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :options   => ems.cloud_volume_types.map do |cvt|
             {
               :label => cvt.name,
-              :value => cvt.type,
+              :value => cvt.name,
             }
           end,
         },


### PR DESCRIPTION
Fixes [this issue](https://github.com/ManageIQ/manageiq-ui-classic/pull/7399#issuecomment-773327230) in the new CloudVolume form.

@miq-bot assign @agrare 
@miq-bot add_label bug