### PR TITLE
Add custom schema fields to Openstack attach cloud volume form

### DIFF
--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -132,6 +132,19 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume
     }
   end
 
+  def params_for_attach
+    {
+      :fields => [
+        {
+          :component => 'text-field',
+          :name      => 'device_mountpoint',
+          :id        => 'device_mountpoint',
+          :label     => _('Device Mountpoint')
+        }
+      ]
+    }
+  end
+
   def self.raw_create_volume(ext_management_system, options)
     options = options.symbolize_keys
 


### PR DESCRIPTION
Companion PR to https://github.com/ManageIQ/manageiq-ui-classic/pull/8254

Part of the process for upgrading [_attach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_attach.html.haml#L33) and [_detach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_detach.html.haml#L25) to react as per https://github.com/ManageIQ/manageiq-ui-classic/issues/7603.