### PR TITLE
Fixed cloud provider form clearable select field

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -98,7 +98,8 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
           :name        => "provider_id",
           :label       => _("Openstack Infra Provider"),
           :isClearable => true,
-          :options     => provider_id_options
+          :simpleValue => true,
+          :options     => provider_id_options,
         },
         {
           :component    => "select",


### PR DESCRIPTION
Fixed cloud provider form `isclearable` select field bug where the entire object is returned when an option is selected instead of just the selected value.

Before:
<img width="293" alt="Before" src="https://user-images.githubusercontent.com/32444791/179302437-a6edd526-5612-47d4-a564-4d25e61d09e1.png">

After:
<img width="126" alt="After" src="https://user-images.githubusercontent.com/32444791/179302458-f663c4e4-2791-4008-8372-00794e0a06b7.png">

@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy
@miq-bot assign @agrare 
@miq-bot add-label bug
