### PR TITLE
Fixed cloud tenant ids for cloud volumes and cloud subnets

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -38,7 +38,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :options      => ems.cloud_tenants.map do |ct|
             {
               :label => ct.name,
-              :value => ct.id,
+              :value => ct.id.to_s,
             }
           end,
         },
@@ -96,7 +96,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
           :options    => ext_management_system.cloud_tenants.map do |ct|
             {
               :label => ct.name,
-              :value => ct.id,
+              :value => ct.id.to_s,
             }
           end,
         },


### PR DESCRIPTION
Fixed issues in the cloud volumes add/edit form where changing text fields results in the cloud tenant or cloud network selected options being reset.

<img width="1401" alt="Screen Shot 2022-04-11 at 4 11 10 PM" src="https://user-images.githubusercontent.com/32444791/162823970-724e6a48-de77-44a5-b60e-cd8974da0bf6.png">

@miq-bot add_reviewer @agrare 
@miq-bot assign @agrare 
@miq-bot add-label bug