### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -1,28 +1,4 @@
 class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :AvailabilityZoneNull
-  require_nested :CloudResourceQuota
-  require_nested :CloudTenant
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :HostAggregate
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :OrchestrationServiceOptionConverter
-  require_nested :OrchestrationStack
-  require_nested :OrchestrationTemplate
-  require_nested :VnfdTemplate
-  require_nested :PlacementGroup
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Snapshot
-  require_nested :Template
-  require_nested :Vm
-
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::Openstack::NetworkManager",

--- a/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/event_catcher.rb
@@ -1,5 +1,3 @@
 class ManageIQ::Providers::Openstack::CloudManager::EventCatcher < ::MiqEventCatcher
   include ManageIQ::Providers::Openstack::EventCatcherMixin
-
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "openstack"
 
   def friendly_name

--- a/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
   include ManageIQ::Providers::Openstack::HelperMethods
-  require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     create_options = {:stack_name => stack_name, :template => template.content}.merge(options).except(:tenant_name)

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Openstack::CloudManager::Provision < ::MiqProvisionCloud
   include ManageIQ::Providers::Openstack::HelperMethods
-  include_concern 'Cloning'
-  include_concern 'Configuration'
-  include_concern 'VolumeAttachment'
-  include_concern 'OptionsHelper'
+  include Cloning
+  include Configuration
+  include VolumeAttachment
+  include OptionsHelper
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqProvisionCloudWorkflow
-  include_concern "DialogFieldValidation"
+  include DialogFieldValidation
 
   def allowed_instance_types(_options = {})
     source                  = load_ar_obj(get_source_vm)

--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openstack::CloudManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/scanning.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/scanning.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openstack::CloudManager::Scanning
-  require_nested :Job
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/template.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::Template < ManageIQ::Provide
   include ManageIQ::Providers::Openstack::HelperMethods
   belongs_to :cloud_tenant
 
-  include_concern 'ManageIQ::Providers::Openstack::CloudManager::VmOrTemplateShared'
+  include ManageIQ::Providers::Openstack::CloudManager::VmOrTemplateShared
 
   has_and_belongs_to_many :cloud_tenants,
                           :foreign_key             => "vm_id",

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -1,12 +1,10 @@
 class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'ManageIQ::Providers::Openstack::CloudManager::VmOrTemplateShared'
-
-  include_concern 'Operations'
-  include_concern 'RemoteConsole'
-  include_concern 'Resize'
-  include_concern 'AssociateIp'
-  include_concern 'ManageSecurityGroups'
-
+  include ManageIQ::Providers::Openstack::CloudManager::VmOrTemplateShared
+  include Operations
+  include RemoteConsole
+  include Resize
+  include AssociateIp
+  include ManageSecurityGroups
   include ManageIQ::Providers::Openstack::HelperMethods
 
   supports :capture

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/operations.rb
@@ -1,11 +1,11 @@
 module ManageIQ::Providers::Openstack::CloudManager::Vm::Operations
   extend ActiveSupport::Concern
 
-  include_concern 'Configuration'
-  include_concern 'Guest'
-  include_concern 'Power'
-  include_concern 'Relocation'
-  include_concern 'Snapshot'
+  include Configuration
+  include Guest
+  include Power
+  include Relocation
+  include Snapshot
 
   included do
     supports :terminate do

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm_or_template_shared.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm_or_template_shared.rb
@@ -1,4 +1,4 @@
 module ManageIQ::Providers::Openstack::CloudManager::VmOrTemplateShared
   extend ActiveSupport::Concern
-  include_concern 'Scanning'
+  include Scanning
 end

--- a/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vnf.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::Openstack::CloudManager::Vnf < ManageIQ::Providers::CloudManager::OrchestrationStack
   include ManageIQ::Providers::Openstack::HelperMethods
-  require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     create_options = {:vnf => {:name => stack_name, :vnfd_id => template.ems_ref}}

--- a/app/models/manageiq/providers/openstack/infra_manager.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager.rb
@@ -1,17 +1,4 @@
 class ManageIQ::Providers::Openstack::InfraManager < ManageIQ::Providers::InfraManager
