### PR TITLE
Feat: Enhance NetworkManager EventTargetParser targets

### DIFF
--- a/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/openstack/network_manager/event_target_parser_spec.rb
@@ -13,6 +13,168 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
       oslo_message_text = "with#{"out" unless oslo_message} oslo_message"
 
       it "parses network events #{oslo_message_text}" do
+        payload = {
+          "network" => {
+            "id"         => "network_id_test",
+            "name"       => "test_network",
+            "tenant_id"  => "tenant_id_test",
+            "project_id" => "tenant_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "network.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # network + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:cloud_networks, {:ems_ref => "network_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses subnet events #{oslo_message_text}" do
+        payload = {
+          "subnet" => {
+            "id"         => "subnet_id_test",
+            "name"       => "test_subnet",
+            "tenant_id"  => "tenant_id_test",
+            "project_id" => "tenant_id_test",
+            "network_id" => "network_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "subnet.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # subnet + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:cloud_subnets, {:ems_ref => "subnet_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses router events #{oslo_message_text}" do
+        payload = {
+          "router" => {
+            "id"         => "router_id_test",
+            "name"       => "test_router",
+            "tenant_id"  => "tenant_id_test",
+            "project_id" => "tenant_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "router.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # router + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:network_routers, {:ems_ref => "router_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses port events #{oslo_message_text}" do
+        payload = {
+          "port" => {
+            "id"         => "port_id_test",
+            "name"       => "test_port",
+            "tenant_id"  => "tenant_id_test",
+            "project_id" => "tenant_id_test",
+            "network_id" => "network_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "port.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # port + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:network_ports, {:ems_ref => "port_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses floating ip events #{oslo_message_text}" do
+        payload = {
+          "floatingip" => {
+            "id"                  => "floating_ip_id_test",
+            "floating_ip_address" => "192.168.1.100",
+            "tenant_id"           => "tenant_id_test",
+            "project_id"          => "tenant_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "floatingip.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # floating_ip + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:floating_ips, {:ems_ref => "floating_ip_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses security_group events #{oslo_message_text}" do
+        payload = {
+          "security_group" => {
+            "id"         => "security_group_id_test",
+            "name"       => "test_security_group",
+            "tenant_id"  => "tenant_id_test",
+            "project_id" => "tenant_id_test"
+          }
+        }
+        ems_event = create_ems_event(@manager, "security_group.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(2) # security_group + tenant
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:cloud_tenants, {:ems_ref => "tenant_id_test"}],
+              [:security_groups, {:ems_ref => "security_group_id_test"}]
+            ]
+          )
+        )
+      end
+
+      it "parses security_group_rule events without ID #{oslo_message_text}" do
+        payload = {
+          "security_group_rule" => {
+            "ethertype"         => "IPv4",
+            "direction"         => "ingress",
+            "security_group_id" => "security_group_id_test",
+            "protocol"          => "tcp"
+          }
+        }
+        ems_event = create_ems_event(@manager, "security_group_rule.create.end", oslo_message, payload)
+
+        parsed_targets = described_class.new(ems_event).parse
+        expect(parsed_targets.size).to eq(1) # firewall_rules with nil (full refresh)
+        expect(target_references(parsed_targets)).to(
+          match_array(
+            [
+              [:firewall_rules, {:ems_ref => nil}]
+            ]
+          )
+        )
+      end
+
+      it "falls back to direct resource_id field when nested structure not present #{oslo_message_text}" do
         payload = {"resource_id" => "network_id_test"}
         ems_event = create_ems_event(@manager, "network.create.end", oslo_message, payload)
 
@@ -27,78 +189,22 @@ describe ManageIQ::Providers::Openstack::NetworkManager::EventTargetParser do
         )
       end
 
-      it "parses subnet events #{oslo_message_text}" do
-        payload = {"resource_id" => "subnet_id_test"}
-        ems_event = create_ems_event(@manager, "subnet.create.end", oslo_message, payload)
+      it "extracts tenant_id from initiator when not in resource #{oslo_message_text}" do
+        payload = {
+          "network" => {
+            "id"   => "network_id_test",
+            "name" => "test_network"
+          },
+          "initiator" => {
+            "project_id" => "initiator_tenant_id"
+          }
+        }
+        ems_event = create_ems_event(@manager, "network.create.end", oslo_message, payload)
 
         parsed_targets = described_class.new(ems_event).parse
-        expect(parsed_targets.size).to eq(1)
+        expect(parsed_targets.size).to eq(2)
         expect(target_references(parsed_targets)).to(
-          match_array(
-            [
-              [:cloud_subnets, {:ems_ref => "subnet_id_test"}]
-            ]
-          )
-        )
-      end
-
-      it "parses router events #{oslo_message_text}" do
-        payload = {"resource_id" => "router_id_test"}
-        ems_event = create_ems_event(@manager, "router.create.end", oslo_message, payload)
-
-        parsed_targets = described_class.new(ems_event).parse
-        expect(parsed_targets.size).to eq(1)
-        expect(target_references(parsed_targets)).to(
-          match_array(
-            [
-              [:network_routers, {:ems_ref => "router_id_test"}]
-            ]
-          )
-        )
-      end
-
-      it "parses port events #{oslo_message_text}" do
-        payload = {"resource_id" => "port_id_test"}
-        ems_event = create_ems_event(@manager, "port.create.end", oslo_message, payload)
-
-        parsed_targets = described_class.new(ems_event).parse
-        expect(parsed_targets.size).to eq(1)
-        expect(target_references(parsed_targets)).to(
-          match_array(
-            [
-              [:network_ports, {:ems_ref => "port_id_test"}]
-            ]
-          )
-        )
-      end
-
-      it "parses floating ip events #{oslo_message_text}" do
-        payload = {"resource_id" => "floating_ip_id_test"}
-        ems_event = create_ems_event(@manager, "floatingip.create.end", oslo_message, payload)
-
-        parsed_targets = described_class.new(ems_event).parse
-        expect(parsed_targets.size).to eq(1)
-        expect(target_references(parsed_targets)).to(
-          match_array(
-            [
-              [:floating_ips, {:ems_ref => "floating_ip_id_test"}]
-            ]
-          )
-        )
-      end
-
-      it "parses security_group events #{oslo_message_text}" do
-        payload = {"resource_id" => "security_group_id_test"}
-        ems_event = create_ems_event(@manager, "security_group.create.end", oslo_message, payload)
-
-        parsed_targets = described_class.new(ems_event).parse
-        expect(parsed_targets.size).to eq(1)
-        expect(target_references(parsed_targets)).to(
-          match_array(
-            [
-              [:security_groups, {:ems_ref => "security_group_id_test"}]
-            ]
-          )
+          include([:cloud_tenants, {:ems_ref => "initiator_tenant_id"}])
         )
       end
     end


### PR DESCRIPTION
## Fix NetworkManager EventTargetParser for Neutron event payload structure

### Summary
Fixes the `EventTargetParser` in `NetworkManager` to correctly extract resource IDs from Neutron events. The current implementation assumes a flat payload structure with a direct `resource_id` field, but Neutron uses nested payloads where resources are contained in type-specific objects.

### Problem

**Current behavior:**
```ruby
resource_id = event_payload['resource_id']  # Always returns nil for Neutron events
```

**Actual Neutron payload structure:**
```json
{
  "payload": {
    "network": {
      "id": "b39598c6-e36e-4d8c-82c9-d295addcf82c",
      "tenant_id": "fd2f0bf534504696a8fb62ca84f4e191",
      ...
    }
  }
}
```
### Solution

#### Key Changes

**1. Added `resource_type` helper:**
```ruby
def resource_type
  @resource_type ||= ems_event.event_type.split(".").first
end
```
Extracts `"network"` from `"network.create.end"` automatically.

**2. Added intelligent `resource_id` extraction:**
```ruby
def resource_id
  @resource_id ||= event_payload.dig(resource_type, "id") || event_payload["resource_id"]
end
```
- First tries nested structure: `payload.dig("network", "id")`
- Falls back to direct field for backwards compatibility

**3. Replaced `if/elsif` chain with `case` statement:**
```ruby
target_type = case resource_type
              when "floatingip" then :floating_ips
              when "router" then :network_routers
              when "network" then :cloud_networks
              ...
```

**4. Enhanced tenant ID extraction:**
```ruby
tenant_id = event_payload['tenant_id'] || 
            event_payload['project_id'] || 
            event_payload.dig(resource_type, 'tenant_id') ||
            event_payload.dig(resource_type, 'project_id') ||
            event_payload.dig('initiator', 'project_id')
```
Searches multiple locations for tenant/project ID in nested structures.

### Testing

**Manual testing with real Neutron events via AMQP:**
- ✅ Networks, Subnets, Routers, Floating IPs, Security Groups, Ports
- ✅ Resource IDs correctly extracted from nested payloads
- ✅ Tenant IDs correctly extracted from nested structures
- ✅ Targeted refresh working as intended
- ✅ Security group rules (without IDs) correctly trigger full refresh

**Updated spec tests:**
- Payloads now reflect real Neutron structure (nested objects)
- Added tests for security group rules, fallback scenarios, and tenant extraction

---