### PR TITLE
Use standard verify_credentials

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -414,10 +414,6 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
     n_('Infrastructure Provider (OpenStack)', 'Infrastructure Providers (OpenStack)', number)
   end
 
-  def verify_credentials?(args)
-    !!verify_credentials(args) && !!verify_credentials(args.merge(:service =>"BareMetal"))
-  end
-
   private
 
   def authentication_class(attributes)


### PR DESCRIPTION
The previous code determined if ironic was present.
If it was not, it succeeded, but provided a warning message.

#846 converted that to requiring both to work.
This deviates from the original course.

This PR goes back to the straight/default behavior of only verifying
credentials for the service requested and not adding additional verification