### PR TITLE
Allow numberic-only passwords for keystone v3 again

### DIFF
--- a/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
+++ b/lib/manageiq/providers/openstack/legacy/openstack_handle/handle.rb
@@ -60,13 +60,6 @@ module OpenstackHandle
       opts[:openstack_service_type] = ["nfv-orchestration"] if service == "NFV"
       opts[:openstack_service_type] = ["workflowv2"] if service == "Workflow"
 
-      # Fog handles just numeric fields as integer which fails for password, making check here until
-      # it get resolved in fog.
-      if password == password.to_i.to_s
-        $log.error("Wrong password format, just numeric passwords are not accepted.")
-        raise MiqException::MiqOpenstackApiRequestError, _("Numeric-only passwords are not accepted")
-      end
-
       if service == "Planning"
         Fog::OpenStack::Planning.new(opts)
       elsif service == "Workflow"

--- a/manageiq-providers-openstack.gemspec
+++ b/manageiq-providers-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport",        "~> 6.0"
   spec.add_dependency "bunny",                "~> 2.1.0"
   spec.add_dependency "excon",                "~> 0.71"
-  spec.add_dependency "fog-openstack",        "~> 1.0"
+  spec.add_dependency "fog-openstack",        "~> 1.1"
   spec.add_dependency "more_core_extensions", ">= 3.2", "< 5"
   spec.add_dependency "parallel",             "~> 1.12"
 

--- a/spec/legacy/openstack_handle/handle_spec.rb
+++ b/spec/legacy/openstack_handle/handle_spec.rb
@@ -42,14 +42,6 @@ describe OpenstackHandle::Handle do
     end
   end
 
-  context "errors from connection" do
-    it "raises error for numeric-only password" do
-      handle = OpenstackHandle::Handle.new("dummy", "123456", "dummy")
-      expect { handle.connect } .to raise_error MiqException::MiqOpenstackApiRequestError, \
-                                                "Numeric-only passwords are not accepted"
-    end
-  end
-
   context "supports ssl" do
     it "handles default ssl type connections just fine" do
       fog      = double('fog')


### PR DESCRIPTION
The bug which this was added to workaround has been fixed in fog-openstack and we no longer need this.

Added by: https://github.com/ManageIQ/manageiq-providers-openstack/pull/504
Fog-openstack fixed by: https://github.com/fog/fog-openstack/pull/493 released in v1.0.9

Fixes https://github.com/ManageIQ/manageiq/issues/22683