-  require_nested :AuthKeyPair
-  require_nested :Cluster
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Host
-  require_nested :HostServiceGroup
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :OrchestrationStack
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Template
-
   include ManageIQ::Providers::Openstack::ManagerMixin
   include HasManyOrchestrationStackMixin
   include HasNetworkManagerMixin

--- a/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::Openstack::InfraManager::EventCatcher < ::MiqEventCatcher
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_openstack_infra
   end

--- a/app/models/manageiq/providers/openstack/infra_manager/host.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/host.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::Openstack::InfraManager::Host < ::Host
 
   has_many :floating_ips, :through => :network_ports
 
-  include_concern 'Operations'
+  include Operations
 
   supports :capture
   supports :update

--- a/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openstack::InfraManager::MetricsCollectorWorker < ::MiqEmsMetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "openstack_infra"
 
   def friendly_name

--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openstack::InfraManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_openstack_infra
   end

--- a/app/models/manageiq/providers/openstack/inventory.rb
+++ b/app/models/manageiq/providers/openstack/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Openstack::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/openstack/inventory/collector.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector.rb
@@ -2,11 +2,6 @@ class ManageIQ::Providers::Openstack::Inventory::Collector < ManageIQ::Providers
   include ManageIQ::Providers::Openstack::RefreshParserCommon::HelperMethods
   include Vmdb::Logging
 
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   attr_reader :availability_zones
   attr_reader :cloud_services
   attr_reader :tenants

--- a/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/collector/storage_manager.rb
@@ -1,4 +1,2 @@
 module ManageIQ::Providers::Openstack::Inventory::Collector::StorageManager
-  require_nested :CinderManager
-  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/parser.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::Openstack::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :InfraManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-
   def orchestration_stack_parameters(stack, stack_inventory_object)
     collector.orchestration_parameters(stack).each do |param_key, param_val|
       uid = compose_ems_ref(stack.id, param_key)

--- a/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/parser/storage_manager.rb
@@ -1,4 +1,2 @@
 module ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager
-  require_nested :CinderManager
-  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/inventory/persister.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister.rb
@@ -1,10 +1,4 @@
 class ManageIQ::Providers::Openstack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :InfraManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   # TODO(lsmola) figure out a way to pass collector info, probably via target, then remove the below
   attr_reader :collector
 

--- a/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/openstack/inventory/persister/storage_manager.rb
@@ -1,4 +1,2 @@
 module ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager
-  require_nested :CinderManager
-  require_nested :SwiftManager
 end

--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -1,14 +1,4 @@
 class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :FloatingIp
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::Openstack::ManagerMixin
   include SupportsFeatureMixin
 

--- a/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/cloud_network.rb
@@ -456,9 +456,6 @@ class ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork < ::CloudNetw
     }
   end
 
-  require_nested :Private
-  require_nested :Public
-
   def self.class_by_ems(ext_management_system, external = false)
     external ? super::Public : super::Private
   end

--- a/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::Openstack::NetworkManager::EventCatcher < ::MiqEventCatcher
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_openstack_network
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -1,12 +1,4 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::Providers::StorageManager
-  require_nested :CloudVolume
-  require_nested :CloudVolumeBackup
-  require_nested :CloudVolumeSnapshot
-  require_nested :CloudVolumeType
-  require_nested :Refresher
-  require_nested :EventCatcher
-  require_nested :EventParser
-
   include ManageIQ::Providers::StorageManager::BlockMixin
   include ManageIQ::Providers::Openstack::ManagerMixin
 

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/cloud_volume.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager::CloudVolume < ::CloudVolume
   include ManageIQ::Providers::Openstack::HelperMethods
-  include_concern 'Operations'
+  include Operations
 
   supports :backup_create
   supports :backup_restore

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher < ::MiqEventCatcher
   include ManageIQ::Providers::Openstack::EventCatcherMixin
 
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_openstack_cinder
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/swift_manager.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Openstack::StorageManager::SwiftManager < ManageIQ::Providers::StorageManager
-  require_nested :CloudObjectStoreContainer
-  require_nested :CloudObjectStoreObject
-  require_nested :Refresher
-
   include ManageIQ::Providers::StorageManager::ObjectMixin
 
   delegate :authentication_check,


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854