### PR TITLE
Extend error catching in detect_service for tenant

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -330,7 +330,8 @@ module OpenstackHandle
 
     def detect_service(service, tenant_name = nil)
       connect(:service => service, :tenant_name => tenant_name)
-    rescue MiqException::ServiceNotAvailable
+    rescue => err
+      $fog_log.warn("MIQ(#{self.class.name}.#{__method__}) detect service error: #{err}")
       return nil
     end
 


### PR DESCRIPTION
Detection of a service for given tenant could return multiple kind of errors potentially (like unauthorized, most likely only in cases when OpenStack policy files were customized), extending rescue to generic Error.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1935206