### PR TITLE
[WIP] Fix NetworkManager EventTargetParser

### DIFF
--- a/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
@@ -13,7 +13,33 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       oslo_message_text = "with#{"out" unless oslo_message} oslo_message"
 
       it "parses network events #{oslo_message_text}" do
-        payload = {"resource_id" => "network_id_test"}
+        payload = {
+          "network" => {
+            "id"                        => "network_id_test",
+            "name"                      => "network",
+            "tenant_id"                 => "tenant_id_test",
+            "admin_state_up"            => true,
+            "mtu"                       => 1442,
+            "status"                    => "ACTIVE",
+            "subnets"                   => [],
+            "shared"                    => false,
+            "project_id"                => "project_id_test",
+            "port_security_enabled"     => true,
+            "router:external"           => false,
+            "provider:network_type"     => "geneve",
+            "provider:physical_network" => nil,
+            "provider:segmentation_id"  => 1160,
+            "is_default"                => false,
+            "availability_zone_hints"   => [],
+            "availability_zones"        => [],
+            "ipv4_address_scope"        => nil,
+            "ipv6_address_scope"        => nil,
+            "description"               => "",
+            "tags"                      => [],
+            "revision_number"           => 1
+          }
+        }
+
         ems_event = create_ems_event(@manager, "network.create.end", oslo_message, payload)
 
         parsed_targets = described_class.new(ems_event).parse


### PR DESCRIPTION
Some event payload types don't have a `resource_id` in the payload, but they do have e.g. `{"network" => {"id" => ...}}`

Ref: https://github.com/orgs/ManageIQ/discussions/23589
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
