### PR TITLE
[WIP] Subclass orchestration stacks under the cloud manager

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::CloudManager::OrchestrationStack
+class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack
   include ManageIQ::Providers::Openstack::HelperMethods
   require_nested :Status
 

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -95,14 +95,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
     add_collection_with_ems_param(cloud, :host_aggregates)
   end
 
-  def add_orchestration_stacks(extra_properties = {})
-    add_collection(cloud, :orchestration_stacks, extra_properties) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::CloudManager::OrchestrationStack)
-
-      yield builder if block_given?
-    end
-  end
-
   def add_auth_key_pairs(extra_properties = {})
     add_collection(cloud, :auth_key_pairs, extra_properties) do |builder|
       # targeted refresh workaround-- always refresh the whole keypair collection

--- a/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/orchestration_stack_spec.rb
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
         allow(the_new_stack).to receive(:[]).with("id").and_return('new_id')
         expect(the_new_stack).to receive(:save).and_return(the_new_stack)
 
-        stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
+        stack = ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
         expect(stack.class).to eq(described_class)
         expect(stack.name).to eq('mystack')
         expect(stack.ems_ref).to eq('new_id')
@@ -50,7 +50,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack do
         expect(the_new_stack).to receive(:save).and_raise('bad request')
 
         expect do
-          ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
+          ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack.create_stack(ems, 'mystack', template, stack_option)
         end.to raise_error(MiqException::MiqOrchestrationProvisionError)
       end
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb
@@ -702,7 +702,7 @@ module Openstack
     def assert_specific_stacks
       return unless orchestration_supported?
 
-      stacks = OrchestrationStack.all
+      stacks = ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack.all
 
       assert_objects_with_hashes(stacks,
                                  orchestration_data.stacks,
@@ -712,7 +712,7 @@ module Openstack
     end
 
     def assert_targeted_stack
-      stack_target = OrchestrationStack.find_by(:name => "stack1")
+      stack_target = ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack.find_by(:name => "stack1")
       assert_objects_with_hashes([stack_target],
                                  [orchestration_data.stacks[0]],
                                  orchestration_data.stack_translate_table,


### PR DESCRIPTION
These should be subclassed under the `Openstack::CloudManager`

TODO:
- [ ] Ensure nothing is expecting these to have the _exact_ class `ManageIQ::Providers::CloudManager::OrchestrationStack`