### PR TITLE
Handle Openstack instances with no Swift Service

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/swift_manager.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager::Swif
   end
 
   def directories
-    @directories ||= swift_service.handled_list(:directories)
+    @directories ||= swift_service&.handled_list(:directories) || []
   end
 
   def files(directory)


### PR DESCRIPTION
Not all openstack deployments have a Swfit service (e.g. microstack).

```
[----] E, [2021-04-19T10:40:44.451463 #88863:14820] ERROR -- : MIQ(ManageIQ::Providers::Openstack::StorageManager::SwiftManager::Refresher#refresh) EMS: [openstack Swift Manager], id: [5] Refresh failed
[----] E, [2021-04-19T10:40:44.452137 #88863:14820] ERROR -- : [NoMethodError]: undefined method 'handled_list' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2021-04-19T10:40:44.452502 #88863:14820] ERROR -- : /home/grare/adam/src/manageiq/manageiq-providers-openstack/app/models/manageiq/providers/openstack/inventory/collector/storage_manager/swift_manager.rb:10:in 'directories'
/home/grare/adam/src/manageiq/manageiq-providers-openstack/app/models/manageiq/providers/openstack/inventory/parser/storage_manager/swift_manager.rb:3:in 'parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:42:in 'block in parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in 'each'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/inventory.rb:39:in 'parse'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:125:in 'parse_targeted_inventory'
/home/grare/adam/src/manageiq/manageiq/app/models/manageiq/providers/base_manager/refresher.rb:92:in 'block in refresh_targets_for_ems'
```