### PR TITLE
Add the volume to the root disk (vda) if the selected flavor has a ro…

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment.rb
@@ -10,8 +10,6 @@ module ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment
             volume_attrs[:imageRef] = source.ems_ref # Set the image reference for booting
             volume_attrs[:bootable] = true
             volume_attrs[:boot_index] = 0
-          else # Subsequent volumes will be assigned to vdb, vdc, etc.
-            volume_attrs[:boot_index] = -1
           end
         end
 

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -1,82 +1,78 @@
 describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachment do
+  let(:ems)          { FactoryBot.create(:ems_openstack_with_authentication) }
+  let(:flavor)       { FactoryBot.create(:flavor_openstack) }
+  let(:template)     { FactoryBot.create(:template_openstack, :ext_management_system => ems) }
+  let(:volume)       { FactoryBot.create(:cloud_volume_openstack) }
+  let(:service)      { double("volume service") }
+  let(:task_options) { {:instance_type => flavor, :src_vm_id => template.id, :volumes => task_volumes} }
+  let(:task_volumes) { [{:name => "custom_volume_1", :size => 2}] }
+  let(:task)         { FactoryBot.create(:miq_provision_openstack, :source => template, :state => 'pending', :status => 'Ok', :options => task_options) }
+
   before do
-    @ems = FactoryBot.create(:ems_openstack_with_authentication)
-    @template = FactoryBot.create(:template_openstack, :ext_management_system => @ems)
-    @flavor = FactoryBot.create(:flavor_openstack)
-    @volume = FactoryBot.create(:cloud_volume_openstack)
-
     # We're storing objects in the instance_type, so we must permit loading this class
-    ActiveRecord.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [@flavor.class]
-
-    @task = FactoryBot.create(:miq_provision_openstack,
-                               :source  => @template,
-                               :state   => 'pending',
-                               :status  => 'Ok',
-                               :options => {
-                                 :instance_type => @flavor,
-                                 :src_vm_id     => @template.id,
-                                 :volumes       => [{:name => "custom_volume_1", :size => 2}]
-                               })
+    ActiveRecord.yaml_column_permitted_classes = YamlPermittedClasses.app_yaml_permitted_classes | [flavor.class]
   end
 
   context "#configure_volumes" do
-    it "create volumes" do
-      service = double
-      allow(service).to receive_message_chain('volumes.create').and_return @volume
-      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+    before do
+      allow(service).to receive_message_chain(:volumes, :create).and_return(volume)
+      allow(task.source.ext_management_system).to receive(:with_provider_connection)
         .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
-      allow(@task).to receive(:instance_type).and_return @flavor
+      allow(task).to receive(:instance_type).and_return(flavor)
+    end
 
+    it "create volumes" do
       default_volume = {:name => "root", :size => 1, :source_type => "image", :destination_type => "local",
                         :boot_index => 0, :delete_on_termination => true, :uuid => nil}
-      requested_volume = {:name => "custom_volume_1", :size => 2, :uuid => @volume.id, :source_type => "volume",
+      requested_volume = {:name => "custom_volume_1", :size => 2, :uuid => volume.id, :source_type => "volume",
                           :destination_type => "volume"}
 
-      expect(@task.create_requested_volumes(@task.options[:volumes])).to eq [default_volume, requested_volume]
+      expect(task.create_requested_volumes(task.options[:volumes])).to eq([default_volume, requested_volume])
     end
   end
 
   context "#check_volumes" do
     it "status pending" do
       pending_volume_attrs = {:source_type => "volume"}
-      service = double
-      allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
-                                                                                          :status => "pending")
-      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+
+      allow(service).to receive_message_chain('volumes.get')
+        .and_return(FactoryBot.build(:cloud_volume_openstack, :status => "pending"))
+      allow(task.source.ext_management_system).to receive(:with_provider_connection)
         .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
-      expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq [false, "pending"]
+      expect(task.do_volume_creation_check([pending_volume_attrs])).to eq([false, "pending"])
     end
 
     it "check creation status available" do
       pending_volume_attrs = {:source_type => "volume"}
