### PR TITLE
Move all valid ems in zone to mixin

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
@@ -1,12 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::EventCatcher < ::MiqEventCatcher
-  require_nested :Runner
+  include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  def self.all_valid_ems_in_zone
-    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-    super.select do |ems|
-      ems.sync_event_monitor_available?.tap do |available|
-        _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
-      end
-    end
-  end
+  require_nested :Runner
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
-  include ManageIQ::Providers::Openstack::EventCatcherMixin
+  include ManageIQ::Providers::Openstack::EventCatcherRunnerMixin
 
   def add_openstack_queue(event)
     event_hash = ManageIQ::Providers::Openstack::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -1,0 +1,14 @@
+module ManageIQ::Providers::Openstack::EventCatcherMixin
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def all_valid_ems_in_zone
+      require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
+      super.select do |ems|
+        ems.sync_event_monitor_available?.tap do |available|
+          _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
+        end
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/openstack/event_catcher_runner_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_runner_mixin.rb
@@ -1,4 +1,4 @@
-module ManageIQ::Providers::Openstack::EventCatcherMixin
+module ManageIQ::Providers::Openstack::EventCatcherRunnerMixin
   # seems like most of this class could be boilerplate when compared against EventCatcherRhevm
   def event_monitor_handle
     require 'manageiq/providers/openstack/legacy/openstack_event_monitor'

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -1,16 +1,9 @@
 class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCatcher
+  include ManageIQ::Providers::Openstack::EventCatcherMixin
+
   require_nested :Runner
 
   def self.settings_name
     :event_catcher_openstack_infra
-  end
-
-  def self.all_valid_ems_in_zone
-    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-    super.select do |ems|
-      ems.sync_event_monitor_available?.tap do |available|
-        _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
-      end
-    end
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::InfraManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
-  include ManageIQ::Providers::Openstack::EventCatcherMixin
+  include ManageIQ::Providers::Openstack::EventCatcherRunnerMixin
 
   def add_openstack_queue(event)
     event_hash = ManageIQ::Providers::Openstack::InfraManager::EventParser.event_to_hash(event, @cfg[:ems_id])

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
@@ -1,16 +1,9 @@
 class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher < ::MiqEventCatcher
+  include ManageIQ::Providers::Openstack::EventCatcherMixin
+
   require_nested :Runner
 
   def self.settings_name
     :event_catcher_openstack_network
-  end
-
-  def self.all_valid_ems_in_zone
-    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-    super.select do |ems|
-      ems.sync_event_monitor_available?.tap do |available|
-        _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
-      end
-    end
   end
 end

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
-  include ManageIQ::Providers::Openstack::EventCatcherMixin
+  include ManageIQ::Providers::Openstack::EventCatcherRunnerMixin
 
   def add_openstack_queue(event)
     event_hash = ManageIQ::Providers::Openstack::NetworkManager::EventParser.event_to_hash(event, @cfg[:ems_id])

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher.rb
@@ -1,16 +1,9 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher < ::MiqEventCatcher
+  include ManageIQ::Providers::Openstack::EventCatcherMixin
+
   require_nested :Runner
 
   def self.settings_name
     :event_catcher_openstack_cinder
-  end
-
-  def self.all_valid_ems_in_zone
-    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-    super.select do |ems|
-      ems.sync_event_monitor_available?.tap do |available|
-        _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
-      end
-    end
   end
 end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher/runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
-  include ManageIQ::Providers::Openstack::EventCatcherMixin
+  include ManageIQ::Providers::Openstack::EventCatcherRunnerMixin
 
   def add_openstack_queue(event)
     event_hash = ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventParser.event_to_hash(event, @cfg[:ems_id])


### PR DESCRIPTION
Currently all Openstack EventCatchers copy&paste this `all_valid_ems_in_zone` override to check if the event service is available, move it to a mixin.

Steps:
1. Rename the current `EventCatcherMixin` -> `EventCatcherRunnerMixin` since it is included in the `EventCatcher::Runner` class
2. Move `all_valid_ems_in_zone` to a new `EventCatcherMixin`

Easier to review commit by commit