### PR TITLE
Fixed cloud tenant id for object store containers

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager/cloud_object_store_container.rb
@@ -26,7 +26,7 @@ class ManageIQ::Providers::Openstack::StorageManager::SwiftManager::CloudObjectS
           :includeEmpty => true,
           :validate     => [{:type => 'required'}],
           :options      => cloud_tenants.map do |ct|
-            {:label => ct.name, :value => ct.id}
+            {:label => ct.name, :value => ct.id.to_s}
           end
         }
       ]


### PR DESCRIPTION
Fixed an issue in this form where the cloud tenant selection gets reset when the user changes the name value.

<img width="1417" alt="Screen Shot 2022-04-11 at 3 31 17 PM" src="https://user-images.githubusercontent.com/32444791/162816791-1f72d50b-b122-4a00-8bb4-c9e4dad39b8b.png">

@miq-bot add_reviewer @agrare 
@miq-bot assign @agrare 
@miq-bot add-label bug