### PR TITLE
Added fields for cloud object store container form

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
@@ -7,9 +7,16 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectS
 
   def self.params_for_create(ems)
     cloud_tenants = ems.parent_manager.cloud_tenants
-
     {
       :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'name',
+          :id         => 'name',
+          :label      => _('Container Name'),
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+        },
         {
           :component    => 'select',
           :name         => 'cloud_tenant_id',
@@ -18,10 +25,6 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectS
           :isRequired   => true,
           :includeEmpty => true,
           :validate     => [{:type => 'required'}],
-          :condition    => {
-            :when => 'edit',
-            :is   => false,
-          },
           :options      => cloud_tenants.map do |ct|
             {:label => ct.name, :value => ct.id}
           end
@@ -31,11 +34,12 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectS
   end
 
   def self.raw_cloud_object_store_container_create(ext_management_system, options)
-    cloud_tenant = options.delete(:cloud_tenant)
+    cloud_tenant_id = options.delete(:cloud_tenant_id)
+    cloud_tenant = CloudTenant.find_by(:id => cloud_tenant_id) if cloud_tenant_id
     project_id = ''
 
-    options[:key] = options["name"]
-    with_notification(:cloud_container_create, :options => {:cloud_container_name => options["name"]}) do
+    options[:key] = options[:name]
+    with_notification(:cloud_container_create, :options => {:cloud_container_name => options[:name]}) do
       ext_management_system.with_provider_connection(swift_connection_options(cloud_tenant)) do |service|
         project_id = service.get_current_tenant.id
         directory = service.directories.new(options)
@@ -43,8 +47,8 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectS
       end
     end
 
-    {:ems_ref => "#{project_id}/#{options["name"]}", :key => options["name"], :object_count => 0, :bytes => 0,
-     :ems_id => ext_management_system.id, :cloud_tenant_id => options["cloud_tenant_id"]}
+    {:ems_ref => "#{project_id}/#{options[:name]}", :key => options[:name], :object_count => 0, :bytes => 0,
+     :ems_id => ext_management_system.id, :cloud_tenant_id => cloud_tenant_id}
   rescue => e
     _log.error("container=[#{options[:name]}], error: #{e}")
     parsed_error = parse_error_message_from_neutron_response(e)


### PR DESCRIPTION
part of: https://github.com/ManageIQ/manageiq-api/pull/1142

Moved fields to provider repo for the create cloud object store container form as well as add support for creating cloud object store container form.

Fields:
<img width="1346" alt="Screen Shot 2022-03-28 at 8 25 51 AM" src="https://user-images.githubusercontent.com/32444791/160397489-db8d3c47-77cc-4053-a15e-dc530ec6ee46.png">

