### PR TITLE
Fix OpenStack events capability not being set

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager.rb
@@ -479,11 +479,19 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
   end
 
   def verify_credentials(auth_type = nil, options = {})
+    auth_type         ||= "default"
     options[:service] ||= "Compute"
-    ret = super
-    return ret unless auth_type.nil?
 
-    capabilities["events"] = !!event_monitor_available?
+    return unless super
+
+    # Only check if the event monitor is available if we have an events endpoint
+    # and the auth_type that we're currently checking is being used for events.
+    if events_endpoint.present?
+      capabilities["events"] = !!event_monitor_available? if auth_type_for_events == auth_type.to_s
+    else
+      capabilities["events"] = false
+    end
+
     save! if changed?
 
     true
@@ -548,6 +556,22 @@ class ManageIQ::Providers::Openstack::CloudManager < ManageIQ::Providers::CloudM
 
   def authentications_to_validate
     authentication_for_providers.collect(&:authentication_type) - [:ssh_keypair]
+  end
+
+  EVENTS_ENDPOINT_ROLES = %w[amqp ceilometer stf].freeze
+
+  def events_endpoint
+    endpoints.find_by(:role => EVENTS_ENDPOINT_ROLES)
+  end
+
+  def auth_type_for_events
+    role = events_endpoint&.role
+    case role
+    when "amqp"
+      role
+    when "ceilometer", "stf"
+      "default"
+    end
   end
 
   def volume_availability_zones

--- a/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager_spec.rb
@@ -225,16 +225,196 @@ describe ManageIQ::Providers::Openstack::CloudManager do
   end
 
   context "validation" do
-    let!(:ems) { FactoryBot.create(:ems_openstack_with_authentication) }
+    let(:zone) { EvmSpecHelper.local_miq_server.zone }
+    let!(:ems) { FactoryBot.create(:ems_openstack_with_authentication, :zone => zone) }
 
-    it "verifies AMQP credentials" do
-      EvmSpecHelper.stub_amqp_support
+    describe "#verify_credentials" do
+      context "default" do
+        context "with valid credentials" do
+          before { allow(ems).to receive(:verify_api_credentials).and_return(true) }
 
