### PR TITLE
Provider validate credentials

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -503,6 +503,17 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
     vs&.name == :swift ? vs : nil
   end
 
+  def verify_credentials(auth_type = nil, options = {})
+    options[:service] ||= "Compute"
+    ret = super
+    return ret unless auth_type.nil?
+
+    capabilities["events"] = !!event_monitor_available?
+    save! if changed?
+
+    true
+  end
+
   def self.ems_type
     @ems_type ||= "openstack".freeze
   end

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -357,17 +357,9 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   end
 
   def verify_credentials(auth_type = nil, options = {})
-    auth_type ||= 'default'
+    options[:service] ||= "BareMetal"
 
-    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
-
-    options[:auth_type] = auth_type
-    case auth_type.to_s
-    when 'default'     then verify_api_credentials(options)
-    when 'amqp'        then verify_amqp_credentials(options)
-    when 'ssh_keypair' then verify_ssh_keypair_credentials(options)
-    else               raise "Invalid OpenStack Authentication Type: #{auth_type.inspect}"
-    end
+    super
   end
 
   def required_credential_fields(type)

--- a/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host/operations.rb
@@ -1,5 +1,5 @@
 module ManageIQ::Providers::Openstack::InfraManager::Host::Operations
-  include ActiveSupport::Concern
+  extend ActiveSupport::Concern
 
   def ironic_fog_node
     connection_options = {:service => "Baremetal"}


### PR DESCRIPTION
We hashed around some ideas for provider's validate_credentials

- Wanted to get Compute and Baremetal into there
- Wanted the logic for each of those to be specific
- I didn't touch the auth_type.nil? case - we can discuss.
- I didn't handle cinder or swift managers. Anything special there?
- I did not see an issue with `ActiveSupport::Concerns`, but it is wrong and was bugging me
