### PR TITLE
Validate ceilometer endpoint

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -142,286 +142,257 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
           :name      => 'endpoints-subform',
           :title     => _('Endpoints'),
           :fields    => [
-            :component => 'tabs',
-            :name      => 'tabs',
-            :fields    => [
-              {
-                :component => 'tab-item',
-                :id        => 'default-tab',
-                :name      => 'default-tab',
-                :title     => _('Default'),
+            {
+              :component => 'sub-form',
+              :id        => 'default-tab',
+              :name      => 'default-tab',
+              :title     => _('Default'),
+              :fields    => [
+                {
+                  :component              => 'validate-provider-credentials',
+                  :id                     => 'authentications.default.valid',
+                  :name                   => 'authentications.default.valid',
+                  :skipSubmit             => true,
+                  :isRequired             => true,
+                  :validationDependencies => %w[name type api_version provider_region uid_ems],
+                  :fields                 => [
+                    {
+                      :component    => "select",
+                      :id           => "endpoints.default.security_protocol",
+                      :name         => "endpoints.default.security_protocol",
+                      :label        => _("Security Protocol"),
+                      :isRequired   => true,
+                      :initialValue => 'ssl-with-validation',
+                      :validate     => [{:type => "required"}],
+                      :options      => [
+                        {
+                          :label => _("SSL without validation"),
+                          :value => "ssl-no-validation"
+                        },
+                        {
+                          :label => _("SSL"),
+                          :value => "ssl-with-validation"
+                        },
+                        {
+                          :label => _("Non-SSL"),
+                          :value => "non-ssl"
+                        }
+                      ]
+                    },
+                    {
+                      :component  => "text-field",
+                      :id         => "endpoints.default.hostname",
+                      :name       => "endpoints.default.hostname",
+                      :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                      :isRequired => true,
+                      :validate   => [{:type => "required"}],
+                    },
+                    {
+                      :component    => "text-field",
+                      :id           => "endpoints.default.port",
+                      :name         => "endpoints.default.port",
+                      :label        => _("API Port"),
+                      :type         => "number",
+                      :initialValue => 13_000,
+                      :isRequired   => true,
+                      :validate     => [{:type => "required"}],
+                    },
+                    {
+                      :component  => "text-field",
+                      :id         => "authentications.default.userid",
+                      :name       => "authentications.default.userid",
+                      :label      => "Username",
+                      :isRequired => true,
+                      :validate   => [{:type => "required"}],
+                    },
+                    {
+                      :component  => "password-field",
+                      :id         => "authentications.default.password",
+                      :name       => "authentications.default.password",
+                      :label      => "Password",
+                      :type       => "password",
+                      :isRequired => true,
+                      :validate   => [{:type => "required"}],
+                    },
+                    {
+                      :component => 'sub-form',
+                      :id        => 'events-tab',
+                      :name      => 'events-tab',
+                      :title     => _('Events'),
+                      :fields    => [
+                        {
+                          :component    => 'protocol-selector',
+                          :id           => 'event_stream_selection',
+                          :name         => 'event_stream_selection',
+                          :skipSubmit   => true,
+                          :initialValue => 'none',
+                          :label        => _('Type'),
+                          :options      => [
+                            {
+                              :label => _('Disabled'),
+                              :value => 'none',
+                            },
+                            {
+                              :label => _('Ceilometer'),
+                              :value => 'ceilometer',
+                            },
+                            {
+                              :label => _('STF'),
+                              :value => 'stf',
+                              :pivot => 'endpoints.stf.hostname',
+                            },
+                            {
+                              :label => _('AMQP'),
+                              :value => 'amqp',
+                              :pivot => 'endpoints.amqp.hostname',
+                            },
+                          ],
+                        },
+                        {
+                          :component              => 'sub-form',
+                          :id                     => 'endpoints.amqp.valid',
+                          :name                   => 'endpoints.amqp.valid',
+                          :validationDependencies => %w[type event_stream_selection],
+                          :condition              => {
+                            :when => 'event_stream_selection',
+                            :is   => 'amqp',
+                          },
+                          :fields                 => [
+                            {
+                              :component  => "text-field",
+                              :id         => "endpoints.amqp.hostname",
+                              :name       => "endpoints.amqp.hostname",
+                              :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                              :isRequired => true,
+                              :validate   => [{:type => "required"}],
+                            },
+                            {
+                              :component    => "text-field",
+                              :id           => "endpoints.amqp.port",
+                              :name         => "endpoints.amqp.port",
+                              :label        => _("API Port"),
+                              :type         => "number",
+                              :isRequired   => true,
+                              :initialValue => 5672,
+                              :validate     => [{:type => "required"}],
+                            },
+                            {
+                              :component  => "text-field",
+                              :id         => "authentications.amqp.userid",
+                              :name       => "authentications.amqp.userid",
+                              :label      => "Username",
+                              :isRequired => true,
+                              :validate   => [{:type => "required"}],
+                            },
+                            {
+                              :component  => "password-field",
+                              :id         => "authentications.amqp.password",
+                              :name       => "authentications.amqp.password",
+                              :label      => "Password",
+                              :type       => "password",
+                              :isRequired => true,
+                              :validate   => [{:type => "required"}],
+                            },
+                          ],
+                        },
+                        {
+                          :component              => 'sub-form',
+                          :id                     => 'endpoints.stf.valid',
+                          :name                   => 'endpoints.stf.valid',
+                          :validationDependencies => %w[type event_stream_selection],
+                          :condition              => {
+                            :when => 'event_stream_selection',
+                            :is   => 'stf',
+                          },
+                          :fields                 => [
+                            {
+                              :component    => "select",
+                              :id           => "endpoints.stf.security_protocol",
+                              :name         => "endpoints.stf.security_protocol",
+                              :label        => _("Security Protocol"),
+                              :isRequired   => true,
+                              :initialValue => 'ssl-with-validation',
+                              :validate     => [{:type => "required"}],
+                              :options      => [
+                                {
+                                  :label => _("SSL without validation"),
+                                  :value => "ssl-no-validation"
+                                },
+                                {
+                                  :label => _("SSL"),
+                                  :value => "ssl-with-validation"
+                                },
+                                {
+                                  :label => _("Non-SSL"),
+                                  :value => "non-ssl"
+                                }
+                              ]
+                            },
+                            {
+                              :component  => "text-field",
+                              :id         => "endpoints.stf.hostname",
+                              :name       => "endpoints.stf.hostname",
+                              :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                              :isRequired => true,
+                              :validate   => [{:type => "required"}],
+                            },
+                            {
+                              :component    => "text-field",
+                              :id           => "endpoints.stf.port",
+                              :name         => "endpoints.stf.port",
+                              :label        => _("API Port"),
+                              :type         => "number",
+                              :isRequired   => true,
+                              :initialValue => 5666,
+                              :validate     => [{:type => "required"}],
+                            },
+                          ]
+                        }
+                      ],
+                    },
+                  ]
+                },
+              ]
+            },
+            {
+              :component => 'sub-form',
+              :id        => 'ssh_keypair-tab',
+              :name      => 'ssh_keypair-tab',
+              :title     => _('RSA key pair'),
+              :fields    => [
+                :component => 'provider-credentials',
+                :id        => 'endpoints.ssh_keypair.valid',
+                :name      => 'endpoints.ssh_keypair.valid',
                 :fields    => [
                   {
-                    :component              => 'validate-provider-credentials',
-                    :id                     => 'authentications.default.valid',
-                    :name                   => 'authentications.default.valid',
-                    :skipSubmit             => true,
-                    :isRequired             => true,
-                    :validationDependencies => %w[name type api_version provider_region uid_ems],
-                    :fields                 => [
-                      {
-                        :component    => "select",
-                        :id           => "endpoints.default.security_protocol",
-                        :name         => "endpoints.default.security_protocol",
-                        :label        => _("Security Protocol"),
-                        :isRequired   => true,
-                        :initialValue => 'ssl-with-validation',
-                        :validate     => [{:type => "required"}],
-                        :options      => [
-                          {
-                            :label => _("SSL without validation"),
-                            :value => "ssl-no-validation"
-                          },
-                          {
-                            :label => _("SSL"),
-                            :value => "ssl-with-validation"
-                          },
-                          {
-                            :label => _("Non-SSL"),
-                            :value => "non-ssl"
-                          }
-                        ]
-                      },
-                      {
-                        :component  => "text-field",
-                        :id         => "endpoints.default.hostname",
-                        :name       => "endpoints.default.hostname",
-                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                      {
-                        :component    => "text-field",
-                        :id           => "endpoints.default.port",
-                        :name         => "endpoints.default.port",
-                        :label        => _("API Port"),
-                        :type         => "number",
-                        :initialValue => 13_000,
-                        :isRequired   => true,
-                        :validate     => [{:type => "required"}],
-                      },
-                      {
-                        :component  => "text-field",
-                        :id         => "authentications.default.userid",
-                        :name       => "authentications.default.userid",
-                        :label      => "Username",
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                      {
-                        :component  => "password-field",
-                        :id         => "authentications.default.password",
-                        :name       => "authentications.default.password",
-                        :label      => "Password",
-                        :type       => "password",
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                    ]
-                  },
-                ]
-              },
-              {
-                :component => 'tab-item',
-                :id        => 'events-tab',
-                :name      => 'events-tab',
-                :title     => _('Events'),
-                :fields    => [
-                  {
-                    :component    => 'protocol-selector',
-                    :id           => 'event_stream_selection',
-                    :name         => 'event_stream_selection',
-                    :skipSubmit   => true,
-                    :initialValue => 'none',
-                    :label        => _('Type'),
-                    :options      => [
-                      {
-                        :label => _('Disabled'),
-                        :value => 'none',
-                      },
-                      {
-                        :label => _('Ceilometer'),
-                        :value => 'ceilometer',
-                      },
-                      {
-                        :label => _('STF'),
-                        :value => 'stf',
-                        :pivot => 'endpoints.stf.hostname',
-                      },
-                      {
-                        :label => _('AMQP'),
-                        :value => 'amqp',
-                        :pivot => 'endpoints.amqp.hostname',
-                      },
-                    ],
-                  },
-                  {
-                    :component              => 'validate-provider-credentials',
-                    :id                     => 'endpoints.ceilometer.valid',
-                    :name                   => 'endpoints.ceilometer.valid',
-                    :skipSubmit             => true,
-                    :isRequired             => true,
-                    :validationDependencies => %w[type event_stream_selection authentications.default.valid],
-                    :condition              => {
-                      :when => 'event_stream_selection',
-                      :is   => 'ceilometer',
+                    :component    => 'text-field',
+                    :hideField    => true,
+                    :label        => 'ssh_keypair',
+                    :id           => 'endpoints.ssh_keypair',
+                    :name         => 'endpoints.ssh_keypair',
+                    :initialValue => '',
+                    :condition    => {
+                      :when       => 'authentications.ssh_keypair.userid',
+                      :isNotEmpty => true,
                     },
-                    :fields                 => [
-                      {
-                        :component  => "text-field",
-                        :id         => "endpoints.ceilometer.hostname",
-                        :name       => "endpoints.ceilometer.hostname",
-                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
-                        :isRequired => false
-                      },
-                    ]
                   },
                   {
-                    :component              => 'validate-provider-credentials',
-                    :id                     => 'endpoints.amqp.valid',
-                    :name                   => 'endpoints.amqp.valid',
-                    :skipSubmit             => true,
-                    :isRequired             => true,
-                    :validationDependencies => %w[type event_stream_selection],
-                    :condition              => {
-                      :when => 'event_stream_selection',
-                      :is   => 'amqp',
-                    },
-                    :fields                 => [
-                      {
-                        :component  => "text-field",
-                        :id         => "endpoints.amqp.hostname",
-                        :name       => "endpoints.amqp.hostname",
-                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                      {
-                        :component    => "text-field",
-                        :id           => "endpoints.amqp.port",
-                        :name         => "endpoints.amqp.port",
-                        :label        => _("API Port"),
-                        :type         => "number",
-                        :isRequired   => true,
-                        :initialValue => 5672,
-                        :validate     => [{:type => "required"}],
-                      },
-                      {
-                        :component  => "text-field",
-                        :id         => "authentications.amqp.userid",
-                        :name       => "authentications.amqp.userid",
-                        :label      => "Username",
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                      {
-                        :component  => "password-field",
-                        :id         => "authentications.amqp.password",
-                        :name       => "authentications.amqp.password",
-                        :label      => "Password",
-                        :type       => "password",
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                    ],
+                    :component => "text-field",
+                    :id        => "authentications.ssh_keypair.userid",
+                    :name      => "authentications.ssh_keypair.userid",
+                    :label     => _("Username"),
                   },
                   {
-                    :component              => 'validate-provider-credentials',
-                    :id                     => 'endpoints.stf.valid',
-                    :name                   => 'endpoints.stf.valid',
-                    :skipSubmit             => true,
-                    :isRequired             => true,
-                    :validationDependencies => %w[type event_stream_selection],
-                    :condition              => {
-                      :when => 'event_stream_selection',
-                      :is   => 'stf',
-                    },
-                    :fields                 => [
-                      {
-                        :component    => "select",
-                        :id           => "endpoints.stf.security_protocol",
-                        :name         => "endpoints.stf.security_protocol",
-                        :label        => _("Security Protocol"),
-                        :isRequired   => true,
-                        :initialValue => 'ssl-with-validation',
-                        :validate     => [{:type => "required"}],
-                        :options      => [
-                          {
-                            :label => _("SSL without validation"),
-                            :value => "ssl-no-validation"
-                          },
-                          {
-                            :label => _("SSL"),
-                            :value => "ssl-with-validation"
-                          },
-                          {
-                            :label => _("Non-SSL"),
-                            :value => "non-ssl"
-                          }
-                        ]
-                      },
-                      {
-                        :component  => "text-field",
-                        :id         => "endpoints.stf.hostname",
-                        :name       => "endpoints.stf.hostname",
-                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
-                        :isRequired => true,
-                        :validate   => [{:type => "required"}],
-                      },
-                      {
-                        :component    => "text-field",
-                        :id           => "endpoints.stf.port",
-                        :name         => "endpoints.stf.port",
-                        :label        => _("API Port"),
-                        :type         => "number",
-                        :isRequired   => true,
-                        :initialValue => 5666,
-                        :validate     => [{:type => "required"}],
-                      },
-                    ]
-                  }
+                    :component      => "password-field",
+                    :id             => "authentications.ssh_keypair.auth_key",
+                    :name           => "authentications.ssh_keypair.auth_key",
+                    :componentClass => 'textarea',
+                    :rows           => 10,
+                    :label          => _("Private Key"),
+                  },
                 ],
-              },
-              {
-                :component => 'tab-item',
-                :id        => 'ssh_keypair-tab',
-                :name      => 'ssh_keypair-tab',
-                :title     => _('RSA key pair'),
-                :fields    => [
-                  :component => 'provider-credentials',
-                  :id        => 'endpoints.ssh_keypair.valid',
-                  :name      => 'endpoints.ssh_keypair.valid',
-                  :fields    => [
-                    {
-                      :component    => 'text-field',
-                      :hideField    => true,
-                      :label        => 'ssh_keypair',
-                      :id           => 'endpoints.ssh_keypair',
-                      :name         => 'endpoints.ssh_keypair',
-                      :initialValue => '',
-                      :condition    => {
-                        :when       => 'authentications.ssh_keypair.userid',
-                        :isNotEmpty => true,
-                      },
-                    },
-                    {
-                      :component => "text-field",
-                      :id        => "authentications.ssh_keypair.userid",
-                      :name      => "authentications.ssh_keypair.userid",
-                      :label     => _("Username"),
-                    },
-                    {
-                      :component      => "password-field",
-                      :id             => "authentications.ssh_keypair.auth_key",
-                      :name           => "authentications.ssh_keypair.auth_key",
-                      :componentClass => 'textarea',
-                      :rows           => 10,
-                      :label          => _("Private Key"),
-                    },
-                  ],
-                ],
-              },
-            ],
+              ],
+            },
           ],
         },
       ]

--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -232,9 +232,13 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     :id           => 'event_stream_selection',
                     :name         => 'event_stream_selection',
                     :skipSubmit   => true,
-                    :initialValue => 'ceilometer',
+                    :initialValue => 'none',
                     :label        => _('Type'),
                     :options      => [
+                      {
+                        :label => _('Disabled'),
+                        :value => 'none',
+                      },
                       {
                         :label => _('Ceilometer'),
                         :value => 'ceilometer',
@@ -252,16 +256,25 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
                     ],
                   },
                   {
-                    :component    => 'text-field',
-                    :hideField    => true,
-                    :label        => 'ceilometer',
-                    :id           => 'endpoints.ceilometer',
-                    :name         => 'endpoints.ceilometer',
-                    :initialValue => '',
-                    :condition    => {
+                    :component              => 'validate-provider-credentials',
+                    :id                     => 'endpoints.ceilometer.valid',
+                    :name                   => 'endpoints.ceilometer.valid',
+                    :skipSubmit             => true,
+                    :isRequired             => true,
+                    :validationDependencies => %w[type event_stream_selection authentications.default.valid],
+                    :condition              => {
                       :when => 'event_stream_selection',
                       :is   => 'ceilometer',
                     },
+                    :fields                 => [
+                      {
+                        :component  => "text-field",
+                        :id         => "endpoints.ceilometer.hostname",
+                        :name       => "endpoints.ceilometer.hostname",
+                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                        :isRequired => false
+                      },
+                    ]
                   },
                   {
                     :component              => 'validate-provider-credentials',

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -15,10 +15,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     def amqp_available?(password, params)
       require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
       OpenstackRabbitEventMonitor.available?(
-        :hostname => params[:amqp_hostname],
-        :username => params[:amqp_userid],
+        :hostname => params[:hostname],
+        :username => params[:userid],
         :password => ManageIQ::Password.try_decrypt(password),
-        :port     => params[:amqp_api_port] || params[:amqp_port].to_s
+        :port     => params[:api_port] || params[:port].to_s
       )
     end
     private :amqp_available?
@@ -26,9 +26,9 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     def stf_available?(_password, params)
       require 'manageiq/providers/openstack/legacy/events/openstack_stf_event_monitor'
       OpenstackStfEventMonitor.available?(
-        :hostname          => params[:stf_hostname],
-        :port              => params[:stf_api_port] || params[:stf_port].to_s,
-        :security_protocol => params[:stf_security_protocol]
+        :hostname          => params[:hostname],
+        :port              => params[:api_port] || params[:port].to_s,
+        :security_protocol => params[:security_protocol]
       )
     end
     private :stf_available?
@@ -43,10 +43,10 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.name                   = params[:name].strip
       ems.provider_region        = params[:provider_region]
       ems.api_version            = params[:api_version].strip
-      ems.security_protocol      = params[:default_security_protocol].strip
+      ems.security_protocol      = params[:security_protocol].strip
       ems.keystone_v3_domain_id  = params[:uid_ems]
 
-      user, hostname, port = params[:default_userid], params[:default_hostname].strip, params[:default_port].try(:strip)
+      user, hostname, port = params[:userid], params[:hostname].strip, params[:port].try(:strip)
 
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
       authentication = {:userid => user, :password => ManageIQ::Password.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}
@@ -98,25 +98,35 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     #   }
     # }
     def verify_credentials(args)
-      endpoint_name = args.dig("endpoints").keys.first
-      endpoint = args.dig("endpoints", endpoint_name)
-      authentication = args.dig("authentications", endpoint_name)
+      endpoints = args["endpoints"] || {}
+      authentications = args["authentications"]
 
-      userid, password = authentication&.values_at('userid', 'password')
-      password = ManageIQ::Password.try_decrypt(password)
-      password ||= find(args["id"]).authentication_password(endpoint_name) if args["id"]
-
-      params = %w[hostname port security_protocol].reduce(
-        [endpoint_name, 'userid'].join('_')   => userid,
-        [endpoint_name, 'password'].join('_') => password
-      ) do |obj, item|
-        obj.merge([endpoint_name, item].join('_') => endpoint.try(:[], item))
+      # ceilometer has no additional endpoint info other than what is in the default endpoint
+      # but has to be verified separately
+      if args["event_stream_selection"] == "ceilometer"
+        endpoints["ceilometer"] = endpoints["default"]
+        authentications["ceilometer"] = authentications["default"]
       end
 
-      params.merge!(args.slice('name', 'provider_region', 'api_version', 'uid_ems'))
-      params['event_stream_selection'] = args['event_stream_selection'] if endpoint_name != 'default'
+      endpoints.each do |endpoint_name, endpoint|
+        authentication = authentications[endpoint_name]
 
-      !!raw_connect(password, params.symbolize_keys)
+        userid, password = authentication&.values_at('userid', 'password')
+        password = ManageIQ::Password.try_decrypt(password)
+        password ||= find(args["id"]).authentication_password(endpoint_name) if args["id"]
+
+        endpoint_params = endpoint.slice("hostname", "port", "security_protocol")
+        args_params     = args.slice('name', 'provider_region', 'api_version', 'uid_ems')
+
+        params = {
+          "userid"   => userid,
+          "password" => password
+        }.merge(endpoint_params).merge(args_params)
+
+        params['event_stream_selection'] = args['event_stream_selection'] if endpoint_name != 'default'
+
+        raise unless !!raw_connect(password, params.symbolize_keys)
+      end
     end
 
     def raw_connect(password, params, service = "Compute")

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -33,6 +33,11 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     end
     private :stf_available?
 
+    def ceilometer_available?(password, params)
+      ems_connect?(password, params, "Event")
+    end
+    private :ceilometer_available?
+
     def ems_connect?(password, params, service)
       ems = new
       ems.name                   = params[:name].strip
@@ -122,6 +127,8 @@ module ManageIQ::Providers::Openstack::ManagerMixin
         amqp_available?(password, params)
       when "stf"
         stf_available?(password, params)
+      when "ceilometer"
+        ceilometer_available?(password, params)
       else
         ems_connect?(password, params, service)
       end

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -162,13 +162,13 @@ describe ManageIQ::Providers::Openstack::CloudManager do
 
     it "accepts and decrypts encrypted passwords" do
       params = {
-        :name                      => 'dummy',
-        :provider_region           => '',
-        :api_version               => 'v2.0',
-        :default_security_protocol => 'non-ssl',
-        :default_userid            => 'admin',
-        :default_hostname          => 'address',
-        :default_port              => '5000'
+        :name              => 'dummy',
+        :provider_region   => '',
+        :api_version       => 'v2.0',
+        :security_protocol => 'non-ssl',
+        :userid            => 'admin',
+        :hostname          => 'address',
+        :port              => '5000'
       }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "admin",
@@ -183,13 +183,13 @@ describe ManageIQ::Providers::Openstack::CloudManager do
 
     it "works with unencrypted passwords" do
       params = {
-        :name                      => 'dummy',
-        :provider_region           => '',
-        :api_version               => 'v2.0',
-        :default_security_protocol => 'non-ssl',
-        :default_userid            => 'admin',
-        :default_hostname          => 'address',
-        :default_port              => '5000'
+        :name              => 'dummy',
+        :provider_region   => '',
+        :api_version       => 'v2.0',
+        :security_protocol => 'non-ssl',
+        :userid            => 'admin',
+        :hostname          => 'address',
+        :port              => '5000'
       }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "admin",
@@ -204,13 +204,13 @@ describe ManageIQ::Providers::Openstack::CloudManager do
 
     it "works with a non-default port" do
       params = {
-        :name                      => 'dummy',
-        :provider_region           => '',
-        :api_version               => 'v2.0',
-        :default_security_protocol => 'ssl-with-validation',
-        :default_userid            => 'admin',
-        :default_hostname          => 'address',
-        :default_port              => '13001'
+        :name              => 'dummy',
+        :provider_region   => '',
+        :api_version       => 'v2.0',
+        :security_protocol => 'ssl-with-validation',
+        :userid            => 'admin',
+        :hostname          => 'address',
+        :port              => '13001'
       }
       expect(OpenstackHandle::Handle).to receive(:raw_connect).with(
         "admin",


### PR DESCRIPTION
We currently assume that if we can connect to OpenStack Compute then we will be able to connect to Ceilometer, however this isn't always the case

- [x] Update DDF form to pass event endpoint with default credentials and verify in one step
- [x] Update verify_credentials to verify all endpoints
- [x] Live test on an Openstack without ceilometer (aka microstack) raises service not found error
- [x] Live test on an Openstack with ceilometer/stf/amqp 