### PR TITLE
Use add_cloud_collection for cinder_manager

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager/cinder_manager.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::Cind
       cloud_tenants
       disks
     ].each do |name|
-      add_collection(cloud, name, shared_cloud_properties) do |builder|
+      add_cloud_collection(name, shared_cloud_properties) do |builder|
         builder.add_properties(:strategy => :local_db_cache_all) unless name == :disks
         builder.add_properties(:complete => false) if name == :disks
       end


### PR DESCRIPTION
Set the parent manager properly by using add_cloud_collection for referencing vms, etc... from the cinder manager refresh

Required for:
* https://github.com/ManageIQ/manageiq/pull/21650