### PR TITLE
Fix CloudVolume Create - DDF sends cloud_tenant_id not cloud_tenant record

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -87,7 +87,8 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
   def self.raw_create_volume(ext_management_system, options)
     options = options.symbolize_keys
 
-    cloud_tenant = options.delete(:cloud_tenant)
+    cloud_tenant_id = options.delete(:cloud_tenant_id)
+    cloud_tenant    = CloudTenant.find_by(:id => cloud_tenant_id) if cloud_tenant_id
     volume = nil
 
     # provide display_name for Cinder V1

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_spec.rb
@@ -38,7 +38,7 @@ describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVol
   describe 'volume actions' do
     context ".create_volume" do
       let(:the_new_volume) { double }
-      let(:volume_options) { {:cloud_tenant => tenant, :name => "new_name", :size => 2} }
+      let(:volume_options) { {"cloud_tenant_id" => tenant.id, "name" => "new_name", "size" => 2} }
 
       before do
         NotificationType.seed


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-openstack/pull/768 now that I am able to test with the proper UI form after https://github.com/ManageIQ/manageiq-providers-openstack/pull/769