### PR TITLE
Fix InfraManager authentication

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -357,7 +357,7 @@ class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraM
   end
 
   def verify_credentials(auth_type = nil, options = {})
-    options[:service] ||= "BareMetal"
+    options[:service] ||= "Baremetal"
 
     super
   end


### PR DESCRIPTION
There is a typo for the baremetal service which is causing `verify_credentials` to fail, `BareMetal` should be `Baremetal` instead

```
[----] I, [2023-05-01T14:03:46.121823 #86507:9740]  INFO -- evm: MIQ(ManageIQ::Providers::Openstack::InfraManager#with_provider_connection) Connecting through ManageIQ::Providers::Openstack::InfraManager: [openstack-infra]
[----] E, [2023-05-01T14:08:53.566963 #86507:9740] ERROR -- evm: MIQ(ManageIQ::Providers::Openstack::InfraManager#verify_api_credentials) Error Class=NameError, Message=uninitialized constant Fog::BareMetal
Did you mean?  Fog::Baremetal
[----] W, [2023-05-01T14:08:57.902627 #86507:9740]  WARN -- evm: MIQ(ManageIQ::Providers::Openstack::InfraManager#authentication_check_no_validation) type: [:default] for [24] [openstack-infra] Validation failed: invalid, Unexpected response returned from system: uninitialized constant Fog::BareMetal
Did you mean?  Fog::Baremetal
[----] W, [2023-05-01T14:08:59.887033 #86507:9740]  WARN -- evm: MIQ(AuthUseridPassword#validation_failed) [ExtManagementSystem] [24], previously valid on: , previous status: []
[----] I, [2023-05-01T14:08:59.907040 #86507:9740]  INFO -- evm: MIQ(MiqQueue.put) Message id: [139], Zone: [default], Role: [], Server: [], MiqTask id: [], Handler id: [], Ident: [generic], Target id: [], Instance id: [], Task id: [], Command: [MiqEvent.raise_evm_event], Timeout: [600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: [["ManageIQ::Providers::Openstack::InfraManager", 24], "ems_auth_invalid", {}]
```

@miq-bot assign @agrare 
@miq-bot add_reviewer @kbrock 
@miq-bot add_label bug

Introduced in https://github.com/ManageIQ/manageiq-providers-openstack/pull/842