### PR TITLE
Fix missing OpenStack VM CPU Usage Metrics

### DIFF
--- a/app/models/manageiq/providers/openstack/base_metrics_capture.rb
+++ b/app/models/manageiq/providers/openstack/base_metrics_capture.rb
@@ -93,7 +93,7 @@ module ManageIQ::Providers::Openstack::BaseMetricsCapture
   def meter_names(metric_capture_module)
     @meter_names ||= metric_capture_module::COUNTER_NAMES
   end
-  
+
   included do
     cache_with_timeout(:counters_by_vm, 60.minutes) { Hash.new }
   end

--- a/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/metrics_capture_spec.rb
@@ -32,7 +32,7 @@ describe ManageIQ::Providers::Openstack::CloudManager::MetricsCapture do
     end
 
     it "treats openstack timestamp as UTC" do
-      ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("cpu_util").last)
+      ts_as_utc = api_time_as_utc(@mock_stats_data.get_statistics("cpu").last)
       _counters, values_by_id_and_ts = @vm.perf_collect_metrics("realtime")
       ts = Time.parse(values_by_id_and_ts[@vm.ems_ref].keys.max)
 

--- a/spec/tools/openstack_data/openstack_perf_data/aggregate.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/aggregate.yml
@@ -1,5 +1,5 @@
 ---
-  cpu_util:
+  cpu:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"

--- a/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/irregular_interval.yml
@@ -6,7 +6,7 @@
 # actually laziness.  The only values used by the spec of any importance are
 # "duration_end" and "avg".
 ---
-  cpu_util:
+  cpu:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"
@@ -17,7 +17,7 @@
     period_end: "2013-08-28T11:01:20"
     duration: 0.0
     period_start: "2013-08-28T11:01:00"
-    avg: 50
+    avg: 50000000000
     sum: 59.732767253505116
   -
     count: 1
@@ -29,7 +29,7 @@
     period_end: "2013-08-28T11:02:20"
     duration: 0.0
     period_start: "2013-08-28T11:02:00"
-    avg: 100
+    avg: 113000000000
     sum: 93.22194385928294
   -
     count: 1
@@ -41,7 +41,7 @@
     period_end: "2013-08-28T11:03:20"
     duration: 0.0
     period_start: "2013-08-28T11:03:00"
-    avg: 25
+    avg: 128750000000
     sum: 69.18954688449031
   -
     count: 1
@@ -53,7 +53,7 @@
     period_end: "2013-08-28T11:04:20"
     duration: 0.0
     period_start: "2013-08-28T11:04:00"
-    avg: 50
+    avg: 160250000000
     sum: 90.25964906693075
   -
     count: 1
@@ -65,7 +65,7 @@
     period_end: "2013-08-28T11:05:40"
     duration: 0.0
     period_start: "2013-08-28T11:05:20"
-    avg: 20
+    avg: 172850000000
     sum: 58.68941796269206
   -
     count: 1
@@ -77,7 +77,7 @@
     period_end: "2013-08-28T11:06:40"
     duration: 0.0
     period_start: "2013-08-28T11:06:20"
-    avg: 100
+    avg: 235850000000
     sum: 89.69734809669511
   -
     count: 1
@@ -89,7 +89,7 @@
     period_end: "2013-08-28T11:07:40"
     duration: 0.0
     period_start: "2013-08-28T11:07:20"
-    avg: 0
+    avg: 235850000000
     sum: 58.72447525285487
   -
     count: 1

--- a/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/multiple_collection_periods.yml
@@ -6,7 +6,7 @@
 # actually laziness.  The only values used by the spec of any importance are
 # "duration_end" and "avg".
 ---
-  cpu_util:
+  cpu:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"

--- a/spec/tools/openstack_data/openstack_perf_data/standard.yml
+++ b/spec/tools/openstack_data/openstack_perf_data/standard.yml
@@ -1,5 +1,5 @@
 ---
-  cpu_util:
+  cpu:
   -
     count: 1
     duration_start: "2013-08-28T11:01:09"


### PR DESCRIPTION
Older versions of RHOSP had a cpu_util meter but a current installation of OpenStack version 2025.2 gnocchi lists a `cpu` counter in nanoseconds.

```
(gnocchi) metric list
+--------------------------------------+---------------------+-------------------------------+---------+--------------------------------------+
| id                                   | archive_policy/name | name                          | unit    | resource_id                          |
+--------------------------------------+---------------------+-------------------------------+---------+--------------------------------------+
| 2ba229ea-e914-45df-8095-0eedbd7d4c03 | ceilometer-low-rate | cpu                           | ns      | 84bfba1d-faf5-43c8-b936-ac7a195a2a84 |
+--------------------------------------+---------------------+-------------------------------+---------+--------------------------------------+
(gnocchi) measures show cpu --resource-id 84bfba1d-faf5-43c8-b936-ac7a195a2a84
+---------------------------+-------------+----------------+
| timestamp                 | granularity |          value |
+---------------------------+-------------+----------------+
| 2025-10-20T19:05:00+00:00 |       300.0 | 193120000000.0 |
| 2025-10-20T19:10:00+00:00 |       300.0 | 493040000000.0 |
+---------------------------+-------------+----------------+
```

WIP pending spec tests

https://github.com/ManageIQ/manageiq-providers-openstack/issues/879
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
