### PR TITLE
Delete an unused NetworkManager MetricsCollectorWorker Runner class

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/openstack/network_manager/metrics_collector_worker/runner.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
-end


### PR DESCRIPTION
The worker class for this runner was deleted long ago by https://github.com/ManageIQ/manageiq-providers-openstack/pull/548, remove the corresponding Runner class.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
