### PR TITLE
Use standard CRUD names for HostAggregate supports

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -32,7 +32,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   include ManageIQ::Providers::Openstack::ManagerMixin
   include ManageIQ::Providers::Openstack::IdentitySyncMixin
 
-  supports :auth_key_pair_create
   supports :catalog
   supports :provisioning
   supports :cloud_tenants
@@ -45,7 +44,6 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     end
   end
   supports :create_flavor
-  supports :create_host_aggregate
   supports :label_mapping
   supports :metrics
   supports :storage_manager

--- a/app/models/manageiq/providers/openstack/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/auth_key_pair.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair < ManageIQ::Providers::CloudManager::AuthKeyPair
   include ManageIQ::Providers::Openstack::HelperMethods
 
+  supports :create
   supports :delete
 
   def self.raw_create_key_pair(ext_management_system, create_options)

--- a/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/host_aggregate.rb
@@ -1,8 +1,9 @@
 class ManageIQ::Providers::Openstack::CloudManager::HostAggregate < ::HostAggregate
   include ManageIQ::Providers::Openstack::HelperMethods
 
-  supports :update_aggregate
-  supports :delete_aggregate
+  supports :create
+  supports :update
+  supports :delete
   supports :add_host
   supports :remove_host
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
@@ -41,7 +41,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
 
   describe 'validations' do
     it 'ems supports auth_key_pair_create' do
-      expect(ems.supports?(:auth_key_pair_create)).to eq(true)
+      expect(ems.class_by_ems("AuthKeyPair").supports?(:create)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Required for:
* https://github.com/ManageIQ/manageiq-api/pull/1098