### PR TITLE
Cleanup the TargetCollection persister

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/target_collection.rb
@@ -7,26 +7,10 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::TargetCollection < M
     true
   end
 
-  def strategy
-    :local_db_find_missing_references
-  end
-
-  def parent
-    if @init_network_collections
-      manager.try(:network_manager)
-    else
-      manager.presence
-    end
-  end
-
   def initialize_inventory_collections
     initialize_tag_mapper
     initialize_cloud_inventory_collections
-
-    @init_network_collections = true
     initialize_network_inventory_collections
-    @init_network_collections = false
-
     initialize_storage_inventory_collections
   end
 end


### PR DESCRIPTION
The strategy is handled automatically for targeted persisters and with the add_network_collection changes we can drop the parent ivar weirdness around adding the network manager collections.