### PR TITLE
rename params_for_edit as params_for_update

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -236,7 +236,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     }
   end
 
-  def params_for_edit
+  def params_for_update
     {
       :fields => [
         {


### PR DESCRIPTION
depends:
- [ ] https://github.com/ManageIQ/manageiq-api/pull/1078

this is what it is called for other models

commentary:
It looks like we have one of each. And it looks like we are not consistent in our api between update and edit. So it could go either way but I just wanted to pick one and go from there.


@miq-bot cross-repo-tests ManageIQ/manageiq-api#1078