### PR TITLE
Fix incorrect constant name reference by referencing HostAggregate

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/host_aggregate_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/host_aggregate_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ManageIQ::Providers::Openstack::CloudManager::CloudVolume do
+describe ManageIQ::Providers::Openstack::CloudManager::HostAggregate do
   let(:ems) { FactoryBot.create(:ems_openstack) }
   let(:zone) { FactoryBot.create(:availability_zone_openstack,
                                   :ext_management_system => ems) }


### PR DESCRIPTION
This was a bug.  `ManageIQ::Providers::Openstack::CloudManager::CloudVolume` resolved to `CloudVolume` in classic rails loader. With zeitwerk, this bug raises a NameError.