### PR TITLE
Allow a missing Snapshot#vm_or_template_id

### DIFF
--- a/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/definitions/cloud_collections.rb
@@ -21,7 +21,9 @@ module ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudC
     add_cloud_collection(:operating_systems)
     add_cloud_collection(:placement_groups)
     add_cloud_collection(:disks)
-    add_cloud_collection(:snapshots)
+    add_cloud_collection(:snapshots) do |builder|
+      builder.add_properties(:manager_ref_allowed_nil => %i[vm_or_template])
+    end
     add_cloud_collection(:networks)
 
     unless targeted?


### PR DESCRIPTION
When a snapshot is taken of a VM an image is created on the OpenStack side.  We associate this as a snapshot record to the VM that created it.

If the VM is deleted then the lazy_find will return `nil` and a log or raise an exception depending on prod/dev.

We can mark vm_or_template as optional in the manager_ref since the snapshot uid is globally unique.

Fixes https://github.com/ManageIQ/manageiq-providers-openstack/issues/844