-      service = double
-      allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
-                                                                                          :status => "available")
-      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+
+      allow(service).to receive_message_chain('volumes.get')
+        .and_return(FactoryBot.build(:cloud_volume_openstack, :status => "available"))
+      allow(task.source.ext_management_system).to receive(:with_provider_connection)
         .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
-      expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq true
+      expect(task.do_volume_creation_check([pending_volume_attrs])).to be_truthy
     end
 
     it "check creation status - not found" do
       pending_volume_attrs = {:source_type => "volume"}
-      service = double
-      allow(service).to receive_message_chain('volumes.get').and_return nil
-      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+
+      allow(service).to receive_message_chain('volumes.get').and_return(nil)
+      allow(task.source.ext_management_system).to receive(:with_provider_connection)
         .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
 
-      expect(@task.do_volume_creation_check([pending_volume_attrs])).to eq [false, nil]
+      expect(task.do_volume_creation_check([pending_volume_attrs])).to eq([false, nil])
     end
 
     it "status error" do
       pending_volume_attrs = {:source_type => "volume"}
-      service = double
-      allow(service).to receive_message_chain('volumes.get').and_return FactoryBot.build(:cloud_volume_openstack,
-                                                                                          :status => "error")
-      allow(@task.source.ext_management_system).to receive(:with_provider_connection)\
+
+      allow(service).to receive_message_chain('volumes.get')
+        .and_return(FactoryBot.build(:cloud_volume_openstack, :status => "error"))
+      allow(task.source.ext_management_system).to receive(:with_provider_connection)
         .with({:service => 'volume', :tenant_name => nil}).and_yield(service)
-      expect { @task.do_volume_creation_check([pending_volume_attrs]) }.to raise_error(MiqException::MiqProvisionError)
+
+      expect { task.do_volume_creation_check([pending_volume_attrs]) }.to raise_error(MiqException::MiqProvisionError)
     end
   end
 end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision/volume_attachment_spec.rb
@@ -43,11 +43,11 @@ describe ManageIQ::Providers::Openstack::CloudManager::Provision::VolumeAttachme
       context "with multiple requested volumes" do
         let(:task_volumes) { [{:name => "custom_volume_1", :size => 2}, {:name => "custom_volume_2", :size => 4}] }
 
-        it "sets other volumes as boot_index -1" do
+        it "only sets boot_index for first volumes" do
           expected_volume_1 = {:name => "custom_volume_1", :size => 2, :uuid => volume.id, :source_type => "volume",
                                :destination_type => "volume", :boot_index => 0, :bootable => true, :imageRef => template.ems_ref}
           expected_volume_2 = {:name => "custom_volume_2", :size => 4, :uuid => volume.id, :source_type => "volume",
-                               :destination_type => "volume", :boot_index => -1}
+                               :destination_type => "volume"}
 
           expect(task.create_requested_volumes(task.options[:volumes])).to eq([expected_volume_1, expected_volume_2])
         end


### PR DESCRIPTION
   This Pull Request addresses the handling of root disk provisioning when using flavors with a root disk size of 0. Specifically, if a flavor has a root disk size of 0, the volume provided during provisioning will be designated as the root disk (vda). Conversely, if the flavor has a non-zero root disk size (e.g., 100GB), the specified volume will be treated as an additional volume (vdb). 

  
   Before the change:
   - Volume specified during provisioning would not be correctly set as the root disk when using a 0 root disk size flavor (10GB volume specified on the add volume page is assigned under vdb).
      ![image](https://github.com/user-attachments/assets/a4b995e2-9a8d-4106-97e7-11c9c010211a)


   After the change:
   - Volume specified during provisioning is correctly assigned as the root disk (vda) if the flavor's root disk size is 0 (25GB volume specified on the add volume page is assigned under vda).
![image](https://github.com/user-attachments/assets/7aaeff6d-3c3c-47d5-9401-a8dc6c132504)

   - Additional volumes specified will automatically come under vdb when the flavor has a root disk size greater than 0 (With a 100GB root disk size flavor, the root disk is assigned under vda, while the 50GB volume specified on the add volume page is assigned under vdb).
![image](https://github.com/user-attachments/assets/8610ca89-4e28-4a5e-8d7e-6d934bc9a610)


   Fixes [#892]
  
