### PR TITLE
Subclass CloudObjectStore(Container|Object) models under Openstack SwiftManager

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::Openstack::StorageManager::SwiftManager < ManageIQ::Providers::StorageManager
+  require_nested :CloudObjectStoreContainer
+  require_nested :CloudObjectStoreObject
   require_nested :Refresher
 
   include ManageIQ::Providers::StorageManager::ObjectMixin

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreContainer < ::CloudObjectStoreObject
+end

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_object.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_object.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectStoreObject < ::CloudObjectStoreObject
+end


### PR DESCRIPTION
These models did not have Openstack SwiftManager subclasses.

NOTE this will require a schema migration to fixup existing records

Schema change:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/612