### PR TITLE
Fix Gem.loaded_specs looking for wrong key name

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 require "manageiq/providers/openstack"
 
 RSpec.configure do |config|
-  config.filter_run_excluding(:qpid_proton) unless ENV['CI'] || Gem.loaded_specs.key?(:qpid_proton)
+  config.filter_run_excluding(:qpid_proton) unless ENV['CI'] || Gem.loaded_specs.key?("qpid_proton")
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
`Gem.loaded_specs` has string keys which was causing this check to
always return false

```
(byebug) Gem.loaded_specs.key?(:qpid_proton)
false
(byebug) Gem.loaded_specs.key?("qpid_proton")
true
```