### PR TITLE
Make it easier to subclass the Openstack refresh classes

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -493,6 +493,10 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     @description ||= "OpenStack".freeze
   end
 
+  def self.vm_vendor
+    @vm_vendor ||= "openstack".freeze
+  end
+
   def self.default_blacklisted_event_names
     %w(
       identity.authenticate

--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -26,7 +26,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       volume_template.name = vt.name.blank? ? vt.id : vt.name
       volume_template.cloud_tenant = persister.cloud_tenants.lazy_find(vt.tenant_id) if vt.tenant_id
       volume_template.location = "N/A"
-      volume_template.vendor = "openstack"
     end
   end
 
@@ -38,7 +37,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       volume_template.name = (vt['display_name'] || vt['name']).blank? ? vt["id"] : (vt['display_name'] || vt['name'])
       volume_template.cloud_tenant = persister.cloud_tenants.lazy_find(vt["os-extended-snapshot-attributes:project_id"])
       volume_template.location = "N/A"
-      volume_template.vendor = "openstack"
     end
   end
 
@@ -187,9 +185,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       image.type = "ManageIQ::Providers::Openstack::CloudManager::Template"
       image.uid_ems = i.id
       image.name = i.name.blank? ? i.id.to_s : i.name
-      image.vendor = "openstack"
       image.raw_power_state = "never"
-      image.template = true
       image.publicly_available = public_image?(i)
       image.cloud_tenants = image_tenants(i)
       image.location = "unknown"
@@ -309,7 +305,6 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       server = persister.vms.find_or_build(s.id.to_s)
       server.uid_ems = s.id
       server.name = s.name
-      server.vendor = "openstack"
       server.raw_power_state = s.state || "UNKNOWN"
       server.connection_state = "connected"
       server.location = "unknown"

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -51,13 +51,14 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
   def add_vms
     add_collection_with_ems_param(cloud, :vms) do |builder|
       builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::Vm)
+      builder.add_default_values(:vendor => manager.class.vm_vendor)
     end
   end
 
   def add_miq_templates
     add_collection(cloud, :miq_templates) do |builder|
       builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::BaseTemplate)
-      builder.add_default_values(:ems_id => manager.id)
+      builder.add_default_values(:ems_id => manager.id, :vendor => manager.class.vm_vendor)
 
       # Extra added to automatic attributes
       builder.add_inventory_attributes(%i(cloud_tenant cloud_tenants))


### PR DESCRIPTION
Replace hard-coded "openstack" vendor strings so that subclasses of the openstack refresh code can easily override them.

Required for:
* https://github.com/iv1111/manageiq-providers-ibm_power_vc/pull/2