### PR TITLE
Use ubuntu-24.04 to fix libqpid-proton11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   - cron: 0 0 * * *
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby-version:

--- a/bin/before_install
+++ b/bin/before_install
@@ -3,9 +3,7 @@
 if [ -n "$CI" ]; then
   echo "== Installing system packages =="
   sudo apt-get update
-  sudo apt-get install -y libcurl4-openssl-dev
-  sudo apt-add-repository --yes 'deb http://us.archive.ubuntu.com/ubuntu lunar universe'
-  sudo apt-get install -t lunar -y libqpid-proton11-dev
+  sudo apt-get install -y libcurl4-openssl-dev libqpid-proton11-dev
   echo
 
   # Enable the qpid_proton bundler group


### PR DESCRIPTION
The lunar dist is no longer available, and installing from the noble dist instead (24.04) causes a conflict due to the version of libssl.

We can move the entire runner to ubuntu-24.04 to resolve the issue, this will be the default for ubuntu-latest "soon" :tm: https://github.com/actions/runner-images/issues/10636

> Rollout will begin on December 5th and will complete on January 17th, 2025.

Once that is complete we can revert back to using ubuntu-latest here.

Fixes https://github.com/ManageIQ/manageiq-providers-openstack/actions/runs/12258034148/job/34196883353
```
Ign:8 http://us.archive.ubuntu.com/ubuntu lunar InRelease
Err:9 http://us.archive.ubuntu.com/ubuntu lunar Release
  404  Not Found [IP: 91.189.91.81 80]
Reading package lists...
E: The repository 'http://us.archive.ubuntu.com/ubuntu lunar Release' does not have a Release file.
Repository: 'deb http://us.archive.ubuntu.com/ubuntu lunar universe'

 Reading package lists...
E: The value 'lunar' is invalid for APT::Default-Release as such a release is not available in the sources
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
