### PR TITLE
Provide backward compatible way to globally set permitted classes

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -6,7 +6,12 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
     @volume = FactoryBot.create(:cloud_volume_openstack)
 
     # We're storing objects in the instance_type, so we must permit loading this class
-    ActiveRecord::Base.yaml_column_permitted_classes = ActiveRecord::Base.yaml_column_permitted_classes | [@flavor.class]
+    if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
+      ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
+    else
+      ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
+    end
+
     @task = FactoryBot.create(:miq_provision_openstack,
                                :source  => @template,
                                :state   => 'pending',


### PR DESCRIPTION
This supports rails 7 and 6.1.  Similar to the change in: https://github.com/ManageIQ/manageiq/pull/22887

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
