### PR TITLE
Loosen the version requirement for parallel

### DIFF
--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "excon",                "~> 0.71"
   spec.add_dependency "fog-openstack",        ">= 0.3.10"
   spec.add_dependency "more_core_extensions", ">= 3.2", "< 5"
-  spec.add_dependency "parallel",             "~> 1.12.0"
+  spec.add_dependency "parallel",             "~> 1.12"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Parallel v1.12.1 was released in 2017, we shouldn't require such an old dependency.

NOTE azure-armrest also has `~> 1.12.0` so we can't go straight to `~> 1.22`.  I opened https://github.com/ManageIQ/azure-armrest/pull/422 to bump that so that we can use 1.22.*  Once that is released we could go to `~> 1.22` here as well.  Up to @Fryguy on if he wants to just loosen this or wait for release of azure-armrest and go to 1.22 here