### PR TITLE
Modified Allocation Pools Field of Cloud Subnet Form

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_subnet.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
           :isRequired   => true,
           :includeEmpty => true,
           :validate     => [{:type => 'required'}],
-          :options      => ems.networks.map do |cvt|
+          :options      => ems.cloud_networks.map do |cvt|
             {
               :label => cvt.name,
               :value => cvt.id,
@@ -76,7 +76,6 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
           :name         => 'extra_attributes.ip_version',
           :id           => 'extra_attributes.ip_version',
           :label        => _('IP Version'),
-          :includeEmpty => true,
           :options      => [
             {
               :label => 'ipv4',
@@ -93,7 +92,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
           :id                => 'extra_attributes.allocation_pools',
           :name              => 'extra_attributes.allocation_pools',
           :label             => _('Allocation Pools'),
-          :fields            => [{:component => 'text-field'}],
+          :fields            => [
+            {:component => 'text-field', :id => 'start', :name => 'start', :label => _('Start')},
+            {:component => 'text-field', :id => 'end', :name => 'end', :label => _('End')}
+          ],
           :noItemsMessage    => _('None'),
           :buttonLabels      => {
             :add    => _('Add'),
@@ -107,7 +109,10 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
           :id                => 'extra_attributes.host_routes',
           :name              => 'extra_attributes.host_routes',
           :label             => _('Host Routes'),
-          :fields            => [{:component => 'text-field'}],
+          :fields            => [
+            {:component => 'text-field', :id => 'nexthop', :name => 'nexthop', :label => _('Nexthop')},
+            {:component => 'text-field', :id => 'destination', :name => 'destination', :label => _('Destination')}
+          ],
           :noItemsMessage    => _('None'),
           :buttonLabels      => {
             :add    => _('Add'),
@@ -121,7 +126,11 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet < ::CloudSubne
   end
 
   def self.raw_create_cloud_subnet(ext_management_system, options)
-    cloud_tenant = options.delete(:cloud_tenant)
+    cloud_network_id = options.delete(:cloud_network_id)
+    cloud_network = CloudNetwork.find_by(:id => cloud_network_id) if cloud_network_id
+    options[:network_id] = cloud_network&.ems_ref
+    cloud_tenant_id = options.delete(:cloud_tenant_id)
+    cloud_tenant = CloudTenant.find_by(:id => cloud_tenant_id) if cloud_tenant_id
     subnet = nil
 
     ext_management_system.with_provider_connection(connection_options(cloud_tenant)) do |service|

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_subnet_spec.rb
@@ -2,11 +2,13 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
   let(:ems) { FactoryBot.create(:ems_openstack) }
   let(:tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems) }
   let(:ems_network) { ems.network_manager }
+  let(:network) { FactoryBot.create(:cloud_network_openstack, :ext_management_system => ems_network) }
   let(:cloud_subnet) do
     FactoryBot.create(:cloud_subnet_openstack,
                        :ext_management_system => ems_network,
                        :name                  => 'test',
                        :ems_ref               => 'one_id',
+                       :cloud_network         => network,
                        :cloud_tenant          => tenant)
   end
 
@@ -39,7 +41,7 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet do
       it 'catches errors from provider' do
         expect(service).to receive_message_chain(:subnets, :new).and_raise(bad_request)
         expect do
-          ems_network.create_cloud_subnet(:cloud_tenant => tenant)
+          ems_network.create_cloud_subnet(:cloud_tenant_id => tenant.id, :cloud_network_id => network.id)
         end.to raise_error(MiqException::MiqCloudSubnetCreateError)
       end
     end


### PR DESCRIPTION
Depends On: https://github.com/ManageIQ/manageiq-ui-classic/pull/7734

Changes `ems.networks` to `ems.cloud_networks`, similar to https://github.com/ManageIQ/manageiq-providers-nuage/pull/247

Also modifies the Allocation Pools and Host Routes fields to ensure the Cloud Subnet form is working correctly.

Before: 
![image](https://user-images.githubusercontent.com/64800041/117202386-bf01fc00-adbb-11eb-9022-c1e8948c32ab.png)

After:
![image](https://user-images.githubusercontent.com/64800041/117201778-089e1700-adbb-11eb-917f-a79e9dbcfe4c.png)
