### PR TITLE
Deleting validate_*_flavor in favor of existing supports :create and :delete

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb
@@ -19,16 +19,6 @@ class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
     raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
   end
 
-  def self.validate_create_flavor(ext_management_system, _options = {})
-    if ext_management_system
-      {:available => true, :message => nil}
-    else
-      {:available => false,
-       :message   => _("The Flavor is not connected to an active %{table}") %
-         {:table => ui_lookup(:table => "ext_management_system")}}
-    end
-  end
-
   def raw_delete_flavor
     ext_management_system.with_provider_connection({:service => 'Compute'}) do |service|
       service.delete_flavor(ems_ref)
@@ -36,10 +26,6 @@ class ManageIQ::Providers::Openstack::CloudManager::Flavor < ::Flavor
   rescue => err
     _log.error "flavor=[#{name}], error: #{err}"
     raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(err), err.backtrace
-  end
-
-  def validate_delete_flavor
-    {:available => true, :message => nil}
   end
 
   def description

--- a/spec/models/manageiq/providers/openstack/cloud_manager/flavor_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/flavor_spec.rb
@@ -71,18 +71,4 @@ describe ManageIQ::Providers::Openstack::CloudManager::Flavor do
       end.to raise_error(MiqException::MiqOpenstackApiRequestError)
     end
   end
-
-  context 'when validations' do
-    it 'fails with invalid parameters' do
-      expect(subject.class.validate_create_flavor(nil)).to eq(
-        :available => false,
-        :message   => 'The Flavor is not connected to an active Provider')
-    end
-
-    it 'doesn`t fail with valid parameters' do
-      expect(subject.class.validate_create_flavor(ems)).to eq(
-        :available => true,
-        :message   => nil)
-    end
-  end
 end


### PR DESCRIPTION
Goes with https://github.com/ManageIQ/manageiq/pull/21502