### PR TITLE
Fixed cloud volumes add page missing fields

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -35,10 +35,6 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :isRequired   => true,
           :includeEmpty => true,
           :validate     => [{:type => 'required'}],
-          :condition    => {
-            :when => 'edit',
-            :is   => false,
-          },
           :options      => ems.cloud_tenants.map do |ct|
             {
               :label => ct.name,
@@ -52,10 +48,6 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :id           => 'availability_zone_id',
           :label        => _('Availability Zone'),
           :includeEmpty => true,
-          :condition    => {
-            :when => 'edit',
-            :is   => false,
-          },
           :options      => ems.volume_availability_zones.map do |az|
             {
               :label => az.name,
@@ -69,10 +61,6 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :id           => 'volume_type',
           :label        => _('Cloud Volume Type'),
           :includeEmpty => true,
-          :condition    => {
-            :when => 'edit',
-            :is   => false,
-          },
           :options      => ems.cloud_volume_types.map do |cvt|
             {
               :label => cvt.name,


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/8077

Fixes the missing field issue for the add cloud volume form.

Before:
<img width="1516" alt="Screen Shot 2022-01-31 at 2 25 24 PM" src="https://user-images.githubusercontent.com/32444791/151859136-3893ec1e-764f-4dd8-8b56-090dcde81a09.png">


After:
<img width="1499" alt="Screen Shot 2022-01-31 at 2 16 13 PM" src="https://user-images.githubusercontent.com/32444791/151858923-fae99ebd-57c1-4e7a-acff-ec4c1d3616ae.png">