-      creds = {}
-      creds[:amqp] = {:userid => "amqp_user", :password => "amqp_password"}
-      ems.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'amqp_hostname', :port => '5672')
-      ems.update_authentication(creds, :save => false)
-      expect(ems.verify_credentials(:amqp)).to be_truthy
+          it "verifies default credentials" do
+            expect(ems.verify_credentials).to be_truthy
+          end
+
+          it "sets events capability to false if no events endpoint present" do
+            ems.verify_credentials
+            expect(ems.reload.capabilities).to include("events" => false)
+          end
+        end
+
+        context "with invalid credentials" do
+          before do
+            allow(ems).to receive(:with_provider_connection).and_raise(Excon::Errors::Unauthorized, "Unauthorized")
+          end
+
+          it "raises an exception" do
+            expect { ems.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError)
+          end
+        end
+      end
+
+      context "AMQP" do
+        require 'manageiq/providers/openstack/legacy/events/openstack_rabbit_event_monitor'
+
+        before do
+          ems.endpoints << Endpoint.create(:role => 'amqp', :hostname => 'amqp_hostname', :port => '5672')
+          ems.update_authentication({:amqp => {:userid => "amqp_user", :password => "amqp_password"}}, :save => false)
+        end
+
+        context "with valid AMQP credentials" do
+          before do
+            allow(ems).to receive(:verify_amqp_credentials).and_return(true)
+          end
+
+          context "with an available AMQP event monitor" do
+            before do
+              EvmSpecHelper.stub_amqp_support
+            end
+
+            it "verifies AMQP credentials" do
+              expect(ems.verify_credentials(:amqp)).to be_truthy
+            end
+
+            it "sets the events capability when checking amqp auth_type" do
+              ems.verify_credentials(:amqp)
+              expect(ems.reload.capabilities).to include("events" => true)
+            end
+
+            it "doesn't set the events capability when checking default auth_type" do
+              expect(ems).to     receive(:verify_api_credentials).and_return(true)
+              expect(ems).not_to receive(:event_monitor_available?)
+
+              ems.verify_credentials
+
+              expect(ems.reload.capabilities).not_to include("events" => true)
+            end
+          end
+
+          context "with an unavailable AMQP event monitor" do
+            before do
+              allow(OpenstackRabbitEventMonitor).to receive(:available?).and_return(false)
+            end
+
+            it "sets the events capability to false" do
+              ems.verify_credentials(:amqp)
+              expect(ems.reload.capabilities).to include("events" => false)
+            end
+          end
+        end
+
+        context "with invalid AMQP credentials" do
+          before do
+            allow(OpenstackRabbitEventMonitor).to receive(:available?).and_return(false)
+          end
+
+          it "returns false" do
+            expect(ems.verify_credentials(:amqp)).to be_falsey
+          end
+        end
+      end
+
+      context "STF" do
+        require 'manageiq/providers/openstack/legacy/events/openstack_stf_event_monitor'
+
+        before do
+          ems.endpoints << Endpoint.create(:role => 'stf', :hostname => 'stf_hostname', :port => 5_666)
+        end
+
+        context "with valid credentials" do
+          before do
+            allow(ems).to receive(:verify_api_credentials).and_return(true)
+          end
+
+          context "with an available STF event monitor" do
+            before do
+              allow(OpenstackStfEventMonitor).to receive(:available?).and_return(true)
+            end
+
+            it "verifies credentials" do
+              expect(ems.verify_credentials).to be_truthy
+            end
+
+            it "sets the events capability to true" do
+              ems.verify_credentials
+              expect(ems.reload.capabilities).to include("events" => true)
+            end
+          end
+
+          context "with an unavailable STF event monitor" do
+            before do
+              allow(OpenstackStfEventMonitor).to receive(:available?).and_return(false)
+            end
+
+            it "verifies credentials" do
+              expect(ems.verify_credentials).to be_truthy
+            end
+
+            it "sets the events capability to false" do
+              ems.verify_credentials
+              expect(ems.reload.capabilities).to include("events" => false)
+            end
+          end
+        end
+
+        context "with invalid credentials" do
+          before do
+            allow(ems).to receive(:with_provider_connection).and_raise(Excon::Errors::Unauthorized, "Unauthorized")
+          end
+
+          it "raises an exception" do
+            expect { ems.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError)
+          end
+        end
+      end
+
+      context "Ceilometer" do
+        require "manageiq/providers/openstack/legacy/events/openstack_ceilometer_event_monitor"
+
+        before do
+          ems.endpoints << Endpoint.create(:role => "ceilometer", :hostname => "ceilometer_hostname")
+        end
+
+        context "with valid credentials" do
+          before do
+            allow(ems).to receive(:verify_api_credentials).and_return(true)
+          end
+
+          context "with an available Ceilometer event monitor" do
+            before do
+              allow(OpenstackCeilometerEventMonitor).to receive(:available?).and_return(true)
+            end
+
+            it "sets the events capability to true" do
+              ems.verify_credentials
+
+              expect(ems.reload.capabilities).to include("events" => true)
+            end
+          end
+
+          context "with an unavailable Ceilometer event monitor" do
+            before do
+              allow(OpenstackCeilometerEventMonitor).to receive(:available?).and_return(false)
+            end
+
+            it "sets the events capability to false" do
+              ems.verify_credentials
+
+              expect(ems.reload.capabilities).to include("events" => false)
+            end
+          end
+        end
+
+        context "with invalid credentials" do
+          before do
+            allow(ems).to receive(:with_provider_connection).and_raise(Excon::Errors::Unauthorized, "Unauthorized")
+          end
+
+          it "raises an exception" do
+            expect { ems.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError)
+          end
+        end
+      end
     end
 
     describe "event_monitor_available?" do


### PR DESCRIPTION
The OpenStack `verify_credentials` method has logic to check if the events monitor is available only if the requested `auth_type` is `nil`.

This was originally to prevent checking the events monitor when specific auth_type was requested to be checked.

In practice however there is always an auth_type passed in when called through `authentication_check_types` because:
```
types = authentications_to_validate if respond_to?(:authentications_to_validate)
```

This does have the downside of checking the event monitor on both default and (amqp|stf).

Fixes https://github.com/ManageIQ/manageiq-providers-openstack/issues/925
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
