### PR TITLE
Use Rails 7 way to set yaml permitted classes

### DIFF
--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -6,11 +6,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
     @volume = FactoryBot.create(:cloud_volume_openstack)
 
     # We're storing objects in the instance_type, so we must permit loading this class
-    if ActiveRecord.respond_to?(:yaml_column_permitted_classes)
-      ActiveRecord.yaml_column_permitted_classes       = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
-    else
-      ActiveRecord::Base.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
-    end
+    ActiveRecord.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
 
     @task = FactoryBot.create(:miq_provision_openstack,
                                :source  => @template,


### PR DESCRIPTION
Drops the rails 6.1 compatibility from:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/885

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
