### PR TITLE
Ruby 3 support: rspec-mocks 3.10.3 requires "with" to be explicit with hashes vs. kwargs

### DIFF
--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -61,10 +61,12 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_tenant               => "admin",
-        :openstack_identity_api_version => 'v2.0',
-        :openstack_region               => nil,
-        :connection_options             => {:ssl_verify_peer => false}
+        {
+          :openstack_tenant               => "admin",
+          :openstack_identity_api_version => 'v2.0',
+          :openstack_region               => nil,
+          :connection_options             => {:ssl_verify_peer => false}
+        }
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
@@ -82,10 +84,12 @@ describe OpenstackHandle::Handle do
         "dummy",
         "http://address:5000",
         "Compute",
-        :openstack_tenant               => "admin",
-        :openstack_identity_api_version => 'v2.0',
-        :openstack_region               => nil,
-        :connection_options             => {}
+        {
+          :openstack_tenant               => "admin",
+          :openstack_identity_api_version => 'v2.0',
+          :openstack_region               => nil,
+          :connection_options             => {}
+        }
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog
@@ -103,10 +107,12 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_tenant               => "admin",
-        :openstack_identity_api_version => 'v2.0',
-        :openstack_region               => nil,
-        :connection_options             => {:ssl_verify_peer => false}
+        {
+          :openstack_tenant               => "admin",
+          :openstack_identity_api_version => 'v2.0',
+          :openstack_region               => nil,
+          :connection_options             => {:ssl_verify_peer => false}
+        }
       ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -125,10 +131,12 @@ describe OpenstackHandle::Handle do
         "dummy",
         "https://address:5000",
         "Compute",
-        :openstack_tenant               => "admin",
-        :openstack_identity_api_version => 'v2.0',
-        :openstack_region               => nil,
-        :connection_options             => {:ssl_verify_peer => true}
+        {
+          :openstack_tenant               => "admin",
+          :openstack_identity_api_version => 'v2.0',
+          :openstack_region               => nil,
+          :connection_options             => {:ssl_verify_peer => true}
+        }
       ) do |_, _, address|
         expect(address).to eq(auth_url_ssl)
         fog
@@ -186,10 +194,12 @@ describe OpenstackHandle::Handle do
         "dummy",
         "http://address:5000",
         "Compute",
-        :openstack_tenant               => "admin",
-        :openstack_identity_api_version => 'v2.0',
-        :openstack_region               => 'RegionOne',
-        :connection_options             => {}
+        {
+          :openstack_tenant               => "admin",
+          :openstack_identity_api_version => 'v2.0',
+          :openstack_region               => 'RegionOne',
+          :connection_options             => {}
+        }
       ).once do |_, _, address|
         expect(address).to eq(auth_url)
         fog

--- a/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/auth_key_pair_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
       service = double
       key_pairs = double
       allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-      allow(ems).to receive(:connect).with(:service => 'Compute').and_return(service)
+      allow(ems).to receive(:connect).with({:service => 'Compute'}).and_return(service)
       allow(service).to receive(:key_pairs).and_return(key_pairs)
       allow(key_pairs).to receive(:create).with(key_pair_attributes).and_return(
         the_raw_key_pair)
@@ -33,7 +33,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair do
       service = double
       subject.name = 'key1'
       subject.resource = ems
-      allow(ems).to receive(:connect).with(:service => 'Compute').and_return(service)
+      allow(ems).to receive(:connect).with({:service => 'Compute'}).and_return(service)
       allow(service).to receive(:delete_key_pair).with('key1')
       subject.delete_key_pair
     end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/flavor_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/flavor_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Flavor do
   context 'when raw_create_flavor' do
     before do
       allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-      allow(ems).to receive(:with_provider_connection).with(:service => 'Compute').and_yield(service)
+      allow(ems).to receive(:with_provider_connection).with({:service => 'Compute'}).and_yield(service)
       allow(service).to receive(:flavors).and_return(flavors)
     end
 
@@ -54,7 +54,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Flavor do
   context 'when raw_delete_flavor' do
     before do
       allow(ExtManagementSystem).to receive(:find).with(ems.id).and_return(ems)
-      allow(ems).to receive(:with_provider_connection).with(:service => 'Compute').and_yield(service)
+      allow(ems).to receive(:with_provider_connection).with({:service => 'Compute'}).and_yield(service)
     end
 
     subject { flavor_openstack }

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       service = double
       allow(service).to receive_message_chain('volumes.create').and_return @volume
       allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
-        .with(:service => 'volume', :tenant_name => nil).and_yield(service)
+        .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
       allow(@task).to receive(:instance_type).and_return @flavor
 
       default_volume = {:name => "root", :size => 1, :source_type => "image", :destination_type => "local",
@@ -40,7 +40,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
                                                                                           :status => "pending")
       allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
-        .with(:service => 'volume', :tenant_name => nil).and_yield(service)
+        .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
       expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq [false, "pending"]
     end
@@ -51,7 +51,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
                                                                                           :status => "available")
       allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
-        .with(:service => 'volume', :tenant_name => nil).and_yield(service)
+        .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
       expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq true
     end
@@ -61,7 +61,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       service = double
       allow(service).to receive_message_chain('volumes.get').and_return nil
       allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
-        .with(:service => 'volume', :tenant_name => nil).and_yield(service)
+        .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
       expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq [false, nil]
     end
@@ -72,7 +72,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
                                                                                           :status => "error")
       allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
-        .with(:service => 'volume', :tenant_name => nil).and_yield(service)
+        .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
       expect { @task.do_volume_creation_check([pending_volume_attrs]) }.to raise_error(MiqException::MiqProvisionError)
     end
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/vm_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
 
   let(:handle) do
     double.tap do |handle|
-      allow(ems).to receive(:connect).with(:service => 'Compute', :tenant_name => tenant.name).and_return(handle)
+      allow(ems).to receive(:connect).with({:service => 'Compute', :tenant_name => tenant.name}).and_return(handle)
     end
   end
 
@@ -32,7 +32,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Vm do
     end
     let(:other_handle) do
       double.tap do |other_handle|
-        allow(ems).to receive(:connect).with(:service => 'Compute', :tenant_name => other_tenant.name).and_return(other_handle)
+        allow(ems).to receive(:connect).with({:service => 'Compute', :tenant_name => other_tenant.name}).and_return(other_handle)
       end
     end
 


### PR DESCRIPTION
https://github.com/rspec/rspec-mocks/issues 1460