### PR TITLE
Improve event monitor available check

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -51,6 +51,9 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   end
   supports :create_flavor
   supports :label_mapping
+  supports :events do
+    unsupported_reason_add(:events, _("Events are not supported")) unless capabilities["events"]
+  end
   supports :metrics
   supports :storage_manager
 

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
     def all_valid_ems_in_zone
       require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
       super.select do |ems|
-        ems.sync_event_monitor_available?.tap do |available|
+        ems.event_monitor_available?.tap do |available|
           _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
         end
       end

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -1,7 +1,15 @@
 module ManageIQ::Providers::Openstack::EventCatcherMixin
   extend ActiveSupport::Concern
 
-  def self.all_valid_ems_in_zone
-    super.select { |ems| ems.supports?(:events) }
+  def after_initialize
+    super
+
+    do_exit("EMS ID [#{@cfg[:ems_id]}] event monitor unavailable.", 1) unless ems.event_monitor_available?
+  end
+
+  class_methods do
+    def all_valid_ems_in_zone
+      super.select { |ems| ems.supports?(:events) }
+    end
   end
 end

--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -1,14 +1,7 @@
 module ManageIQ::Providers::Openstack::EventCatcherMixin
   extend ActiveSupport::Concern
 
-  class_methods do
-    def all_valid_ems_in_zone
-      require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-      super.select do |ems|
-        ems.event_monitor_available?.tap do |available|
-          _log.info("Event Monitor unavailable for #{ems.name}.  Check log history for more details.") unless available
-        end
-      end
-    end
+  def self.all_valid_ems_in_zone
+    super.select { |ems| ems.supports?(:events) }
   end
 end

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -24,6 +24,9 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   supports :create
   supports :catalog
   supports :metrics
+  supports :events do
+    unsupported_reason_add(:events, _("Events are not supported")) unless capabilities["events"]
+  end
 
   def self.params_for_create
     @params_for_create ||= {

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -264,10 +264,6 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     false
   end
 
-  def sync_event_monitor_available?
-    event_monitor_options[:events_monitor] == :ceilometer ? authentication_status_ok? : event_monitor_available?
-  end
-
   def stop_event_monitor_queue_on_change
     if event_monitor_class && !self.new_record? && (authentications.detect{ |x| x.previous_changes.present? } ||
                                                     endpoints.detect{ |x| x.previous_changes.present? })

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -256,8 +256,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   end
 
   def event_monitor_available?
-    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
-    OpenstackEventMonitor.available?(event_monitor_options)
+    verify_event_monitor
   rescue => e
     _log.error("Exception trying to find openstack event monitor for #{name}(#{hostname}). #{e.message}")
     _log.error(e.backtrace.join("\n"))
@@ -310,17 +309,24 @@ module ManageIQ::Providers::Openstack::ManagerMixin
   end
   private :verify_amqp_credentials
 
+  def verify_event_monitor(_options = {})
+    require 'manageiq/providers/openstack/legacy/openstack_event_monitor'
+    OpenstackEventMonitor.available?(event_monitor_options)
+  rescue => err
+    miq_exception = translate_exception(err)
+    raise unless miq_exception
+
+    _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
+    raise miq_exception
+  end
+
   def verify_credentials(auth_type = nil, options = {})
-    auth_type ||= 'default'
+    verify_api_credentials
 
-    raise MiqException::MiqHostError, "No credentials defined" if self.missing_credentials?(auth_type)
+    capabilities["events"] = !!event_monitor_available?
+    save! if changed?
 
-    options[:auth_type] = auth_type
-    case auth_type.to_s
-    when 'default' then verify_api_credentials(options)
-    when 'amqp' then    verify_amqp_credentials(options)
-    else;           raise "Invalid OpenStack Authentication Type: #{auth_type.inspect}"
-    end
+    true
   end
 
   def required_credential_fields(_type)

--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -314,19 +314,23 @@ module ManageIQ::Providers::Openstack::ManagerMixin
     OpenstackEventMonitor.available?(event_monitor_options)
   rescue => err
     miq_exception = translate_exception(err)
-    raise unless miq_exception
-
-    _log.error("Error Class=#{err.class.name}, Message=#{err.message}")
-    raise miq_exception
+    raise miq_exception || err
   end
 
   def verify_credentials(auth_type = nil, options = {})
-    verify_api_credentials
+    case auth_type
+    when :default
+      verify_api_credentials
+    when :amqp
+      verify_amqp_credentials
+    else
+      verify_api_credentials
 
-    capabilities["events"] = !!event_monitor_available?
-    save! if changed?
+      capabilities["events"] = !!event_monitor_available?
+      save! if changed?
 
-    true
+      true
+    end
   end
 
   def required_credential_fields(_type)

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -36,6 +36,7 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
            :hostname,
            :default_endpoint,
            :endpoints,
+           :supports_events?,
            :to        => :parent_manager,
            :allow_nil => true
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -35,6 +35,7 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
            :endpoints,
            :cloud_tenants,
            :volume_availability_zones,
+           :supports_events?,
            :to        => :parent_manager,
            :allow_nil => true
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
@@ -1,19 +1,23 @@
 describe ManageIQ::Providers::Openstack::CloudManager::EventCatcher do
   before do
     _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryBot.create(:ems_openstack, :with_authentication, :zone => zone)
+    @ems = FactoryBot.create(:ems_openstack, :with_authentication, :zone => zone, :capabilities => {"events" => events_supported})
     allow(ManageIQ::Providers::Openstack::CloudManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 
-  it "logs info about EMS that do not have Event Monitors available" do
-    allow(@ems).to receive(:event_monitor_available?).and_return(false)
-    expect($log).to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).not_to include @ems
+  context "when EMS does not have Event Monitors available" do
+    let(:events_supported) { false }
+
+    it "doesn't include ems in all_valid_ems_in_zone" do
+      expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).not_to include(@ems)
+    end
   end
 
