### PR TITLE
Fix port for class-level verify_credentials

### DIFF
--- a/app/models/manageiq/providers/openstack/manager_mixin.rb
+++ b/app/models/manageiq/providers/openstack/manager_mixin.rb
@@ -46,7 +46,7 @@ module ManageIQ::Providers::Openstack::ManagerMixin
       ems.security_protocol      = params[:security_protocol].strip
       ems.keystone_v3_domain_id  = params[:uid_ems]
 
-      user, hostname, port = params[:userid], params[:hostname].strip, params[:port].try(:strip)
+      user, hostname, port = params[:userid], params[:hostname].strip, params[:port]
 
       endpoint = {:role => :default, :hostname => hostname, :port => port, :security_protocol => ems.security_protocol}
       authentication = {:userid => user, :password => ManageIQ::Password.try_decrypt(password), :save => false, :role => 'default', :authtype => 'default'}


### PR DESCRIPTION
The class-level verify_credentials method takes DDF parameters with the port being an integer.  The ems_connect? method was assuming the port was a string so it was doing `params[:port].try(:strip)` which was returning `nil` for an integer.  This then used the default port `5000` since no port appeared to be passed.

The result is the class-level verify succeeds, then the instance-level fails.