### PR TITLE
Use EvmSpecHelper.local_server

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_catcher_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Openstack::CloudManager::EventCatcher do
   before do
-    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    zone = EvmSpecHelper.local_miq_server.zone
     @ems = FactoryBot.create(:ems_openstack, :with_authentication, :zone => zone, :capabilities => {"events" => events_supported})
     allow(ManageIQ::Providers::Openstack::CloudManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/event_target_parser_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Openstack::CloudManager::EventTargetParser do
   before :each do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    zone = EvmSpecHelper.local_miq_server.zone
     @ems                 = FactoryBot.create(:ems_openstack, :zone => zone)
 
     allow_any_instance_of(EmsEvent).to receive(:handle_event)

--- a/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
@@ -2,7 +2,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
   require ManageIQ::Providers::Openstack::Engine.root.join('spec/tools/openstack_data/openstack_data_test_helper').to_s
 
   before :each do
-    _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    @zone = EvmSpecHelper.local_miq_server.zone
 
     @mock_meter_list = OpenstackMeterListData.new
     @mock_stats_data = OpenstackMetricStatsData.new

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_helpers.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_helpers.rb
@@ -59,7 +59,7 @@ module Openstack
     end
 
     def setup_ems(hostname, password, port = 5000, userid = "admin", version = "v2", keystone_v3_domain_id = nil)
-      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       @ems = FactoryBot.create(:ems_openstack,
                                 :zone                   => zone,
                                 :tenant_mapping_enabled => true,

--- a/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_havana_errors_spec.rb
@@ -2,7 +2,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Refresher do
   before(:each) do
     EmsRefresh.debug_failures = false
 
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    zone = EvmSpecHelper.local_miq_server.zone
     @ems = FactoryBot.create(
       :ems_openstack,
       :zone      => zone,

--- a/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/event_catcher_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::Openstack::InfraManager::EventCatcher do
   before do
-    _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+    zone = EvmSpecHelper.local_miq_server.zone
     @ems = FactoryBot.create(:ems_openstack_infra, :with_authentication, :zone => zone, :capabilities => {"events" => events_supported})
     allow(ManageIQ::Providers::Openstack::InfraManager::EventCatcher).to receive(:all_ems_in_zone).and_return([@ems])
   end

--- a/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/host_spec.rb
@@ -242,7 +242,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Host do
 
   describe "Overriden auth methods for ssh fleecing," do
     let(:ext_management_system) do
-      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone = EvmSpecHelper.local_miq_server.zone
       FactoryBot.create(:ems_openstack_infra, :zone => zone).tap do |ems|
         ems.authentications << FactoryBot.create(:authentication_ssh_keypair)
         ems.authentications << FactoryBot.create(:authentication)

--- a/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/metrics_capture_spec.rb
@@ -2,7 +2,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::MetricsCapture do
   require ManageIQ::Providers::Openstack::Engine.root.join('spec/tools/openstack_data/openstack_data_test_helper').to_s
 
   before :each do
-    _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    @zone = EvmSpecHelper.local_miq_server.zone
 
     @mock_meter_list = OpenstackMeterListData.new
     @mock_stats_data = OpenstackMetricStatsData.new

--- a/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
+++ b/spec/models/manageiq/providers/openstack/infra_manager/refresher_rhos_juno_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::Openstack::InfraManager::Refresher do
   include Spec::Support::EmsRefreshHelper
 
   before(:each) do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+    zone = EvmSpecHelper.local_miq_server.zone
     @ems = FactoryBot.create(:ems_openstack_infra, :zone => zone, :hostname => "192.168.24.1",
                               :ipaddress => "192.168.24.1", :port => 5000, :api_version => 'v2',
                               :security_protocol => 'no-ssl')

--- a/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
@@ -1,8 +1,8 @@
 describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
   before :each do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems                 = FactoryBot.create(:ems_openstack, :zone => zone)
-    @manager             = @ems.network_manager
+    zone     = EvmSpecHelper.local_miq_server.zone
+    @ems     = FactoryBot.create(:ems_openstack, :zone => zone)
+    @manager = @ems.network_manager
 
     allow_any_instance_of(EmsEvent).to receive(:handle_event)
     allow(EmsEvent).to receive(:create_completed_event)

--- a/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_target_parser_spec.rb
@@ -1,8 +1,8 @@
 describe ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventTargetParser do
   before :each do
-    _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems                 = FactoryBot.create(:ems_openstack, :zone => zone)
-    @manager             = @ems.cinder_manager
+    zone     = EvmSpecHelper.local_miq_server.zone
+    @ems     = FactoryBot.create(:ems_openstack, :zone => zone)
+    @manager = @ems.cinder_manager
 
     allow_any_instance_of(EmsEvent).to receive(:handle_event)
     allow(EmsEvent).to receive(:create_completed_event)

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -3,7 +3,7 @@ describe Metric::CiMixin::Capture do
                                      %w(.. .. .. tools openstack_data openstack_data_test_helper)))
 
   before :each do
-    _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    @zone = EvmSpecHelper.local_miq_server.zone
 
     @mock_meter_list = OpenstackMeterListData.new
     @mock_stats_data = OpenstackMetricStatsData.new


### PR DESCRIPTION
continuation of https://github.com/ManageIQ/manageiq/pull/21966

if we want the miq_server, no reason to extract guid/zone to then have to code around them.