### PR TITLE
Use the snapshots collection from core

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/cloud_manager.rb
@@ -211,14 +211,12 @@ class ManageIQ::Providers::Openstack::Inventory::Parser::CloudManager < ManageIQ
       operating_system.version = i.try(:os_version)
 
       if snapshot?(i) && parent_server_uid
-        snapshot = persister.snapshots.find_or_build(i.id)
+        snapshot = persister.snapshots.find_or_build_by(:uid => i.id, :vm_or_template => persister.vms.lazy_find(parent_server_uid))
         snapshot.name = i.name
-        snapshot.uid  = i.id
         snapshot.uid_ems = i.id
         snapshot.ems_ref = i.id
         snapshot.create_time = i.created_at
         snapshot.description = i.attributes[:description]
-        snapshot.vm_or_template = persister.vms.lazy_find(parent_server_uid)
       end
     end
   end

--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -28,18 +28,18 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
 
     add_orchestration_stack_collections
 
-    %i(hardwares
-       operating_systems
-       disks
-       networks).each do |name|
-
+    %i[
+      hardwares
+      operating_systems
+      disks
+      snapshots
+      networks
+    ].each do |name|
       add_collection(cloud, name)
     end
 
     # Custom processing of Ancestry
     add_collection(cloud, :vm_and_miq_template_ancestry)
-
-    add_snapshots
 
     add_vm_and_template_labels
     add_vm_and_template_taggings
@@ -111,14 +111,6 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
         builder.add_properties(:targeted => false)
       end
       builder.add_default_values(:resource => manager)
-    end
-  end
-
-  def add_snapshots
-    add_collection(cloud, :snapshots) do |builder|
-      builder.add_properties(:model_class => ::Snapshot)
-      builder.add_properties(:parent_inventory_collections => %i[vms miq_templates])
-      builder.add_properties(:complete => !targeted?)
     end
   end
 


### PR DESCRIPTION
Now that the core persister has a snapshots inventory collection we can use that rather than redefine it here

Follow-up to https://github.com/ManageIQ/manageiq/pull/21629