### PR TITLE
The Openstack NetworkManager cannot be added standalone

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -12,7 +12,6 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 
-  supports :create
   supports :create_network_router
   supports :cloud_subnet_create
 


### PR DESCRIPTION
This is a child manager of a CloudManager and is not supported for create by itself.

This had `supports :create` incorrectly for a long time, but after https://github.com/ManageIQ/manageiq/pull/21573 started checking for it now it shows up as supported for creation.