### PR TITLE
Don't stub authentication_status_ok? in event_catcher_spec

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Openstack::CloudManager::EventCatcher do
   before do
-    @ems = FactoryBot.create(:ems_openstack)
-    allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryBot.create(:ems_openstack, :with_authentication, :zone => zone)
     allow(ManageIQ::Providers::Openstack::CloudManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 

--- a/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Openstack::InfraManager::EventCatcher do
   before do
-    @ems = FactoryBot.create(:ems_openstack_infra)
-    allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    @ems = FactoryBot.create(:ems_openstack_infra, :with_authentication, :zone => zone)
     allow(ManageIQ::Providers::Openstack::InfraManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 


### PR DESCRIPTION
Rather than stub ems.authentication_status_ok? and ems.supports?(:timeline) we can just create appropriate authentication records and set the capabilities

Required for: https://github.com/ManageIQ/manageiq/pull/21138