### PR TITLE
Fix for the OpenStack port always being nil and defaulting to 5000

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -41,7 +41,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.security_protocol      = params[:default_security_protocol].strip
       ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
 
-      user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_api_port].try(:strip)
+      user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_port].try(:strip)
 
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
       authentication = {:userid => user, :password => ManageIQ::Password.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}


### PR DESCRIPTION
The params passed in to `ems_connect?` sets `:default_port` but it then tries to use `:default_api_port` which is always `nil`.

This means that the `OpenstackHandle` will always default to 5000 for the port regardless of what is passed in to the UI.