### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -150,13 +150,14 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :validationDependencies => %w[name type api_version provider_region keystone_v3_domain_id],
                     :fields                 => [
                       {
-                        :component  => "select",
-                        :id         => "endpoints.default.security_protocol",
-                        :name       => "endpoints.default.security_protocol",
-                        :label      => _("Security Protocol"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                        :options    => [
+                        :component    => "select",
+                        :id           => "endpoints.default.security_protocol",
+                        :name         => "endpoints.default.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :initialValue => 'ssl-with-validation',
+                        :validate     => [{:type => "required"}],
+                        :options      => [
                           {
                             :label => _("SSL without validation"),
                             :value => "ssl-no-validation"
@@ -313,13 +314,14 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     },
                     :fields                 => [
                       {
-                        :component  => "select",
-                        :id         => "endpoints.stf.security_protocol",
-                        :name       => "endpoints.stf.security_protocol",
-                        :label      => _("Security Protocol"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                        :options    => [
+                        :component    => "select",
+                        :id           => "endpoints.stf.security_protocol",
+                        :name         => "endpoints.stf.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :initialValue => 'ssl-with-validation',
+                        :validate     => [{:type => "required"}],
+                        :options      => [
                           {
                             :label => _("SSL without validation"),
                             :value => "ssl-no-validation"

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -85,13 +85,14 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
                     :validationDependencies => %w[name type api_version provider_region keystone_v3_domain_id],
                     :fields                 => [
                       {
-                        :component  => "select",
-                        :id         => "endpoints.default.security_protocol",
-                        :name       => "endpoints.default.security_protocol",
-                        :label      => _("Security Protocol"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                        :options    => [
+                        :component    => "select",
+                        :id           => "endpoints.default.security_protocol",
+                        :name         => "endpoints.default.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :initialValue => 'ssl-with-validation',
+                        :validate     => [{:type => "required"}],
+                        :options      => [
                           {
                             :label => _("SSL without validation"),
                             :value => "ssl-no-validation"

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -23,17 +23,18 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :validate   => [{:type => 'required'}],
         },
         {
-          :component  => 'select',
-          :name       => 'cloud_tenant_id',
-          :id         => 'cloud_tenant_id',
-          :label      => _('Cloud Tenant'),
-          :isRequired => true,
-          :validate   => [{:type => 'required'}],
-          :condition  => {
+          :component    => 'select',
+          :name         => 'cloud_tenant_id',
+          :id           => 'cloud_tenant_id',
+          :label        => _('Cloud Tenant'),
+          :isRequired   => true,
+          :includeEmpty => true,
+          :validate     => [{:type => 'required'}],
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
-          :options    => ems.cloud_tenants.map do |ct|
+          :options      => ems.cloud_tenants.map do |ct|
             {
               :label => ct.name,
               :value => ct.id,
@@ -41,15 +42,16 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           end,
         },
         {
-          :component => 'select',
-          :name      => 'availability_zone_id',
-          :id        => 'availability_zone_id',
-          :label     => _('Availability Zone'),
-          :condition => {
+          :component    => 'select',
+          :name         => 'availability_zone_id',
+          :id           => 'availability_zone_id',
+          :label        => _('Availability Zone'),
+          :includeEmpty => true,
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
-          :options   => ems.volume_availability_zones.map do |az|
+          :options      => ems.volume_availability_zones.map do |az|
             {
               :label => az.name,
               :value => az.id,
@@ -57,15 +59,16 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           end,
         },
         {
-          :component => 'select',
-          :name      => 'volume_type',
-          :id        => 'volume_type',
-          :label     => _('Cloud Volume Type'),
-          :condition => {
+          :component    => 'select',
+          :name         => 'volume_type',
+          :id           => 'volume_type',
+          :label        => _('Cloud Volume Type'),
+          :includeEmpty => true,
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
-          :options   => ems.cloud_volume_types.map do |cvt|
+          :options      => ems.cloud_volume_types.map do |cvt|
             {
               :label => cvt.name,
               :value => cvt.name,


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit `initialValue` or `includeEmpty` settings in order to make the form validation work.

@miq-bot assign @agrare 