### PR TITLE
Fix shadowed exceptions, ignore rescue exception cop.

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -617,7 +617,7 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     raise
   end
 
-  def vm_remove_all_snapshots(vm, options = {})
+  def vm_remove_all_snapshots(vm, _options = {})
     vm.snapshots.each { |snapshot| vm_remove_snapshot(vm, :snMor => snapshot.uid) }
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_target_parser.rb
@@ -22,18 +22,18 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
     target_collection = InventoryRefresh::TargetCollection.new(:manager => ems_event.ext_management_system, :event => ems_event)
 
     # there's almost always a tenant id regardless of event type
-    collect_identity_tenant_references!(target_collection, ems_event)
+    collect_identity_tenant_references!(target_collection)
 
     if ems_event.event_type.start_with?("compute.instance")
-      collect_compute_instance_references!(target_collection, ems_event)
+      collect_compute_instance_references!(target_collection)
     elsif ems_event.event_type.start_with?("orchestration.stack")
-      collect_orchestration_stack_references!(target_collection, ems_event)
+      collect_orchestration_stack_references!(target_collection)
     elsif ems_event.event_type.start_with?("image.")
-      collect_image_references!(target_collection, ems_event)
+      collect_image_references!(target_collection)
     elsif ems_event.event_type.start_with?("aggregate.")
-      collect_host_aggregate_references!(target_collection, ems_event)
+      collect_host_aggregate_references!(target_collection)
     elsif ems_event.event_type.start_with?("keypair")
-      collect_key_pair_references!(target_collection, ems_event)
+      collect_key_pair_references!(target_collection)
     end
 
     target_collection.targets
@@ -47,29 +47,29 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
     target_collection.add_target(:association => association, :manager_ref => {:ems_ref => ref})
   end
 
-  def collect_compute_instance_references!(target_collection, ems_event)
+  def collect_compute_instance_references!(target_collection)
     instance_id = event_payload['instance_id']
     add_target(target_collection, :vms, instance_id) if instance_id
   end
 
-  def collect_image_references!(target_collection, ems_event)
+  def collect_image_references!(target_collection)
     resource_id = event_payload['resource_id'] || event_payload['id']
     add_target(target_collection, :images, resource_id) if resource_id # Works for Create and Update action
     add_target(target_collection, :miq_templates, resource_id) if resource_id # Existing association name needed for Delete action
   end
 
-  def collect_identity_tenant_references!(target_collection, ems_event)
+  def collect_identity_tenant_references!(target_collection)
     tenant_id = event_payload['tenant_id'] || event_payload['project_id'] || event_payload.fetch_path('initiator', 'project_id')
     add_target(target_collection, :cloud_tenants, tenant_id) if tenant_id
   end
 
-  def collect_orchestration_stack_references!(target_collection, ems_event)
+  def collect_orchestration_stack_references!(target_collection)
     stack_id = event_payload['stack_id'] || event_payload['resource_id']
     tenant_id = event_payload['tenant_id']
     target_collection.add_target(:association => :orchestration_stacks, :manager_ref => {:ems_ref => stack_id}, :options => {:tenant_id => tenant_id})
   end
 
-  def collect_host_aggregate_references!(target_collection, ems_event)
+  def collect_host_aggregate_references!(target_collection)
     # aggregate events from ceilometer don't have an id field for the aggregate,
     # but they do have a "service" field in the form of "aggregate.<id>"
     aggregate_id = event_payload['service']
@@ -77,7 +77,7 @@ class ManageIQ::Providers::Openstack::CloudManager::EventTargetParser
     add_target(target_collection, :host_aggregates, aggregate_id) if aggregate_id
   end
 
-  def collect_key_pair_references!(target_collection, _ems_event)
+  def collect_key_pair_references!(target_collection)
     add_target(target_collection, :key_pairs, nil)
   end
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -111,14 +111,14 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
     targets.each_with_object({}) { |az, h| h[az.id] = az.name if az.provider_services_supported.include?("compute") }
   end
 
+  def self.provider_model
+    ManageIQ::Providers::Openstack::CloudManager
+  end
+
   private
 
   def dialog_name_from_automate(message = 'get_dialog_name')
     super(message, {'platform' => 'openstack'})
-  end
-
-  def self.provider_model
-    ManageIQ::Providers::Openstack::CloudManager
   end
 
   def filter_cloud_networks(networks)

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -201,8 +201,9 @@ module ManageIQ::Providers::Openstack::ManagerMixin
 
       ceilometer = connection_configuration_by_role("ceilometer")
       stf = connection_configuration_by_role("stf")
