### PR TITLE
Remove unused validate_update_volume

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -107,10 +107,6 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     raise MiqException::MiqVolumeCreateError, parse_error_message_from_fog_response(e), e.backtrace
   end
 
-  def validate_update_volume
-    validate_volume
-  end
-
   def raw_update_volume(options)
     with_notification(:cloud_volume_update,
                       :options => {

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
@@ -88,14 +88,13 @@ describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVol
       end
 
       it "validates the volume update operation" do
-        validation = cloud_volume.validate_update_volume
-        expect(validation[:available]).to be true
+        expect(cloud_volume.supports?(:update)).to be_truthy
       end
 
       it "validates the volume update operation when ems is missing" do
         expect(cloud_volume).to receive(:ext_management_system).and_return(nil)
-        validation = cloud_volume.validate_update_volume
-        expect(validation[:available]).to be false
+        expect(cloud_volume.supports?(:update)).to be_falsy
+        expect(cloud_volume.unsupported_reason(:update)).to eq("The Volume is not connected to an active Provider")
       end
 
       it 'catches errors from provider' do


### PR DESCRIPTION
Follow-up to: https://github.com/ManageIQ/manageiq/pull/21181

This has been replaced with `supports :update`