### PR TITLE
Fix CloudNetwork#delete_cloud_network argument error

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -485,7 +485,7 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     raise MiqException::MiqNetworkCreateError, parsed_error, e.backtrace
   end
 
-  def raw_delete_cloud_network
+  def raw_delete_cloud_network(_options = {})
     with_notification(:cloud_network_delete,
                       :options => {
                         :subject => self,

--- a/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/cloud_network_spec.rb
@@ -45,16 +45,30 @@ describe ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork do
     end
 
     context "#update_cloud_network" do
+      it "updates the cloud network" do
+        options = {"name" => "new-name"}
+
+        expect(service).to receive(:update_network).with(cloud_network.ems_ref, options)
+        cloud_network.update_cloud_network(options)
+      end
+
       it 'catches errors from provider' do
         expect(service).to receive(:update_network).and_raise(bad_request)
-        expect { cloud_network.raw_update_cloud_network({}) }.to raise_error(MiqException::MiqNetworkUpdateError)
+        expect { cloud_network.update_cloud_network({}) }.to raise_error(MiqException::MiqNetworkUpdateError)
       end
     end
 
     context "#delete_cloud_network" do
+      before { NotificationType.seed }
+
+      it "deletes the cloud network" do
+        expect(service).to receive(:delete_network).with(cloud_network.ems_ref)
+        cloud_network.delete_cloud_network({})
+      end
+
       it 'catches errors from provider' do
         expect(service).to receive(:delete_network).and_raise(bad_request)
-        expect { cloud_network.raw_delete_cloud_network }.to raise_error(MiqException::MiqNetworkDeleteError)
+        expect { cloud_network.delete_cloud_network({}) }.to raise_error(MiqException::MiqNetworkDeleteError)
       end
     end
   end


### PR DESCRIPTION
The core `CloudNetwork#raw_delete_cloud_network` method takes an optional `options` hash as the first parameter.

https://github.com/ManageIQ/manageiq/blob/master/app/models/cloud_network.rb#L100-L106