### PR TITLE
fix issue finding parallel

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -1,5 +1,6 @@
 require 'active_support/inflector'
 require 'util/miq-exception'
+require 'parallel'
 
 module OpenstackHandle
   class Handle
@@ -371,7 +372,7 @@ module OpenstackHandle
       services = []
       all_tenants = tenants
       all_tenants.delete("services")
-      Parallel.each(all_tenants, :in_threads => thread_limit) do |tenant|
+      ::Parallel.each(all_tenants, :in_threads => thread_limit) do |tenant|
         service = detect_service(service_name, tenant.name)
         if service
           services << [service, tenant]
@@ -386,7 +387,7 @@ module OpenstackHandle
     def accessor_for_accessible_tenants(service, accessor, unique_id, array_accessor = true)
       results = []
       not_found_error = Fog.const_get(service)::OpenStack::NotFound
-      Parallel.each(service_for_each_accessible_tenant(service), :in_threads => thread_limit) do |svc, project|
+      ::Parallel.each(service_for_each_accessible_tenant(service), :in_threads => thread_limit) do |svc, project|
 
         response = begin
           if accessor.kind_of?(Proc)


### PR DESCRIPTION
The legacy code requires 'parallel'
But that is not always called in the tests. Or possibly production
This requires it to make sure it is present

```
     NameError:
       uninitialized constant Parallel

rspec ./spec/legacy/openstack_handle/handle_spec.rb:27 # OpenstackHandle::Handle errors from services ignores 404 errors from services
rspec ./spec/legacy/openstack_handle/handle_spec.rb:34 # OpenstackHandle::Handle errors from services ignores 404 errors from services returning arrays
```

---

Does seem like this should not be a problem as it is required by the parent file, but alas, I'm getting these errors locally.

I'm also getting a table not found error, so maybe my database is just not working correctly.