### PR TITLE
Fix storage manager edit

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -72,6 +72,66 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     }
   end
 
+  def params_for_update
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'size',
+          :id         => 'size',
+          :label      => _('Size (in bytes)'),
+          :type       => 'number',
+          :step       => 1.gigabytes,
+          :isRequired => true,
+          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 0, :message => _('Size must be greater than or equal to 0')}],
+        },
+        {
+          :component  => 'select',
+          :name       => 'cloud_tenant_id',
+          :id         => 'cloud_tenant_id',
+          :label      => _('Cloud Tenant'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+          :isDisabled => !!id,
+          :options    => ext_management_system.cloud_tenants.map do |ct|
+            {
+              :label => ct.name,
+              :value => ct.id,
+            }
+          end,
+        },
+        {
+          :component    => 'select',
+          :name         => 'availability_zone_id',
+          :id           => 'availability_zone_id',
+          :label        => _('Availability Zone'),
+          :includeEmpty => true,
+          :isDisabled   => !!id,
+          :options      => ext_management_system.volume_availability_zones.map do |az|
+            {
+              :label => az.name,
+              :value => az.id,
+            }
+          end,
+        },
+        {
+          :component    => 'select',
+          :name         => 'volume_type',
+          :id           => 'volume_type',
+          :label        => _('Cloud Volume Type'),
+          :includeEmpty => true,
+          :isDisabled   => !!id,
+          :options      => ext_management_system.cloud_volume_types.map do |cvt|
+            {
+              :label => cvt.name,
+              :value => cvt.name,
+            }
+          end,
+        },
+      ]
+    }
+  end
+
   def self.raw_create_volume(ext_management_system, options)
     options = options.symbolize_keys
 


### PR DESCRIPTION
Due to API changes the Cloud volumes edit page was broken and would not load. This PR fixes this issue and allows the page to load correctly with all the fields that can't be edited set to disabled.

<img width="1493" alt="Screen Shot 2022-02-03 at 11 36 57 AM" src="https://user-images.githubusercontent.com/32444791/152386591-fa2444ac-c89f-4b18-a4dc-ef4862ae8fbb.png">

