### PR TITLE
Minor Cleanup child manager init/ensure_

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -21,6 +21,11 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   require_nested :Template
   require_nested :Vm
 
+  has_one :network_manager,
+          :foreign_key => :parent_ems_id,
+          :class_name  => "ManageIQ::Providers::Openstack::NetworkManager",
+          :autosave    => true,
+          :dependent   => :destroy
   has_many :storage_managers,
            :foreign_key => :parent_ems_id,
            :class_name  => "ManageIQ::Providers::StorageManager",
@@ -442,19 +447,15 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   end
 
   def ensure_network_manager
-    build_network_manager(:type => 'ManageIQ::Providers::Openstack::NetworkManager') unless network_manager
+    build_network_manager unless network_manager
   end
 
   def ensure_cinder_manager
-    return false if cinder_manager
-    build_cinder_manager
-    true
+    build_cinder_manager unless cinder_manager
   end
 
   def ensure_swift_manager
-    return false if swift_manager
-    build_swift_manager
-    true
+    build_swift_manager unless swift_manager
   end
 
   after_save :save_on_other_managers

--- a/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/swift_manager_mixin.rb
@@ -12,10 +12,4 @@ module ManageIQ::Providers::Openstack::SwiftManagerMixin
              :to        => :swift_manager,
              :allow_nil => true
   end
-
-  private
-
-  def ensure_swift_manager
-    swift_manager || build_swift_manager
-  end
 end


### PR DESCRIPTION
Similar in vein to #677
This was part of a very old more drastic PR that I wrote.

I noticed since cinder and swift already have this refactor here, implementing it for network manager makes sense

- Don't subclass from core NetworkManager. (mimics work already done for swift/cinder)
- Remove duplicate `ensure_swift_manager` (all of the ensures seem to be defined in the parent class right now
except for network manager

Keeping duplicate `ensure_network_manager`. It feels like it is best to define where it is actually used