### PR TITLE
Fix OpenStack Destroy failure

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -24,7 +24,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   has_many :storage_managers,
            :foreign_key => :parent_ems_id,
            :class_name  => "ManageIQ::Providers::StorageManager",
-           :autosave    => true
+           :autosave    => true,
+           :dependent   => :destroy
   has_many :snapshots, :through => :vms_and_templates
   include ManageIQ::Providers::Openstack::CinderManagerMixin
   include ManageIQ::Providers::Openstack::SwiftManagerMixin
@@ -436,18 +437,21 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def ensure_managers_zone_and_provider_region
     if network_manager
+      network_manager.enabled         = enabled
       network_manager.zone_id         = zone_id
       network_manager.tenant_id       = tenant_id
       network_manager.provider_region = provider_region
     end
 
     if cinder_manager
+      cinder_manager.enabled         = enabled
       cinder_manager.zone_id         = zone_id
       cinder_manager.tenant_id       = tenant_id
       cinder_manager.provider_region = provider_region
     end
 
     if swift_manager
+      swift_manager.enabled         = enabled
       swift_manager.zone_id         = zone_id
       swift_manager.tenant_id       = tenant_id
       swift_manager.provider_region = provider_region

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -101,6 +101,20 @@ describe ManageIQ::Providers::Openstack::CloudManager do
     expect(ems.swift_manager.provider_region).to eq "region2"
   end
 
+  describe "#pause!" do
+    before    { Zone.seed } # Seed the maintenance zone
+    let(:ems) { FactoryBot.create(:ems_openstack) }
+
+    it "pauses all child managers" do
+      ems.pause!
+
+      expect(ems).not_to be_enabled
+      expect(ems.network_manager).not_to be_enabled
+      expect(ems.cinder_manager).not_to be_enabled
+      expect(ems.swift_manager).not_to be_enabled
+    end
+  end
+
   describe ".metrics_collector_queue_name" do
     it "returns the correct queue name" do
       worker_queue = ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker.default_queue_name


### PR DESCRIPTION
The OpenStack CloudManager syncs its zone, tenant_id, and provider region with all child managers before save.  This was causing conflicts with pause which disables and moves to the maintenance zone all managers starting with the "parent" manager since the `ensure_managers_zone_and_provider_region` hook was setting the child managers to the maintenance zone without being disabled.

```
ERROR -- evm: MIQ(MiqQueue#deliver) Message id: [12], Error: [Validation failed: ManageIQ::Providers::Openstack::NetworkManager: Zone cannot be the maintenance zone when provider is active]
ERROR -- evm: [ActiveRecord::RecordInvalid]: Validation failed: ManageIQ::Providers::Openstack::NetworkManager: Zone cannot be the maintenance zone when provider is active  Method:[block (2 levels) in <class:LogProxy>]
ERROR -- evm: /home/grare/adam/.gem/gems/activerecord-6.0.4.1/lib/active_record/validations.rb:80:in `raise_validation_error'
/home/grare/adam/.gem/gems/activerecord-6.0.4.1/lib/active_record/validations.rb:53:in `save!'
```