-  it "does not log info about unavailable Event Monitors when EMS can provide an event monitor" do
-    allow(@ems).to receive(:event_monitor_available?).and_return(true)
-    expect($log).not_to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).to include @ems
+  context "when EMS can provide an event monitor" do
+    let(:events_supported) { true }
+
+    it "includes ems in all_valid_ems_in_zone" do
+      expect(ManageIQ::Providers::Openstack::CloudManager::EventCatcher.all_valid_ems_in_zone).to include(@ems)
+    end
   end
 end

--- a/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
@@ -1,19 +1,23 @@
 describe ManageIQ::Providers::Openstack::InfraManager::EventCatcher do
   before do
     _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryBot.create(:ems_openstack_infra, :with_authentication, :zone => zone)
+    @ems = FactoryBot.create(:ems_openstack_infra, :with_authentication, :zone => zone, :capabilities => {"events" => events_supported})
     allow(ManageIQ::Providers::Openstack::InfraManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end
 
-  it "logs info about EMS that do not have Event Monitors available" do
-    allow(@ems).to receive(:event_monitor_available?).and_return(false)
-    expect($log).to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).not_to include @ems
+  context "when EMS does not have Event Monitors available" do
+    let(:events_supported) { false }
+
+    it "doesn't include ems in all_valid_ems_in_zone" do
+      expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).not_to include(@ems)
+    end
   end
 
-  it "does not log info about unavailable Event Monitors when EMS can provide an event monitor" do
-    allow(@ems).to receive(:event_monitor_available?).and_return(true)
-    expect($log).not_to receive(:info).with(/Event Monitor unavailable for #{@ems.name}/)
-    expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).to include @ems
+  context "when EMS can provide an event monitor" do
+    let(:events_supported) { true }
+
+    it "includes ems in all_valid_ems_in_zone" do
+      expect(ManageIQ::Providers::Openstack::InfraManager::EventCatcher.all_valid_ems_in_zone).to include(@ems)
+    end
   end
 end


### PR DESCRIPTION
Currently sync_event_monitor_available runs in the `EventCatcher#all_valid_ems_in_zone` method which is run A. by MiqServer not in the worker zone and B. every sync_workers loop multiple times per minute.

It is more advantageous to run this in the verify_credentials method which is run on the ems_operations role in the right zone and also runs far less frequently.

We can still run `event_monitor_available` before starting the event_catcher in case something went wrong since the last verify_credentials run.