### PR TITLE
Fixed cloud volume minimum size

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :type       => 'number',
           :step       => 1.gigabytes,
           :isRequired => true,
-          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 0, :message => _('Size must be greater than or equal to 0')}],
+          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 1, :message => _('Size must be greater than or equal to 1')}],
         },
         {
           :component    => 'select',
@@ -83,7 +83,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :type       => 'number',
           :step       => 1.gigabytes,
           :isRequired => true,
-          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 0, :message => _('Size must be greater than or equal to 0')}],
+          :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 1, :message => _('Size must be greater than or equal to 1')}],
         },
         {
           :component  => 'select',


### PR DESCRIPTION
When trying to create a cloud volume with size 0 it throws an error:
```
Expected([200, 202]) <=> Actual(400 Bad Request) excon.error.response
  :body => "{\"badRequest\": {\"code\": 400, \"message\": \"Invalid input for field/attribute size. Value: 0. 0 is less than the minimum of 1\"}}" 
  :cookies => [ ]
  :headers => { "Connection" => "keep-alive" "Content-Length" => "125" "Content-Type" => "application/json" "Date" => "Fri, 04 Feb 2022 17:14:50 GMT" "Server" => "nginx/1.19.0" "x-compute-request-id" => "req-5e9566bc-6c44-43f3-80c0-a4a34171798f" "x-openstack-request-id" => "req-5e9566bc-6c44-43f3-80c0-a4a34171798f" }
  :host => "192.168.0.23"
  :local_address => "192.168.0.75"
  :local_port => 61347
  :path => "/v2/a72fca25a78d41e2ac1492e4f3a9bbb2/volumes"
  :port => 8776
  :reason_phrase => "Bad Request"
  :remote_ip => "192.168.0.23"
  :status => 400
  :status_line => "HTTP/1.1 400 Bad Request\r\n" 
```

Fixed the minimum size validation to account for this error.

@miq-bot add-label bug