### PR TITLE
Fix domain_id params / verify key mismatch

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -153,7 +153,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :name                   => 'authentications.default.valid',
                     :skipSubmit             => true,
                     :isRequired             => true,
-                    :validationDependencies => %w[name type api_version provider_region keystone_v3_domain_id],
+                    :validationDependencies => %w[name type api_version provider_region uid_ems],
                     :fields                 => [
                       {
                         :component    => "select",

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -39,7 +39,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.provider_region        = params[:provider_region]
       ems.api_version            = params[:api_version].strip
       ems.security_protocol      = params[:default_security_protocol].strip
-      ems.keystone_v3_domain_id  = params[:keystone_v3_domain_id]
+      ems.keystone_v3_domain_id  = params[:uid_ems]
 
       user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_port].try(:strip)
 
@@ -108,7 +108,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         obj.merge([endpoint_name, item].join('_') => endpoint.try(:[], item))
       end
 
-      params.merge!(args.slice('name', 'provider_region', 'api_version'))
+      params.merge!(args.slice('name', 'provider_region', 'api_version', 'uid_ems'))
       params['event_stream_selection'] = args['event_stream_selection'] if endpoint_name != 'default'
 
       !!raw_connect(password, params.symbolize_keys)


### PR DESCRIPTION
The domain_id is being passed in as uid_ems according to params_for_create but verify_credentials was looking for it in keystone_v3_domain_id

This was causing `.verify_credentials` to pass but later on `#verify_credentials` which was using the right domain_id would fail.

Similar issue as: https://github.com/ManageIQ/manageiq-providers-openstack/pull/698