### PR TITLE
Ubuntu Kinetic has been removed, replace with Lunar

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -4,7 +4,7 @@ if [ -n "$CI" ]; then
   echo "== Installing system packages =="
   sudo apt-get update
   sudo apt-get install -y libcurl4-openssl-dev
-  sudo apt-add-repository --yes 'deb http://us.archive.ubuntu.com/ubuntu kinetic universe'
+  sudo apt-add-repository --yes 'deb http://us.archive.ubuntu.com/ubuntu lunar universe'
   sudo apt-get install -y libqpid-proton11-dev
   echo
 


### PR DESCRIPTION
The Ubuntu Kinetic 22.10 release has reached end-of-life and the repository files have been removed from mirrors.

Ubuntu Lunar 23.04 has the same version of libqpid-proton11