### PR TITLE
Remove unused supports_*? methods from EMS

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -530,18 +530,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     errors.add(:hostname, "has already been taken") if existing_providers.any?
   end
 
-  def supports_port?
-    true
-  end
-
-  def supports_api_version?
-    true
-  end
-
-  def supports_security_protocol?
-    true
-  end
-
   def supported_auth_types
     %w(default amqp ssh_keypair)
   end
@@ -552,10 +540,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def self.catalog_types
     {"openstack" => N_("OpenStack")}
-  end
-
-  def supports_provider_id?
-    true
   end
 
   def supports_authentication?(authtype)

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -334,18 +334,6 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
     )
   end
 
-  def supports_port?
-    true
-  end
-
-  def supports_api_version?
-    true
-  end
-
-  def supports_security_protocol?
-    true
-  end
-
   def supported_auth_types
     %w(default amqp ssh_keypair)
   end

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -60,24 +60,8 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
     )
   end
 
-  def supports_port?
-    true
-  end
-
-  def supports_api_version?
-    true
-  end
-
-  def supports_security_protocol?
-    true
-  end
-
   def supported_auth_types
     %w(default amqp)
-  end
-
-  def supports_provider_id?
-    true
   end
 
   def supports_authentication?(authtype)

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -69,24 +69,8 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
     "#{parent_manager.try(:name)} Cinder Manager"
   end
 
-  def supports_port?
-    true
-  end
-
-  def supports_api_version?
-    true
-  end
-
-  def supports_security_protocol?
-    true
-  end
-
   def supported_auth_types
     %w(default amqp)
-  end
-
-  def supports_provider_id?
-    true
   end
 
   def supports_authentication?(authtype)

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
@@ -52,18 +52,6 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager < ManageIQ::P
     "#{parent_manager.try(:name)} Swift Manager"
   end
 
-  def supports_api_version?
-    true
-  end
-
-  def supports_security_protocol?
-    true
-  end
-
-  def supports_provider_id?
-    true
-  end
-
   def allow_targeted_refresh?
     false
   end


### PR DESCRIPTION
These methods are no longer used by the UI and can be deleted

Follow-up to: https://github.com/ManageIQ/manageiq/pull/21497