### PR TITLE
Don't hard code cloud_tenant STI type

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -71,9 +71,7 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
   # model_class defined due to ovirt dependency
   def add_cloud_tenants
-    add_collection_with_ems_param(cloud, :cloud_tenants) do |builder|
-      builder.add_properties(:model_class => ManageIQ::Providers::Openstack::CloudManager::CloudTenant)
-    end
+    add_collection_with_ems_param(cloud, :cloud_tenants)
   end
 
   # model_class defined due to ovirt dependency


### PR DESCRIPTION
This causes any subclasses of openstack (e.g. powervc) to have the wrong type on their cloud_tenant records

We're already checking in specs that the cloud_tenant records have the appropriate class name for this repo