### PR TITLE
Improve OpenStack operations error parsing

### DIFF
--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -24,8 +24,8 @@ module ManageIQ::Providers::Openstack::HelperMethods
     end
 
     def parse_error_message_from_fog_response(exception)
-      exception_string = exception.to_s
-      matched_message = exception_string.match(/message\\\": \\\"(.*)\\\", /)
+      exception_string = exception.respond_to?(:response) ? exception.response&.body : exception.to_s
+      matched_message = exception_string.match(/"message": "(.*)"/)
       matched_message ? matched_message[1] : exception_string
     end
 
@@ -68,7 +68,7 @@ module ManageIQ::Providers::Openstack::HelperMethods
         yield
       rescue => ex
         # Fog specific
-        error_message = parse_error_message_from_fog_response(ex.to_s)
+        error_message = parse_error_message_from_fog_response(ex)
         Notification.create(:type => "#{type}_error".to_sym, :options => error_options.merge(:error_message => error_message), **named_options)
         raise
       else

--- a/app/models/manageiq/providers/openstack/helper_methods.rb
+++ b/app/models/manageiq/providers/openstack/helper_methods.rb
@@ -25,8 +25,23 @@ module ManageIQ::Providers::Openstack::HelperMethods
 
     def parse_error_message_from_fog_response(exception)
       exception_string = exception.respond_to?(:response) ? exception.response&.body : exception.to_s
-      matched_message = exception_string.match(/"message": "(.*)"/)
-      matched_message ? matched_message[1] : exception_string
+
+      error_message = nil
+
+      begin
+        parsed_exception = JSON.parse(exception_string)
+
+        # See if the message is at the root
+        error_message = parsed_exception["message"]
+        # Otherwise, see if the message is in a nested hash
+        error_message ||= parsed_exception.values.detect { |v| v.include?("message") }.try(:[], "message")
+      rescue JSON::ParserError
+        # Otherwise, just use the raw exception
+        error_message = exception_string.match(/"message": "(.*)"/)&.captures&.first
+      end
+
+      # If nothing matches return the original exception_string
+      error_message || exception_string
     end
 
     def parse_error_message_from_neutron_response(exception)

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -149,8 +149,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     end
     {:ems_ref => volume.id, :status => volume.status, :name => options[:name]}
   rescue => e
-    _log.error "volume=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqVolumeCreateError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume=[#{options[:name]}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeCreateError, parsed_error, e.backtrace
   end
 
   def raw_update_volume(options)
@@ -165,8 +167,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error "volume=[#{name}], error: #{e}"
-    raise MiqException::MiqVolumeUpdateError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeUpdateError, parsed_error, e.backtrace
   end
 
   def raw_delete_volume
@@ -194,8 +198,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error "backup=[#{name}], error: #{e}"
-    raise MiqException::MiqVolumeBackupCreateError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("backup=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeBackupCreateError, parsed_error, e.backtrace
   end
 
   def backup_create_queue(userid, options = {})
@@ -220,8 +226,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       backup.restore(ems_ref)
     end
   rescue => e
-    _log.error "volume=[#{name}], error: #{e}"
-    raise MiqException::MiqVolumeBackupRestoreError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeBackupRestoreError, parsed_error, e.backtrace
   end
 
   def backup_restore_queue(userid, backup_id)

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume/operations.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume/operations.rb
@@ -25,8 +25,10 @@ module ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolum
     end
   rescue => e
     volume_name = name.presence || ems_ref
-    _log.error("volume=[#{volume_name}], error: #{e}")
-    raise MiqException::MiqVolumeAttachError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume=[#{volume_name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeAttachError, parsed_error, e.backtrace
   end
 
   def raw_detach_volume(server_ems_ref)
@@ -41,7 +43,9 @@ module ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolum
     end
   rescue => e
     volume_name = name.presence || ems_ref
-    _log.error("volume=[#{volume_name}], error: #{e}")
-    raise MiqException::MiqVolumeDetachError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume=[#{volume_name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeDetachError, parsed_error, e.backtrace
   end
 end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_backup.rb
@@ -16,8 +16,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error("backup=[#{name}], error: #{e}")
-    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("backup=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqOpenstackApiRequestError, parsed_error, e.backtrace
   end
 
   def raw_delete
@@ -31,8 +33,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error("volume backup=[#{name}], error: #{e}")
-    raise MiqException::MiqOpenstackApiRequestError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("volume backup=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqOpenstackApiRequestError, parsed_error, e.backtrace
   end
 
   def with_provider_object

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_snapshot.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume_snapshot.rb
@@ -62,8 +62,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       :ext_management_system => ext_management_system,
     )
   rescue => e
-    _log.error "snapshot=[#{options[:name]}], error: #{e}"
-    raise MiqException::MiqVolumeSnapshotCreateError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("snapshot=[#{options[:name]}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeSnapshotCreateError, parsed_error, e.backtrace
   end
 
   def update_snapshot_queue(userid = "system", options = {})
@@ -94,8 +96,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error "snapshot=[#{name}], error: #{e}"
-    raise MiqException::MiqVolumeSnapshotUpdateError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("snapshot=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeSnapshotUpdateError, parsed_error, e.backtrace
   end
 
   def delete_snapshot_queue(userid = "system", _options = {})
@@ -132,8 +136,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
       end
     end
   rescue => e
-    _log.error "snapshot=[#{name}], error: #{e}"
-    raise MiqException::MiqVolumeSnapshotDeleteError, parse_error_message_from_fog_response(e), e.backtrace
+    parsed_error = parse_error_message_from_fog_response(e)
+
+    _log.error("snapshot=[#{name}], error: #{parsed_error}")
+    raise MiqException::MiqVolumeSnapshotDeleteError, parsed_error, e.backtrace
   end
 
   def self.connection_options(cloud_tenant = nil)


### PR DESCRIPTION
Cloud Volume Backup Create example:
Before:
![Screenshot from 2022-04-06 14-52-12](https://user-images.githubusercontent.com/12851112/162048599-3377894e-3181-446f-a7e2-da60de51dd39.png)

After:
![Screenshot from 2022-04-06 14-53-26](https://user-images.githubusercontent.com/12851112/162048616-e3d63f0d-a58b-48d3-910e-8f4e1be6d522.png)


I need to go through the rest of the operations and make sure we are printing the "parsed" exception to the logs otherwise we end up with:
```
[----] E, [2022-04-06T14:52:40.085584 #38769:b4280] ERROR -- evm: MIQ(cloud_volume_controller-wait_for_task): Unable to create backup for Cloud Volume "test": Expected([200, 202]) <=> Actual(400 Bad Request)
excon.error.response
  :body          => "{\"badRequest\": {\"code\": 400, \"message\": \"Invalid volume: Volume to be backed up must be available or in-use, but the current status is \\\"backing-up\\\".\"}}"
  :cookies       => [
  ]
  :headers       => {
    "Connection"             => "keep-alive"
    "Content-Length"         => "153"
    "Content-Type"           => "application/json"
    "Date"                   => "Wed, 06 Apr 2022 18:52:37 GMT"
    "Server"                 => "nginx/1.19.0"
    "x-compute-request-id"   => "req-404f445b-28f0-42bd-9c79-9263fa8f5737"
    "x-openstack-request-id" => "req-404f445b-28f0-42bd-9c79-9263fa8f5737"
  }
  :host          => "10.2.2.20"
  :local_address => "10.2.4.95"
  :local_port    => 46770
  :path          => "/v2/37f2c80029ea4056a090957ad79cddaf/backups"
  :port          => 8776
  :reason_phrase => "Bad Request"
  :remote_ip     => "10.2.2.20"
  :status        => 400
  :status_line   => "HTTP/1.1 400 Bad Request\r\n"
```