+      endpoint = stf.try(:endpoint)
 
-      if endpoint = stf.try(:endpoint)
+      if endpoint
         opts[:events_monitor]    = :stf
         opts[:hostname]          = endpoint.hostname
         opts[:port]              = endpoint.port

--- a/app/models/manageiq/providers/openstack/network_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_target_parser.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser
     target_collection = InventoryRefresh::TargetCollection.new(:manager => ems_event.ext_management_system.parent_manager, :event => ems_event)
 
     # there's almost always a tenant id regardless of event type
-    collect_identity_tenant_references!(target_collection, ems_event)
+    collect_identity_tenant_references!(target_collection)
 
     target_type = if ems_event.event_type.start_with?("floatingip.")
                     :floating_ips
@@ -57,7 +57,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser
     target_collection.targets
   end
 
-  def collect_identity_tenant_references!(target_collection, ems_event)
+  def collect_identity_tenant_references!(target_collection)
     tenant_id = event_payload['tenant_id'] || event_payload['project_id'] || event_payload.fetch_path('initiator', 'project_id')
     add_target(target_collection, :cloud_tenants, tenant_id) if tenant_id
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -218,6 +218,15 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     super(cinder_connection_options)
   end
 
+  def self.cinder_connection_options(cloud_tenant = nil)
+    connection_options = {:service => "Volume"}
+    connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
+    connection_options[:proxy] = openstack_proxy if openstack_proxy
+    connection_options
+  end
+
+  private_class_method :cinder_connection_options
+
   private
 
   def connection_options
@@ -233,14 +242,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     connection_options
   end
 
-  def self.cinder_connection_options(cloud_tenant = nil)
-    connection_options = {:service => "Volume"}
-    connection_options[:tenant_name] = cloud_tenant.name if cloud_tenant
-    connection_options[:proxy] = openstack_proxy if openstack_proxy
-    connection_options
-  end
-
   def cinder_connection_options
-    self.class.cinder_connection_options(cloud_tenant)
+    self.class.send(:cinder_connection_options, cloud_tenant)
   end
 end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser.rb
@@ -22,17 +22,17 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
     target_collection = InventoryRefresh::TargetCollection.new(:manager => ems_event.ext_management_system.parent_manager, :event => ems_event)
 
     if ems_event.event_type.start_with?("volume.")
-      collect_volume_references!(target_collection, ems_event)
+      collect_volume_references!(target_collection)
     elsif ems_event.event_type.start_with?("snapshot.")
-      collect_snapshot_references!(target_collection, ems_event)
+      collect_snapshot_references!(target_collection)
     elsif ems_event.event_type.start_with?("backup.")
-      collect_backup_references!(target_collection, ems_event)
+      collect_backup_references!(target_collection)
     end
 
     target_collection.targets
   end
 
-  def collect_volume_references!(target_collection, ems_event)
+  def collect_volume_references!(target_collection)
     tenant_id = event_payload['project_id']
     resource_id = event_payload['resource_id']
     add_target(target_collection, :cloud_volumes, resource_id, :tenant_id => tenant_id) if resource_id
@@ -40,7 +40,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
     add_target(target_collection, :volume_templates, resource_id, :tenant_id => tenant_id) if resource_id
   end
 
-  def collect_snapshot_references!(target_collection, ems_event)
+  def collect_snapshot_references!(target_collection)
     tenant_id = event_payload['project_id']
     resource_id = event_payload['resource_id']
     add_target(target_collection, :cloud_volume_snapshots, resource_id, :tenant_id => tenant_id) if resource_id
@@ -48,7 +48,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTarget
     add_target(target_collection, :cloud_volumes, volume_id, :tenant_id => tenant_id) if volume_id
   end
 
-  def collect_backup_references!(target_collection, _ems_event)
+  def collect_backup_references!(target_collection)
     # backup notifications from panko don't include IDs, so we can't target
     # a single backup. Add a dummy backup target which will allow us to collect
     # all backups as a workaround.


### PR DESCRIPTION
This is https://github.com/ManageIQ/manageiq-providers-openstack/pull/670 rebased to HEAD
Thanks @djberg96 I moved this b/c github is sometimes hard

---

Various rubocop linter fixes.

Remove redundant return.

Just remove ems_event argument from cloud manager event target parser.

Just remove ems_event argument from cinder manager event target parser.

Just remove ems_event argument from network manager event target parser.

Use send for private method call.