### PR TITLE
Fix the unauthorized login error message

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -133,7 +133,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       when Excon::Errors::NotFound
         MiqException::MiqHostError.new("Endpoint not found.")
       when Excon::Errors::Unauthorized
-        MiqException::MiqInvalidCredentialsError.new("Login failed due to a bad username or password.")
+        MiqException::MiqInvalidCredentialsError.new("Login failed.")
       when Excon::Errors::Timeout
         MiqException::MiqUnreachableError.new("Login attempt timed out")
       when Excon::Errors::SocketError


### PR DESCRIPTION
There are a number of issues that could cause login to return unauthorized including domain_id, username, password.

Just saying "username or password" is misleading as it could be something else wrong as well.