### PR TITLE
Remove former team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aufi @mansam @agrare @Fryguy @andyvesel
+* @agrare @Fryguy


### PR DESCRIPTION
Removing former team members from codeowners. We dont have write
permissions and want get rid of review requests github notification.

Sending greetings to the ManageIQ team!