### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/openstack/network_manager.rb
+++ b/app/models/manageiq/providers/openstack/network_manager.rb
@@ -37,6 +37,10 @@ class ManageIQ::Providers::Openstack::NetworkManager < ManageIQ::Providers::Netw
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Openstack::CloudManager
+  end
+
   def self.hostname_required?
     false
   end

--- a/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/openstack/storage_manager/cinder_manager.rb
@@ -41,6 +41,10 @@ class ManageIQ::Providers::Openstack::StorageManager::CinderManager < ManageIQ::
   virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
   virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Openstack::CloudManager
+  end
+
   def self.default_blacklisted_event_names
     %w(
       scheduler.run_instance.start

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,10 +7,12 @@
     :parallel_thread_limit: 0
   :openstack_network:
     :is_admin: false
+    :refresh_interval: 0
   :openstack_infra:
     :is_admin: false
   :cinder:
     :is_admin: false
+    :refresh_interval: 0
 :ems:
   :ems_openstack:
     :excon:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare