### PR TITLE
Don't hardcode STI class in refresh

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
 
     # ensure the null az exists
     null_az = persister.availability_zones.find_or_build("null_az")
-    null_az.type = "ManageIQ::Providers::Openstack::CloudManager::AvailabilityZoneNull"
+    null_az.type = persister.manager.class::AvailabilityZoneNull.name
     null_az.ems_ref = "null_az"
     null_az.provider_services_supported = ["compute"]
   end

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -20,4 +20,8 @@ class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers
 
     initialize_inventory_collections
   end
+
+  def cinder_manager
+    manager.kind_of?(ManageIQ::Providers::Openstack::StorageManager::CinderManager) ? manager : manager.cinder_manager
+  end
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -50,14 +50,13 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
   # model_class defined due to ovirt dependency
   def add_vms
     add_collection_with_ems_param(cloud, :vms) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::Vm)
       builder.add_default_values(:vendor => manager.class.vm_vendor)
     end
   end
 
   def add_miq_templates
     add_collection(cloud, :miq_templates) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::BaseTemplate)
+      builder.add_properties(:model_class => manager.class::BaseTemplate)
       builder.add_default_values(:ems_id => manager.id, :vendor => manager.class.vm_vendor)
 
       # Extra added to automatic attributes
@@ -67,9 +66,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   # model_class defined due to ovirt dependency
   def add_availability_zones
-    add_collection_with_ems_param(cloud, :availability_zones) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::AvailabilityZone)
-    end
+    add_collection_with_ems_param(cloud, :availability_zones)
   end
 
   # model_class defined due to ovirt dependency
@@ -81,16 +78,12 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   # model_class defined due to ovirt dependency
   def add_flavors
-    add_collection_with_ems_param(cloud, :flavors) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::Flavor)
-    end
+    add_collection_with_ems_param(cloud, :flavors)
   end
 
   # model_class defined due to ovirt dependency
   def add_cloud_resource_quotas
-    add_collection_with_ems_param(cloud, :cloud_resource_quotas) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::CloudResourceQuota)
-    end
+    add_collection_with_ems_param(cloud, :cloud_resource_quotas)
   end
 
   def add_cloud_services
@@ -99,9 +92,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   # model_class defined due to ovirt dependency
   def add_host_aggregates
-    add_collection_with_ems_param(cloud, :host_aggregates) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::HostAggregate)
-    end
+    add_collection_with_ems_param(cloud, :host_aggregates)
   end
 
   def add_orchestration_stacks(extra_properties = {})

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/network_collections.rb
@@ -26,8 +26,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Networ
   # model_class defined due to ovirt dependency
   def add_cloud_networks
     add_collection(network, :cloud_networks) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork)
-
       network_ems_default_value(builder)
     end
   end
@@ -35,8 +33,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Networ
   # model_class defined due to ovirt dependency
   def add_cloud_subnets
     add_collection(network, :cloud_subnets) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet)
-
       network_ems_default_value(builder)
     end
   end
@@ -60,15 +56,12 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Networ
   # model_class defined due to ovirt dependency
   def add_floating_ips
     add_collection(network, :floating_ips) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::FloatingIp)
-
       network_ems_default_value(builder)
     end
   end
 
   def add_network_ports
     add_collection(network, :network_ports) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::NetworkPort)
       builder.add_properties(:delete_method => :disconnect_port)
 
       network_ems_default_value(builder)
@@ -78,8 +71,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Networ
   # model_class defined due to ovirt dependency
   def add_network_routers
     add_collection(network, :network_routers) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter)
-
       network_ems_default_value(builder)
     end
   end
@@ -87,8 +78,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::Networ
   # model_class defined due to ovirt dependency
   def add_security_groups
     add_collection(network, :security_groups) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::NetworkManager::SecurityGroup)
-
       network_ems_default_value(builder)
       # targeted refresh workaround-- always refresh the whole security group collection
       # regardless of whether this is a TargetCollection or not

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -405,7 +405,7 @@ module Openstack
       end
 
       CloudTenant.all.each do |tenant|
-        expect(tenant).to be_kind_of(CloudTenant)
+        expect(tenant).to be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudTenant)
         expect(tenant.ext_management_system).to eq(@ems)
       end
     end
@@ -422,7 +422,7 @@ module Openstack
       end
 
       CloudTenant.all.each do |tenant|
-        expect(tenant).to be_kind_of(CloudTenant)
+        expect(tenant).to be_kind_of(ManageIQ::Providers::Openstack::CloudManager::CloudTenant)
         expect(tenant.ext_management_system).to eq(@ems)
       end
     end


### PR DESCRIPTION
Rather than hard-code the various STI types we should be using the auto_model_class mechanism from the core persister