### PR TITLE
Allow overrides of Openstack::ProvisionWorkflow class

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -117,8 +117,9 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
 
   private
 
-  def dialog_name_from_automate(message = 'get_dialog_name')
-    super(message, {'platform' => 'openstack'})
+  def dialog_name_from_automate(message = 'get_dialog_name', extra_attrs = {})
+    extra_attrs['platform'] ||= 'openstack'
+    super(message, extra_attrs)
   end
 
   def filter_cloud_networks(networks)


### PR DESCRIPTION
Allow child classes to override the `get_dialog_name_from_automate` method passing in the platform extra_attr

Required for:
* https://github.com/ManageIQ/manageiq-providers-ibm_cic/pull/31