### PR TITLE
Improve error messages in verify_credentials

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -154,7 +154,9 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       when Excon::Errors::Timeout
         MiqException::MiqUnreachableError.new("Login attempt timed out")
       when Excon::Errors::SocketError
-        MiqException::MiqHostError.new("Socket error: #{err.message}")
+        MiqException::MiqHostError.new("Socket error: #{err.socket_error}")
+      when Excon::Error::BadRequest
+        MiqException::MiqHostError.new("Bad request: #{err.response.body}")
       when MiqException::MiqInvalidCredentialsError, MiqException::MiqHostError, MiqException::ServiceNotAvailable
         err
       else


### PR DESCRIPTION
Improve the error message returned in a number of cases when verifying credentials

Non-ssl to an SSL endpoint
Before:
![Screenshot from 2022-04-06 12-23-32](https://user-images.githubusercontent.com/12851112/162023126-12cea286-8399-4989-b1f3-ed25eb5807f2.png)

After:
![Screenshot from 2022-04-06 12-23-55](https://user-images.githubusercontent.com/12851112/162023041-40831067-eedb-44f5-8918-41000833041c.png)


SSL Verify with self-signed cert:
Before:
![Screenshot from 2022-04-06 12-23-06](https://user-images.githubusercontent.com/12851112/162022939-f019147c-0c97-4714-bdee-0b3f79acbfdc.png)

After:
![Screenshot from 2022-04-06 12-24-04](https://user-images.githubusercontent.com/12851112/162023179-a394e7c9-35e2-4b08-99cf-df6daac02cfd.png)




