### PR TITLE
Fixed react prop errors for cloud_manager

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -250,10 +250,11 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                   },
                   {
                     :component    => 'text-field',
-                    :type         => 'hidden',
+                    :hideField    => true,
+                    :label        => 'ceilometer',
                     :id           => 'endpoints.ceilometer',
                     :name         => 'endpoints.ceilometer',
-                    :initialValue => {},
+                    :initialValue => '',
                     :condition    => {
                       :when => 'event_stream_selection',
                       :is   => 'ceilometer',
@@ -377,10 +378,11 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                   :fields    => [
                     {
                       :component    => 'text-field',
-                      :type         => 'hidden',
+                      :hideField    => true,
+                      :label        => 'ssh_keypair',
                       :id           => 'endpoints.ssh_keypair',
                       :name         => 'endpoints.ssh_keypair',
-                      :initialValue => {},
+                      :initialValue => '',
                       :condition    => {
                         :when       => 'authentications.ssh_keypair.userid',
                         :isNotEmpty => true,


### PR DESCRIPTION
Fixed these console errors in the cloud provider form and changed implementation of hidden text-field.
<img width="1186" alt="Screen Shot 2021-07-07 at 11 37 57 AM" src="https://user-images.githubusercontent.com/32444791/125129291-40804e00-e0cd-11eb-8150-24e8261653ec.png">
<img width="959" alt="Screen Shot 2021-07-07 at 11 38 03 AM" src="https://user-images.githubusercontent.com/32444791/125129289-3fe7b780-e0cd-11eb-97c6-71e84f14f925.png">

@miq-bot add_reviewer @agrare
@miq-bot add-label bug
